### PR TITLE
Make content deploy timeout configurable with 600s default

### DIFF
--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -41,6 +41,14 @@ class TestConnectConfig:
         cc = ConnectConfig(url="https://connect.example.com", api_key="explicit-key")
         assert cc.api_key == "explicit-key"
 
+    def test_default_deploy_timeout(self):
+        cc = ConnectConfig(url="https://connect.example.com")
+        assert cc.deploy_timeout == 600
+
+    def test_explicit_deploy_timeout(self):
+        cc = ConnectConfig(url="https://connect.example.com", deploy_timeout=1200)
+        assert cc.deploy_timeout == 1200
+
 
 class TestVIPConfig:
     def test_product_config_lookup(self):
@@ -176,6 +184,27 @@ policy_checks_enabled = true
         assert cfg.email_enabled is True
         assert cfg.monitoring_enabled is True
         assert cfg.security_policy_checks_enabled is True
+
+    def test_deploy_timeout_from_toml(self, tmp_toml):
+        path = tmp_toml(
+            """
+[connect]
+url = "https://connect.example.com"
+deploy_timeout = 1200
+"""
+        )
+        cfg = load_config(path)
+        assert cfg.connect.deploy_timeout == 1200
+
+    def test_deploy_timeout_defaults_when_missing(self, tmp_toml):
+        path = tmp_toml(
+            """
+[connect]
+url = "https://connect.example.com"
+"""
+        )
+        cfg = load_config(path)
+        assert cfg.connect.deploy_timeout == 600
 
     def test_full_config(self, tmp_toml):
         path = tmp_toml(

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -31,6 +31,7 @@ class ConnectConfig(ProductConfig):
     """Connect-specific configuration."""
 
     api_key: str = ""
+    deploy_timeout: int = 600
 
     def __post_init__(self) -> None:
         if not self.api_key:
@@ -152,6 +153,7 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
             url=connect_raw.get("url", ""),
             version=connect_raw.get("version"),
             api_key=connect_raw.get("api_key", ""),
+            deploy_timeout=connect_raw.get("deploy_timeout", 600),
         ),
         workbench=ProductConfig(
             enabled=workbench_raw.get("enabled", True),

--- a/tests/connect/test_content_deploy.py
+++ b/tests/connect/test_content_deploy.py
@@ -210,9 +210,10 @@ def upload_and_deploy(connect_client, deploy_state):
 
 
 @when("I wait for the deployment to complete")
-def wait_for_deploy(connect_client, deploy_state):
+def wait_for_deploy(connect_client, deploy_state, vip_config):
     task_id = deploy_state["task_id"]
-    deadline = time.time() + 300  # 5-minute timeout (package installs can be slow)
+    timeout = vip_config.connect.deploy_timeout
+    deadline = time.time() + timeout
     while time.time() < deadline:
         try:
             task = connect_client.get_task(task_id)
@@ -250,11 +251,13 @@ def wait_for_deploy(connect_client, deploy_state):
             raise
     if task is None:
         pytest.fail(
-            "Deployment did not complete within 300 seconds and final task "
+            f"Deployment did not complete within {timeout} seconds and final task "
             "state could not be retrieved due to repeated transient errors."
         )
     output = "\n".join(task.get("output", []))
-    pytest.fail(f"Deployment did not complete within 300 seconds\n\n--- Task output ---\n{output}")
+    pytest.fail(
+        f"Deployment did not complete within {timeout} seconds\n\n--- Task output ---\n{output}"
+    )
 
 
 @then("the content is accessible via HTTP")

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -21,6 +21,10 @@ url = "https://connect.example.com"
 # Prefer setting the VIP_CONNECT_API_KEY environment variable.
 # api_key = "..."
 
+# Timeout in seconds for content deployments (default: 600)
+# Increase this for environments with slower package installation.
+deploy_timeout = 600
+
 [workbench]
 enabled = true
 url = "https://workbench.example.com"


### PR DESCRIPTION
## Summary

Fixes #23 — `test_deploy_shiny` timed out because the deploy timeout was hardcoded at 120s (later 300s), which is insufficient when R packages need to be compiled from source.

### Changes

- Added `deploy_timeout` field to `ConnectConfig` (default: 600s)
- Wired configurable timeout into `wait_for_deploy` step
- Added `deploy_timeout` to `vip.toml.example` with documentation
- Added 4 selftests for the new config field

### Files changed
- `src/vip/config.py`
- `tests/connect/test_content_deploy.py`
- `vip.toml.example`
- `selftests/test_config.py`