### PR TITLE
Increase session launch timeout to 120s and use pytest.fail

### DIFF
--- a/tests/workbench/test_sessions.py
+++ b/tests/workbench/test_sessions.py
@@ -63,13 +63,13 @@ def start_session(page, _url_before_launch):
 def wait_for_session(page, _url_before_launch):
     # Wait for navigation to a *new* /s/<id>/ URL (may already be on one).
     url_before = _url_before_launch.get("url", "")
-    deadline = time.monotonic() + 60
+    deadline = time.monotonic() + 120
     while time.monotonic() < deadline:
         if "/s/" in page.url and page.url != url_before:
             break
         page.wait_for_timeout(500)
     else:
-        raise TimeoutError(f"Session did not start within 60 s.  URL stayed at {page.url}")
+        pytest.fail(f"Session did not start within 120s. URL stayed at {page.url}")
     # Allow a brief settle time.
     time.sleep(3)
 


### PR DESCRIPTION
## Summary

Fixes #24 — `test_session_persists` timed out after 60s waiting for a Workbench session to start. Cold starts on staging can exceed 60s.

### Changes

- Increased session launch timeout from 60s to 120s
- Changed `raise TimeoutError` to `pytest.fail` for better test reporting

### Files changed
- `tests/workbench/test_sessions.py`