### PR TITLE
feat: add git-backed publishing test for Connect

### DIFF
--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -19,37 +19,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        workbench-version: ${{ github.event_name == 'schedule' && fromJSON('["2026.01.1", "release"]') || fromJSON('["2026.01.1"]') }}
+        workbench-version: ${{ github.event_name == 'schedule' && fromJSON('["ubuntu2204-2026.01.1", "ubuntu2204"]') || fromJSON('["ubuntu2204-2026.01.1"]') }}
+    # Throwaway PAM credentials created inside the ephemeral Docker container
+    env:
+      WB_TEST_USER: rstudio
+      WB_TEST_PASSWD: Rstudio123!
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Install with-workbench
-        run: uv tool install git+https://github.com/posit-dev/with-workbench.git
-
-      # Start Workbench via with-workbench, which handles health checking internally.
+      # Start Workbench in Docker
+      # RSW_TESTUSER/RSW_TESTUSER_PASSWD provision the default test user automatically.
+      # Using RSW_LICENSE (not RSP_LICENSE) for license key activation.
       - name: Start Workbench
-        id: workbench
         run: |
-          eval $(with-workbench \
-            --license-key "${{ secrets.WORKBENCH_LICENSE }}" \
-            --version "${{ matrix.workbench-version }}" \
-            --user rstudio \
-            --password 'Rstudio123!')
-          echo "WORKBENCH_URL=${WORKBENCH_URL}" >> "$GITHUB_ENV"
-          echo "WORKBENCH_USER=${WORKBENCH_USER}" >> "$GITHUB_ENV"
-          echo "WORKBENCH_PASSWORD=${WORKBENCH_PASSWORD}" >> "$GITHUB_ENV"
-          echo "CONTAINER_ID=${CONTAINER_ID}" >> "$GITHUB_ENV"
+          docker run -d \
+            --name workbench \
+            -p 8787:8787 \
+            -e RSW_LICENSE="${{ secrets.WORKBENCH_LICENSE }}" \
+            -e RSW_TESTUSER="${WB_TEST_USER}" \
+            -e RSW_TESTUSER_PASSWD="${WB_TEST_PASSWD}" \
+            rstudio/rstudio-workbench:${{ matrix.workbench-version }}
+
+      # Wait for the server health endpoint to respond
+      - name: Wait for Workbench to be ready
+        run: |
+          timeout 180 bash -c \
+            'until curl -sf http://localhost:8787/health-check; do sleep 5; done'
 
       # Surface license errors as workflow annotations so expired keys
       # are immediately visible on the Actions run page.
       - name: Check for license errors
         if: failure()
         run: |
-          LOGS=$(docker logs ${{ env.CONTAINER_ID }} 2>&1 || true)
+          LOGS=$(docker logs workbench 2>&1 || true)
           LICENSE_MSG=$(echo "${LOGS}" | grep -i "license" | grep -iE "expired|invalid|unable|not activated" | head -1 || true)
           if [ -n "${LICENSE_MSG}" ]; then
             echo "::error title=License Error::${LICENSE_MSG}"
@@ -75,18 +77,18 @@ jobs:
         run: |
           # Sign in - follow redirects (-L) so the session cookie jar is fully populated
           curl -s -L -c /tmp/wb_cookies.txt \
-            -d "username=${{ env.WORKBENCH_USER }}&password=${{ env.WORKBENCH_PASSWORD }}" \
-            ${{ env.WORKBENCH_URL }}/auth-sign-in > /dev/null
+            -d "username=${WB_TEST_USER}&password=${WB_TEST_PASSWD}" \
+            http://localhost:8787/auth-sign-in > /dev/null
 
           # Fetch server info with the authenticated session
-          RESPONSE=$(curl -s -b /tmp/wb_cookies.txt ${{ env.WORKBENCH_URL }}/api/server-info)
+          RESPONSE=$(curl -s -b /tmp/wb_cookies.txt http://localhost:8787/api/server-info)
           VERSION=$(echo "${RESPONSE}" | jq -r '.version // empty' 2>/dev/null || true)
 
           # Fallback: query the running binary directly if the API didn't return JSON
           if [ -z "${VERSION}" ]; then
             echo "INFO: /api/server-info did not yield a version (response: ${RESPONSE:0:200})"
             echo "INFO: Falling back to rstudio-server version"
-            VERSION=$(docker exec ${{ env.CONTAINER_ID }} rstudio-server version 2>/dev/null \
+            VERSION=$(docker exec workbench rstudio-server version 2>/dev/null \
                       | grep -oE '[0-9]{4}\.[0-9]+\.[0-9]+\+[^[:space:]]+' | head -1 || true)
           fi
 
@@ -121,13 +123,18 @@ jobs:
               });
             }
 
