### PR TITLE
fix(ci): use matrix version in smoke test artifact names

### DIFF
--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -114,7 +114,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: connect-smoke-results-${{ steps.version.outputs.resolved }}
+          name: connect-smoke-results-${{ matrix.connect-version }}
           path: smoke-results.xml
 
       # Write a rich job summary with test details and emoji

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -162,7 +162,7 @@ jobs:
         if: always() && steps.license.outputs.available == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: pm-smoke-results-${{ steps.version.outputs.resolved }}
+          name: pm-smoke-results-${{ matrix.pm-version }}
           path: smoke-results.xml
 
       # Write a rich job summary with test details

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -152,7 +152,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: workbench-smoke-results-${{ steps.version.outputs.resolved }}
+          name: workbench-smoke-results-${{ matrix.workbench-version }}
           path: smoke-results.xml
 
       # Write a rich job summary with test details and emoji


### PR DESCRIPTION
## Background and Motivation

The scheduled Workbench smoke test run fails with a 409 Conflict when
uploading artifacts:

> Failed to CreateArtifact: an artifact with this name already exists on the workflow run

This happens because artifact names use the **resolved** product version
(e.g. `2026.01.1+403.pro11`), which can be identical across matrix
entries. On scheduled runs the matrix includes both a pinned tag
(`ubuntu2204-2026.01.1`) and a floating tag (`ubuntu2204`), and when
they resolve to the same version the second upload collides with the
first.

## Proposed Changes

Use the matrix input value (the Docker image tag) instead of the
resolved version in artifact names across all three smoke workflows:

- `workbench-smoke.yml` — `matrix.workbench-version`
- `connect-smoke.yml` — `matrix.connect-version`
- `packagemanager-smoke.yml` — `matrix.pm-version`

Matrix values are guaranteed unique per job, so artifact names can
never collide regardless of what version the containers resolve to.

## Testing

- `just check` passes (ruff lint + format)
- `uv run pytest selftests/ -v` — 89 passed
- Validated with `actionlint` — no new issues