### PR TITLE
Add vip auth CLI for credential minting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
     "mypy>=1.10",
 ]
 
+[project.scripts]
+vip = "vip.cli:main"
+
 [project.entry-points.pytest11]
 vip = "vip.plugin"
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -1,0 +1,55 @@
+"""VIP command-line tools for credential management."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def mint_connect_key(args: argparse.Namespace) -> None:
+    """Launch interactive browser auth and mint a Connect API key."""
+    from vip.auth import start_interactive_auth
+
+    session = start_interactive_auth(args.url)
+
+    if not session.api_key:
+        print(json.dumps({"error": "Failed to mint API key"}), file=sys.stderr)
+        sys.exit(1)
+
+    # Output JSON with key and key_name for cleanup.
+    # The key_name can be used to find the key_id via the API later.
+    result = {
+        "api_key": session.api_key,
+        "key_name": session.key_name,
+    }
+
+    print(json.dumps(result))
+
+
+def main() -> None:
+    """Main entry point for the VIP CLI."""
+    parser = argparse.ArgumentParser(prog="vip", description="VIP credential tools")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # vip auth
+    auth_parser = subparsers.add_parser("auth", help="Authentication tools")
+    auth_sub = auth_parser.add_subparsers(dest="auth_command")
+
+    # vip auth mint-connect-key
+    mint_parser = auth_sub.add_parser(
+        "mint-connect-key",
+        help="Mint a Connect API key via interactive browser login",
+    )
+    mint_parser.add_argument("--url", required=True, help="Connect server URL")
+    mint_parser.set_defaults(func=mint_connect_key)
+
+    args = parser.parse_args()
+    if not hasattr(args, "func"):
+        parser.print_help()
+        sys.exit(1)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Part of posit-dev/vip#29 — adds a CLI entry point for minting Connect API keys via interactive browser auth. This enables `ptd verify --interactive-auth` to consume VIP's auth flow without reimplementing browser automation in Go.

### Usage

```bash
vip auth mint-connect-key --url https://connect.example.com
```

Opens a browser window for OIDC login, mints a Connect API key via the UI, and outputs JSON:
```json
{"api_key": "abc123...", "key_name": "_vip_interactive_1709747200"}
```

### Integration

`ptd verify` calls this as a subprocess to get Connect credentials for the K8s Job. The `key_name` is stored alongside the key for later cleanup.

### Files
- `src/vip/cli.py` (new) — CLI entry point with argparse
- `pyproject.toml` — added `[project.scripts]` entry