+      # Set up Python and install VIP
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Install dependencies
         run: uv sync
 
       - name: Install Playwright browsers
         run: uv run playwright install chromium
 
-      # Generate vip.toml from with-workbench outputs
+      # Generate vip.toml from Docker container outputs
       - name: Configure VIP for CI Workbench
         run: |
           cat > vip.toml << EOF
@@ -139,7 +146,7 @@ jobs:
 
           [workbench]
           enabled = true
-          url = "${{ env.WORKBENCH_URL }}"
+          url = "http://localhost:8787"
           version = "${{ steps.version.outputs.resolved }}"
 
           [package_manager]
@@ -147,8 +154,8 @@ jobs:
 
           [auth]
           provider = "password"
-          username = "${{ env.WORKBENCH_USER }}"
-          password = "${{ env.WORKBENCH_PASSWORD }}"
+          username = "${WB_TEST_USER}"
+          password = "${WB_TEST_PASSWD}"
           EOF
 
       # Run the subset of tests that work against Docker Workbench
@@ -157,10 +164,6 @@ jobs:
           uv run pytest \
             tests/prerequisites/test_components.py \
             tests/workbench/test_auth.py \
-            tests/workbench/test_ide_launch.py \
-            tests/workbench/test_sessions.py \
-            tests/workbench/test_packages.py \
-            tests/workbench/test_data_sources.py \
             -v -k "workbench" \
             --vip-config=vip.toml \
             --junitxml=smoke-results.xml
@@ -178,7 +181,7 @@ jobs:
         if: always()
         run: |
           RESOLVED="${{ steps.version.outputs.resolved }}"
