### PR TITLE
ci: add semantic release with conventional commit enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,6 @@ on:
   pull_request:
 
 jobs:
-  commitlint:
-    name: Commit Messages
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: wagoid/commitlint-github-action@v6
-        with:
-          configFile: commitlint.config.js
-
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,43 @@
+# PR Title Convention Check
+#
+# Ensures PR titles follow conventional commit format so that
+# squash merges produce commits that semantic-release can analyze.
+#
+# Valid formats:
+#   feat: add new feature
+#   fix(scope): fix bug in scope
+#   docs: update documentation
+#   chore!: breaking change
+
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject (after the type) cannot be empty.
+            Example: "feat: add user authentication"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ["@commitlint/config-conventional"],
-};


### PR DESCRIPTION
## Summary

- Configure python-semantic-release for v0.x.x versioning (`major_on_zero = false`)
- Add `release.yml` workflow that runs on merge to main, using a deploy key to push tags (so `docker.yml` fires on `v*` tags)
- Add PR title check via `amannn/action-semantic-pull-request` to enforce conventional commits on squash merges
- Version is bumped in both `pyproject.toml` and `src/vip/__init__.py`

## Setup required before merge

1. ~~Generate a deploy key: `ssh-keygen -t ed25519 -C "vip-deploy-key" -f vip-deploy-key -N ""`~~
2. ~~Add the **public key** as a deploy key in repo Settings > Deploy keys (with write access)~~
3. ~~Add the **private key** as a secret named `DEPLOY_KEY` in repo Settings > Secrets > Actions~~

All done via CLI:
```bash
ssh-keygen -t ed25519 -C "vip-deploy-key" -f /tmp/vip-deploy-key -N ""
gh repo deploy-key add /tmp/vip-deploy-key.pub -R posit-dev/vip -t "semantic-release" -w
gh secret set DEPLOY_KEY -R posit-dev/vip < /tmp/vip-deploy-key
rm /tmp/vip-deploy-key /tmp/vip-deploy-key.pub
```

## Test plan

- [x] Create deploy key and add to repo
- [x] PR title check passes with conventional title (`ci: ...`)
- [ ] Merge PR and verify `release.yml` runs (should be a no-op since `ci:` type doesn't trigger a release)
- [ ] Merge a `feat: ...` or `fix: ...` commit and verify a `v0.2.0` release + tag is created
- [ ] Verify `docker.yml` fires on the new `v*` tag and builds a versioned image