### PR TITLE
Add AWS EKS kubeconfig generation via boto3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cluster = [
+    "boto3>=1.26",
+    "pyyaml>=6.0",
+]
 report = [
     "jinja2>=3.1",
     "jupyter",

--- a/selftests/test_cluster_aws.py
+++ b/selftests/test_cluster_aws.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import base64
 from unittest.mock import MagicMock, patch
 
-import yaml
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="pyyaml not installed (install vip[cluster])")
+pytest.importorskip("boto3", reason="boto3 not installed (install vip[cluster])")
 
 
 def test_write_kubeconfig():

--- a/selftests/test_cluster_aws.py
+++ b/selftests/test_cluster_aws.py
@@ -1,0 +1,131 @@
+"""Tests for AWS EKS kubeconfig generation."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+
+def test_write_kubeconfig():
+    """write_kubeconfig produces valid YAML with expected structure."""
+    from vip.cluster.kubeconfig import write_kubeconfig
+
+    cluster_name = "test-cluster"
+    server = "https://example.com"
+    ca_data = "dGVzdC1jZXJ0"  # base64-encoded "test-cert"
+    token = "test-token"
+
+    path = write_kubeconfig(cluster_name, server, ca_data, token)
+
+    assert path.exists()
+    assert path.stat().st_mode & 0o777 == 0o600
+
+    with open(path) as f:
+        config = yaml.safe_load(f)
+
+    assert config["apiVersion"] == "v1"
+    assert config["kind"] == "Config"
+    assert config["current-context"] == cluster_name
+    assert len(config["clusters"]) == 1
+    assert config["clusters"][0]["name"] == cluster_name
+    assert config["clusters"][0]["cluster"]["server"] == server
+    assert config["clusters"][0]["cluster"]["certificate-authority-data"] == ca_data
+    assert len(config["users"]) == 1
+    assert config["users"][0]["user"]["token"] == token
+
+
+def test_kubeconfig_file_permissions():
+    """Kubeconfig file should be 0600."""
+    from vip.cluster.kubeconfig import write_kubeconfig
+
+    path = write_kubeconfig("test", "https://test.com", "cert", "token")
+
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_generate_eks_token_format():
+    """EKS token starts with k8s-aws-v1. and contains a presigned URL."""
+    from vip.cluster.aws import _generate_eks_token
+
+    mock_session = MagicMock()
+    mock_session.region_name = "us-east-1"
+
+    cluster_name = "test-cluster"
+
+    # Mock SigV4QueryAuth to simulate presigned URL generation.
+    # SigV4QueryAuth.add_auth() modifies request.url in-place to add
+    # auth query params. We simulate that here.
+    with patch("vip.cluster.aws.SigV4QueryAuth") as mock_auth_class:
+
+        def mock_add_auth(request):
+            request.url += (
+                "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                "&X-Amz-Credential=AKID%2F20260309%2Fus-east-1%2Fsts%2Faws4_request"
+                "&X-Amz-Date=20260309T000000Z"
+                "&X-Amz-Expires=60"
+                "&X-Amz-SignedHeaders=host%3Bx-k8s-aws-id"
+                "&X-Amz-Signature=abcdef1234567890"
+            )
+
+        mock_auth_class.return_value.add_auth.side_effect = mock_add_auth
+
+        token = _generate_eks_token(mock_session, cluster_name)
+
+    # Verify token format
+    assert token.startswith("k8s-aws-v1.")
+
+    # Decode the base64url part
+    b64_part = token.removeprefix("k8s-aws-v1.")
+    padding = (4 - len(b64_part) % 4) % 4
+    decoded = base64.urlsafe_b64decode(b64_part + "=" * padding).decode("utf-8")
+
+    # Verify the decoded URL contains expected components
+    assert "sts.us-east-1.amazonaws.com" in decoded
+    assert "Action=GetCallerIdentity" in decoded
+    assert "X-Amz-Expires=60" in decoded
+    assert "X-Amz-Signature=" in decoded
+
+
+def test_get_eks_kubeconfig_integration():
+    """get_eks_kubeconfig integrates all components correctly."""
+    from vip.cluster.aws import get_eks_kubeconfig
+
+    cluster_name = "test-cluster"
+    region = "us-west-2"
+
+    with (
+        patch("boto3.Session") as mock_session_class,
+        patch("vip.cluster.aws.SigV4QueryAuth") as mock_auth_class,
+    ):
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+        mock_session.region_name = region
+
+        # Mock EKS client
+        mock_eks = MagicMock()
+        mock_session.client.return_value = mock_eks
+        mock_eks.describe_cluster.return_value = {
+            "cluster": {
+                "endpoint": "https://example.eks.amazonaws.com",
+                "certificateAuthority": {"data": "dGVzdC1jZXJ0"},
+            }
+        }
+
+        # Mock SigV4QueryAuth to simulate presigning
+        def mock_add_auth(request):
+            request.url += "&X-Amz-Signature=test"
+
+        mock_auth_class.return_value.add_auth.side_effect = mock_add_auth
+
+        path = get_eks_kubeconfig(cluster_name, region, profile=None)
+
+    assert path.exists()
+    with open(path) as f:
+        config = yaml.safe_load(f)
+
+    assert config["clusters"][0]["cluster"]["server"] == "https://example.eks.amazonaws.com"
+    assert config["clusters"][0]["cluster"]["certificate-authority-data"] == "dGVzdC1jZXJ0"
+    assert config["users"][0]["user"]["token"].startswith("k8s-aws-v1.")

--- a/src/vip/cluster/__init__.py
+++ b/src/vip/cluster/__init__.py
@@ -1,0 +1,5 @@
+"""Cluster access utilities for VIP."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/src/vip/cluster/aws.py
+++ b/src/vip/cluster/aws.py
@@ -1,0 +1,76 @@
+"""AWS EKS cluster access."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from botocore.auth import SigV4QueryAuth
+
+from vip.cluster.kubeconfig import write_kubeconfig
+
+
+def get_eks_kubeconfig(
+    cluster_name: str,
+    region: str,
+    profile: str | None = None,
+) -> Path:
+    """Generate a kubeconfig for an EKS cluster.
+
+    Uses boto3 to:
+    1. Describe the cluster (get endpoint + CA cert)
+    2. Generate an EKS bearer token via STS presigned URL
+    3. Write kubeconfig to a temp file
+
+    Returns the path to the kubeconfig file.
+    """
+    import boto3
+
+    session = boto3.Session(profile_name=profile, region_name=region)
+
+    # 1. Describe cluster
+    eks = session.client("eks")
+    resp = eks.describe_cluster(name=cluster_name)
+    cluster = resp["cluster"]
+    endpoint = cluster["endpoint"]
+    ca_data = cluster["certificateAuthority"]["data"]
+
+    # 2. Generate EKS token
+    token = _generate_eks_token(session, cluster_name)
+
+    # 3. Write kubeconfig
+    return write_kubeconfig(
+        cluster_name=cluster_name,
+        server=endpoint,
+        ca_data=ca_data,
+        token=token,
+    )
+
+
+def _generate_eks_token(session, cluster_name: str) -> str:
+    """Generate an EKS bearer token using STS presigned URL.
+
+    This is the same technique used by ``aws eks get-token`` and PTD's
+    Go implementation.  The token is a base64url-encoded presigned STS
+    GetCallerIdentity URL, prefixed with ``k8s-aws-v1.``.
+
+    The presigned URL places all auth parameters in query strings (not
+    headers), which is required for EKS token validation.
+
+    The token is valid for ~60 seconds.
+    """
+    from botocore.awsrequest import AWSRequest
+
+    region = session.region_name
+    url = f"https://sts.{region}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
+
+    # Build request with x-k8s-aws-id header (must be signed into the URL)
+    request = AWSRequest(method="GET", url=url, headers={"x-k8s-aws-id": cluster_name})
+
+    # SigV4QueryAuth puts all auth params in query string (presigned URL style)
+    credentials = session.get_credentials().get_frozen_credentials()
+    SigV4QueryAuth(credentials, "sts", region, expires=60).add_auth(request)
+
+    # Base64url-encode the presigned URL (no padding)
+    token_bytes = base64.urlsafe_b64encode(request.url.encode("utf-8"))
+    return "k8s-aws-v1." + token_bytes.decode("utf-8").rstrip("=")

--- a/src/vip/cluster/kubeconfig.py
+++ b/src/vip/cluster/kubeconfig.py
@@ -1,0 +1,60 @@
+"""Kubernetes configuration file generation."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+def write_kubeconfig(
+    cluster_name: str,
+    server: str,
+    ca_data: str,
+    token: str,
+) -> Path:
+    """Write a kubeconfig file for a cluster and return the path.
+
+    The file is written to a temp directory. The caller is responsible
+    for cleanup (or it's cleaned up when the process exits).
+    """
+    config = {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": cluster_name,
+        "clusters": [
+            {
+                "name": cluster_name,
+                "cluster": {
+                    "server": server,
+                    "certificate-authority-data": ca_data,
+                },
+            }
+        ],
+        "contexts": [
+            {
+                "name": cluster_name,
+                "context": {
+                    "cluster": cluster_name,
+                    "user": cluster_name,
+                },
+            }
+        ],
+        "users": [
+            {
+                "name": cluster_name,
+                "user": {
+                    "token": token,
+                },
+            }
+        ],
+    }
+
+    tmpdir = tempfile.mkdtemp(prefix="vip-kube-")
+    os.chmod(tmpdir, 0o700)
+    path = Path(tmpdir) / "config"
+    path.write_text(yaml.dump(config, default_flow_style=False))
+    os.chmod(path, 0o600)
+    return path