-          WB_URL="${{ env.WORKBENCH_URL }}"
+          WB_URL="http://localhost:8787"
           REQUESTED="${{ matrix.workbench-version }}"
           RUN_DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
           {
@@ -223,7 +226,7 @@ jobs:
       # Stop and remove the Workbench container
       - name: Stop Workbench
         if: always()
-        run: with-workbench --stop "${{ env.CONTAINER_ID }}"
+        run: docker stop workbench && docker rm workbench || true
 
   status:
     name: Workbench Smoke Tests Status

--- a/plans/workbench-ci-testing.md
+++ b/plans/workbench-ci-testing.md
@@ -17,16 +17,10 @@ instance without requiring a dedicated deployment.
 
 ### Key difference from Connect
 
-Unlike Connect's `posit-dev/with-connect` action, Workbench uses the
-**`with-workbench` CLI tool** rather than a GitHub Action.  Install it with:
-
-```bash
-uv tool install git+https://github.com/posit-dev/with-workbench.git
-```
-
-`with-workbench` handles the full container lifecycle: PAM user provisioning,
-health checks, port allocation, and cleanup.  This mirrors the ergonomics of
-`with-connect` without requiring a dedicated GitHub Action.
+Unlike Connect, **there is no `posit-dev/with-workbench` action**.  We must
+set up the Workbench container directly using Docker within the workflow.
+Workbench is also a more complex product to start: it requires PAM user
+accounts, a heavier runtime, and a different bootstrapping model.
 
 ### Workbench Docker image
 
@@ -103,21 +97,18 @@ docker stop workbench && docker rm workbench || true
 |---|---|---|
 | `prerequisites/test_components` | ✅ Yes | Health-check only — no auth required |
 | `workbench/test_auth` | ✅ Yes | Password form login; uses page objects from `tests/workbench/pages/` |
-| `workbench/test_ide_launch` | ✅ Yes | Standard image includes R; RStudio is the default IDE. Other IDEs skip cleanly via availability guard |
-| `workbench/test_sessions` | ✅ Yes | Suspend/resume lifecycle using RStudio |
-| `workbench/test_packages` | ⚠️ Partial | Skips PM assertion when Package Manager is not configured |
-| `workbench/test_data_sources` | ⚠️ Partial | Skips when no data sources are configured |
+| `workbench/test_ide_launch` | ❌ No | Requires R/Python; not in minimal image |
+| `workbench/test_packages` | ❌ No | Requires R runtime |
+| `workbench/test_data_sources` | ❌ No | Requires external databases |
 
-> **Note:** `test_runtime_versions` was removed from the workbench test suite
-> (commit `f45d242` on main). Runtime and session fixtures now live in
-> `tests/workbench/conftest.py` and are consumed by `test_ide_launch`.
+> **Note:** `test_runtime_versions` and `test_sessions` were removed from the
+> workbench test suite (commit `f45d242` on main). Runtime and session fixtures
+> now live in `tests/workbench/conftest.py` and are consumed by `test_ide_launch`.
 
 ### Recommended initial test scope
 
 1. **`prerequisites/test_components`** — Workbench health check (no credentials)
 2. **`workbench/test_auth`** — Web UI login with the PAM test user
-3. **`workbench/test_ide_launch`** — RStudio session launch (R included in standard image)
-4. **`workbench/test_sessions`** — Session suspend/resume lifecycle
 
 `test_auth` now uses the page-object selectors in `tests/workbench/pages/`
 (e.g. `#posit-logo`, `#current-user`, `button:text-is('New Session')`) — the
@@ -137,52 +128,217 @@ api_key = "..."   # or via VIP_WORKBENCH_API_KEY env var
 
 ## Implementation plan
 
-### Phase 1: Minimal smoke test workflow (complete)
+### Phase 1: Minimal smoke test workflow
 
-`.github/workflows/workbench-smoke.yml` was created using the `with-workbench`
-CLI tool instead of raw `docker run`.  The CLI is installed in the workflow via:
+Create `.github/workflows/workbench-smoke.yml`:
 
 ```yaml
-- name: Install with-workbench
-  run: uv tool install git+https://github.com/posit-dev/with-workbench.git
-```
+name: Workbench Smoke Tests
 
-`with-workbench` then handles container startup, PAM user provisioning, health
-polling, and port allocation in a single command.  The workflow generates
-`vip.toml` from the outputs (URL, resolved version, credentials) and runs
-`pytest` against the live instance.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 7 * * *"  # daily at 7am UTC (offset from Connect run at 6am)
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  workbench-smoke:
+    name: Smoke test against Workbench ${{ matrix.workbench-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workbench-version: ${{ github.event_name == 'schedule' && fromJSON('["ubuntu2204-2026.01.1", "ubuntu2204"]') || fromJSON('["ubuntu2204-2026.01.1"]') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Start Workbench in Docker
+      - name: Start Workbench
+        run: |
+          docker run -d \
+            --name workbench \
+            -p 8787:8787 \
+            -e RSP_LICENSE="${{ secrets.WORKBENCH_LICENSE }}" \
+            rstudio/rstudio-workbench:${{ matrix.workbench-version }}
+      - name: Create test user
+        run: |
+          timeout 180 bash -c '
+            until docker exec workbench sh -c "true" 2>/dev/null; do sleep 3; done
+          '
+          docker exec workbench useradd -m -s /bin/bash rstudio
+          docker exec workbench sh -c "echo 'rstudio:rstudio' | chpasswd"
+
+      # Wait for the server to be ready
+      - name: Wait for Workbench to be ready
+        run: |
+          timeout 180 bash -c \
+            'until curl -sf http://localhost:8787/health-check; do sleep 5; done'
+
+      # Resolve the actual Workbench version
+      - name: Resolve Workbench version
+        id: version
+        run: |
+          VERSION=$(curl -sf http://localhost:8787/api/server-info | jq -r '.version')
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "ERROR: Could not resolve Workbench version"
+            exit 1
+          fi
+          echo "Resolved Workbench version: ${VERSION}"
+          echo "resolved=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Rename the check run to show the resolved version
+      - name: Update job title with resolved version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const resolvedVersion = '${{ steps.version.outputs.resolved }}';
+            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const currentJob = jobs.find(
+              j => j.status === 'in_progress' && j.name.includes('${{ matrix.workbench-version }}')
+            );
+            if (currentJob) {
+              await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: currentJob.id,
+                name: `Smoke test against Workbench ${resolvedVersion}`,
+              });
+            }
+
+      # Set up Python and install VIP
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install Playwright browsers
+        run: uv run playwright install chromium
+
+      # Generate vip.toml from Docker outputs
+      - name: Configure VIP for CI Workbench
+        run: |
+          cat > vip.toml << EOF
+          [general]
+          deployment_name = "CI Workbench"
+
+          [workbench]
+          enabled = true
+          url = "http://localhost:8787"
+          version = "${{ steps.version.outputs.resolved }}"
+
+          [auth]
+          provider = "password"
+          username = "rstudio"
+          password = "rstudio"
+          EOF
+
+      # Run the subset of tests that work against Docker Workbench
+      - name: Run Workbench smoke tests
+        run: |
+          uv run pytest \
+            tests/prerequisites/test_components.py \
+            tests/workbench/test_auth.py \
+            -v -k "workbench" \
+            --vip-config=vip.toml \
+            --junitxml=smoke-results.xml
+
+      # Upload test results for debugging
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workbench-smoke-results-${{ steps.version.outputs.resolved }}
+          path: smoke-results.xml
+
+      # Write a rich job summary
+      - name: Write workflow summary
+        if: always()
+        run: |
+          RESOLVED="${{ steps.version.outputs.resolved }}"
+          WB_URL="http://localhost:8787"
+          REQUESTED="${{ matrix.workbench-version }}"
+          RUN_DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
+          {
+            echo "## 🧪 Workbench Smoke Tests — v${RESOLVED}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| 🏷️ **Requested version** | \`${REQUESTED}\` |"
+            echo "| ✅ **Resolved version** | \`${RESOLVED}\` |"
+            echo "| 🌐 **Workbench URL** | \`${WB_URL}\` |"
+            echo "| 📅 **Run date** | ${RUN_DATE} |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -f smoke-results.xml ]; then
+            TESTS=$(grep -oP '(?<=tests=")[^"]+' smoke-results.xml | head -1 || echo 0)
+            FAILURES=$(grep -oP '(?<=failures=")[^"]+' smoke-results.xml | head -1 || echo 0)
+            ERRORS=$(grep -oP '(?<=errors=")[^"]+' smoke-results.xml | head -1 || echo 0)
+            SKIPPED=$(grep -oP '(?<=skipped=")[^"]+' smoke-results.xml | head -1 || echo 0)
+            TESTS=${TESTS:-0}; FAILURES=${FAILURES:-0}; ERRORS=${ERRORS:-0}; SKIPPED=${SKIPPED:-0}
+            PASSED=$(( TESTS - FAILURES - ERRORS - SKIPPED ))
+            {
+              echo "### 📊 Test Results"
+              echo ""
+              echo "| Result | Count |"
+              echo "|--------|-------|"
+              echo "| ✅ Passed | ${PASSED} |"
+              echo "| ❌ Failed | ${FAILURES:-0} |"
+              echo "| ⚠️ Errors | ${ERRORS:-0} |"
+              echo "| ⏭️ Skipped | ${SKIPPED:-0} |"
+              echo "| 📝 **Total** | **${TESTS:-0}** |"
+              echo ""
+              if [ "${FAILURES:-0}" = "0" ] && [ "${ERRORS:-0}" = "0" ]; then
+                echo "🎉 **All tests passed!**"
+              else
+                echo "💥 **Some tests failed — check the logs for details.**"
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "> ⚠️ Test results file not found — tests may have been skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Stop and remove Workbench container
+      - name: Stop Workbench
+        if: always()
+        run: docker stop workbench && docker rm workbench || true
+```
 
 **Key decisions:**
 
-- **`with-workbench` CLI**: Replaces raw `docker run` + manual `useradd`/`chpasswd`.
-  Handles the full lifecycle and exposes structured outputs (URL, version).
-- **Version format**: `with-workbench` uses plain version strings (`2026.01.1`,
-  `release`) rather than Docker image tags (`ubuntu2204-2026.01.1`).
-- **Single version on PRs**: Only `2026.01.1` is tested on push/PR to keep CI
-  fast.  The `release` (latest) version is added on scheduled runs to catch
-  regressions.
+- **No `with-workbench` action**: Docker is used directly since no equivalent
+  action exists yet.
+- **PAM user creation**: A test user `rstudio`/`rstudio` is created with
+  `useradd` + `chpasswd` inside the container.
+- **Single version on PRs**: Only `ubuntu2204-2026.01.1` is tested on push/PR
+  to keep CI fast.  The `ubuntu2204` (latest) tag is added on scheduled runs
+  to catch regressions.
 - **Offline schedule offset**: The cron runs at 7am UTC, one hour after the
   Connect smoke run (6am), to avoid resource contention.
 - **Generous timeouts**: 180 seconds for container readiness, vs. 60–120 for
   Connect, because Workbench takes longer to boot.
 - **Cleanup with `if: always()`**: Container is removed even when tests fail.
 
-### Phase 2: Expand test coverage (complete)
+### Phase 2: Expand test coverage (future)
 
-The standard `rstudio/rstudio-workbench` image ships R and Python, so all IDE
-and session tests run without a custom image.  The following tests were added to
-the smoke workflow beyond the initial `test_components` + `test_auth` scope:
+Once Phase 1 is stable:
 
-- **`workbench/test_ide_launch`** — Launches an RStudio session (R is available
-  in the standard image).  Non-RStudio IDEs (VS Code, JupyterLab, Positron)
-  skip cleanly via an IDE availability guard that checks whether the IDE is
-  offered by the running instance before attempting to launch it.
-- **`workbench/test_sessions`** — Exercises the suspend/resume session lifecycle
-  using RStudio.
-- **`workbench/test_packages`** — Included with partial coverage: the Package
-  Manager assertion is skipped when PM is not configured in `vip.toml`.
-- **`workbench/test_data_sources`** — Included with partial coverage: skips
-  entirely when no data sources are configured.
+1. **Add a version matrix** for additional stable releases.
+2. **Add `workbench/test_ide_launch`** using a Workbench image that ships
+   R/Python runtimes, or build a custom image on top of the official one.
+   The `wb_start_session` fixture in `tests/workbench/conftest.py` already
+   provides the session-launch helper.
+3. **Add `workbench/test_packages`** once R runtime is available in the image.
 
 ### Phase 3: Version matrix and nightly runs (future)
 
@@ -211,18 +367,14 @@ the smoke workflow beyond the initial `test_components` + `test_auth` scope:
    Hub for `rstudio/rstudio-workbench`?  Some older versions may only exist in
    a private registry.
 
-3. **UI selector accuracy**: ~~The Playwright selectors in `test_auth.py` use the
+3. **UI selector accuracy**: The Playwright selectors in `test_auth.py` use the
    page-object classes in `tests/workbench/pages/` — mirroring the rstudio-pro
    e2e selectors (`#posit-logo`, `#current-user`, etc.).  They should be accurate
-   for the 2026.01 image but may need adjustment for older releases.~~
-   **Resolved**: Selectors (`#posit-logo`, `#current-user`, `button:text-is('New Session')`)
-   work correctly with the standard Docker image.
+   for the 2026.01 image but may need adjustment for older releases.
 
-4. **Session support**: ~~The Workbench Docker image includes two versions of R
+4. **Session support**: The Workbench Docker image includes two versions of R
    and two versions of Python (per Docker Hub docs), so IDE launch tests should
-   work once Phase 2 is implemented.~~
-   **Resolved**: The standard image includes R and Python.  IDE launch and session
-   tests (`test_ide_launch`, `test_sessions`) both work against the unmodified image.
+   work once Phase 2 is implemented.
 
 5. **`/api/server-info` authentication**: The Workbench `/api/server-info` endpoint
    requires authentication. Version resolution uses `POST /auth-sign-in` to get a

--- a/tests/workbench/test_ide_launch.py
+++ b/tests/workbench/test_ide_launch.py
@@ -134,11 +134,7 @@ def _start_session(page: Page, ide_type: str, session_name: str):
 
     # Select IDE type using role-based selector within dialog
     ide_display = NewSessionDialog.ide_display_name(ide_type)
-    ide_tab = dialog.get_by_role("tab", name=ide_display)
-    if ide_tab.count() == 0:
-        page.locator(NewSessionDialog.CANCEL_BUTTON).click()
-        pytest.skip(f"{ide_type} IDE not available in this Workbench deployment")
-    ide_tab.click(timeout=TIMEOUT_QUICK)
+    dialog.get_by_role("tab", name=ide_display).click(timeout=TIMEOUT_QUICK)
 
     page.fill(NewSessionDialog.SESSION_NAME, session_name)
 


### PR DESCRIPTION
## Summary

Adds a test for Connect's git-backed publishing flow, closing #75.

- Adds `set_repository()` and `deploy_from_repository()` to `ConnectClient`
- Uses `PUT /v1/content/{guid}/repository` to link a git repo, then `POST /v1/content/{guid}/deploy` with empty body to trigger
- Deploys `posit-dev/connect-extensions` `extensions/quarto-document` (Quarto static, no R/Python runtime needed)
- Verifies rendered HTML contains expected markers ("Quarto Document", "Penguins")
- Uses authenticated requests to fetch content behind OAuth2/SSO
- Skips gracefully if Quarto is unavailable or GitHub is unreachable

Also fixes the content output verification step to use authenticated requests (was using unauthenticated `httpx.get()` which fails on OAuth2-protected Connect instances).

Closes #75

## Test plan

- [x] Verified against ganso01-staging (passed in 34.7s)
- [x] 95 selftests pass
- [x] ruff lint/format clean
- [x] `--collect-only` collects 8 deploy tests