### PR TITLE
Guard against re-minting credentials when Secret already exists

### DIFF
--- a/src/vip/verify/credentials.py
+++ b/src/vip/verify/credentials.py
@@ -115,6 +115,12 @@ def mint_interactive_credentials(
         subprocess.CalledProcessError: If kubectl exec commands fail
         RuntimeError: If interactive auth fails
     """
+    existing = get_credentials_from_secret(namespace)
+    if existing and existing.get("connect-api-key"):
+        print("Credentials already exist in K8s Secret.")
+        print("Run 'vip verify cleanup' first to re-mint credentials.")
+        return
+
     print("Minting Connect API key via interactive auth...")
     auth_session = start_interactive_auth(connect_url)
 


### PR DESCRIPTION
## Summary

- Check for existing credentials in the K8s Secret before launching interactive auth
- Prevents `start_interactive_auth()` from sweeping a still-active API key via its `_vip_interactive_*` prefix cleanup
- Users must run `vip verify cleanup` before re-minting

Follow-up to #56 addressing Copilot review feedback about orphan key deletion on re-run.

Refs #29