### PR TITLE
Add Workbench API key and Package Manager token env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ than stored in the configuration file:
 | Variable | Purpose |
 |---|---|
 | `VIP_CONNECT_API_KEY` | Connect admin API key |
+| `VIP_WORKBENCH_API_KEY` | Workbench admin API key |
+| `VIP_PM_TOKEN` | Package Manager token |
 | `VIP_TEST_USERNAME` | Test user login name |
 | `VIP_TEST_PASSWORD` | Test user login password |
 

--- a/src/vip/clients/packagemanager.py
+++ b/src/vip/clients/packagemanager.py
@@ -10,9 +10,12 @@ import httpx
 class PackageManagerClient:
     """Minimal Package Manager HTTP wrapper."""
 
-    def __init__(self, base_url: str, *, timeout: float = 30.0) -> None:
+    def __init__(self, base_url: str, token: str = "", *, timeout: float = 30.0) -> None:
         self.base_url = base_url.rstrip("/")
-        self._client = httpx.Client(base_url=self.base_url, timeout=timeout)
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._client = httpx.Client(base_url=self.base_url, headers=headers, timeout=timeout)
 
     # -- Health / status ----------------------------------------------------
 

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -14,9 +14,12 @@ import httpx
 class WorkbenchClient:
     """Minimal Workbench HTTP wrapper."""
 
-    def __init__(self, base_url: str, *, timeout: float = 30.0) -> None:
+    def __init__(self, base_url: str, api_key: str = "", *, timeout: float = 30.0) -> None:
         self.base_url = base_url.rstrip("/")
-        self._client = httpx.Client(base_url=self.base_url, timeout=timeout)
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Key {api_key}"
+        self._client = httpx.Client(base_url=self.base_url, headers=headers, timeout=timeout)
 
     # -- Health / info ------------------------------------------------------
 

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -38,6 +38,28 @@ class ConnectConfig(ProductConfig):
 
 
 @dataclass
+class WorkbenchConfig(ProductConfig):
+    """Workbench-specific configuration."""
+
+    api_key: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.api_key:
+            self.api_key = os.environ.get("VIP_WORKBENCH_API_KEY", "")
+
+
+@dataclass
+class PackageManagerConfig(ProductConfig):
+    """Package Manager-specific configuration."""
+
+    token: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.token:
+            self.token = os.environ.get("VIP_PM_TOKEN", "")
+
+
+@dataclass
 class AuthConfig:
     """Authentication configuration."""
 
@@ -77,8 +99,8 @@ class VIPConfig:
     extension_dirs: list[str] = field(default_factory=list)
 
     connect: ConnectConfig = field(default_factory=ConnectConfig)
-    workbench: ProductConfig = field(default_factory=ProductConfig)
-    package_manager: ProductConfig = field(default_factory=ProductConfig)
+    workbench: WorkbenchConfig = field(default_factory=WorkbenchConfig)
+    package_manager: PackageManagerConfig = field(default_factory=PackageManagerConfig)
 
     auth: AuthConfig = field(default_factory=AuthConfig)
     runtimes: RuntimesConfig = field(default_factory=RuntimesConfig)
@@ -153,15 +175,17 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
             version=connect_raw.get("version"),
             api_key=connect_raw.get("api_key", ""),
         ),
-        workbench=ProductConfig(
+        workbench=WorkbenchConfig(
             enabled=workbench_raw.get("enabled", True),
             url=workbench_raw.get("url", ""),
             version=workbench_raw.get("version"),
+            api_key=workbench_raw.get("api_key", ""),
         ),
-        package_manager=ProductConfig(
+        package_manager=PackageManagerConfig(
             enabled=pm_raw.get("enabled", True),
             url=pm_raw.get("url", ""),
             version=pm_raw.get("version"),
+            token=pm_raw.get("token", ""),
         ),
         auth=AuthConfig(
             provider=auth_raw.get("provider", "password"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def connect_url(vip_config: VIPConfig) -> str:
 def workbench_client(vip_config: VIPConfig) -> WorkbenchClient | None:
     if not vip_config.workbench.is_configured:
         return None
-    client = WorkbenchClient(vip_config.workbench.url)
+    client = WorkbenchClient(vip_config.workbench.url, vip_config.workbench.api_key)
     yield client
     client.close()
 
@@ -58,7 +58,7 @@ def workbench_url(vip_config: VIPConfig) -> str:
 def pm_client(vip_config: VIPConfig) -> PackageManagerClient | None:
     if not vip_config.package_manager.is_configured:
         return None
-    client = PackageManagerClient(vip_config.package_manager.url)
+    client = PackageManagerClient(vip_config.package_manager.url, vip_config.package_manager.token)
     yield client
     client.close()
 

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -26,10 +26,18 @@ enabled = true
 url = "https://workbench.example.com"
 # version = "2024.09.0"
 
+# API key for a Workbench admin user.
+# Prefer setting the VIP_WORKBENCH_API_KEY environment variable.
+# api_key = "..."
+
 [package_manager]
 enabled = true
 url = "https://packagemanager.example.com"
 # version = "2024.09.0"
+
+# Token for a Package Manager user.
+# Prefer setting the VIP_PM_TOKEN environment variable.
+# token = "..."
 
 [auth]
 # Authentication provider in use: "password", "ldap", "saml", "oidc", "oauth2"


### PR DESCRIPTION
## Summary

Part of #29 — enables VIP to accept pre-generated credentials for all three products via environment variables, supporting the upcoming `ptd verify` K8s Job flow.

### Changes

- Added `WorkbenchConfig` with `api_key` field reading from `VIP_WORKBENCH_API_KEY`
- Added `PackageManagerConfig` with `token` field reading from `VIP_PM_TOKEN`
- Updated `WorkbenchClient` and `PackageManagerClient` to accept and use auth headers
- Wired credentials through `tests/conftest.py` fixtures
- Updated `vip.toml.example` and `README.md` with new env vars

### Environment variables
| Variable | Purpose |
|---|---|
| `VIP_WORKBENCH_API_KEY` | Workbench admin API key |
| `VIP_PM_TOKEN` | Package Manager token |