--- a/uv.lock
+++ b/uv.lock
@@ -161,6 +161,34 @@ css = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.63"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/2a/33d5d4b16fd97dfd629421ebed2456392eae1553cc401d9f86010c18065e/boto3-1.42.63.tar.gz", hash = "sha256:cd008cfd0d7ea30f1c5e22daf0998c55b7c6c68cb68eea05110e33fe641173d5", size = 112778 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/19/f1d8d2b24871d3d0ccb2cbd0b0cb64a3396d439384bd9643d2c25c641b84/boto3-1.42.63-py3-none-any.whl", hash = "sha256:d502a89a0acc701692ae020d15981f2a82e9eb3485acc651cfd0cf1a3afe79ee", size = 140554 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.63"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/eb/a1c042f6638ada552399a9977335a6de2668a85bf80bece193c953531236/botocore-1.42.63.tar.gz", hash = "sha256:1fdfc33cff58d21e8622cf620ba2bba3cff324557932aaf935b5374e4610f059", size = 14965362 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/60/17a2d3b94658bb999c6aee7bba6c76b271905debf0c8c8e6ac63ca8491bc/botocore-1.42.63-py3-none-any.whl", hash = "sha256:83f39d04f2b316bdfc59a3cac2d12238bde7126ac99d9a57d910dbd86d58c528", size = 14639889 },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +744,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419 },
 ]
 
 [[package]]
@@ -2019,6 +2056,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830 },
+]
+
+[[package]]
 name = "send2trash"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2236,6 +2285,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cluster = [
+    { name = "boto3" },
+    { name = "pyyaml" },
+]
 dev = [
     { name = "mypy" },
     { name = "ruff" },
@@ -2250,6 +2303,7 @@ report = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 'cluster'", specifier = ">=1.26" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "ipykernel", marker = "extra == 'report'" },
     { name = "jinja2", marker = "extra == 'report'", specifier = ">=3.1" },
@@ -2262,10 +2316,11 @@ requires-dist = [
     { name = "pytest-bdd", specifier = ">=7.0" },
     { name = "pytest-playwright", specifier = ">=0.5" },
     { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "pyyaml", marker = "extra == 'cluster'", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0,<0.16" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
-provides-extras = ["report", "dev"]
+provides-extras = ["cluster", "report", "dev"]
 
 [[package]]
 name = "wcwidth"


### PR DESCRIPTION
Phase 2 of gene transfusion: PTD K8s access patterns → VIP. Transfuses PTD's EKS kubeconfig generation into Python/boto3 using the same STS presigned URL technique.