### PR TITLE
fix: resolve CVE-2026-4539 by upgrading pygments to >=2.20.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Audit dependencies
-        run: |
-          # CVE-2026-4539: ReDoS in pygments' AdlLexer (archetype.py), CVSS 3.3.
-          # Requires local access; no network exposure. VIP never invokes the ADL lexer.
-          # Pygments cannot be removed — it is a hard dependency of pytest, rich, ipython,
-          # and the full Jupyter stack. No patched version exists upstream yet (reported at
-          # https://github.com/pygments/pygments/issues/3058 but unaddressed as of 2026-03-24).
-          # Re-evaluate when a fix is released.
-          uv run pip-audit --skip-editable --ignore-vuln CVE-2026-4539
+        run: uv run pip-audit --skip-editable
 
   selftest:
     name: Selftests (${{ matrix.python-version }})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "htmltools",
     "tomli>=2.0;python_version<'3.11'",
     "requests>=2.33.0",  # transitive via pytest-playwright; pinned to track updates
+    "pygments>=2.20.0",  # CVE-2026-4539 fix
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2456,13 +2456,14 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.14.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },
     { name = "htmltools" },
     { name = "httpx" },
     { name = "playwright" },
+    { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-bdd" },
     { name = "pytest-playwright" },
@@ -2518,6 +2519,7 @@ requires-dist = [
     { name = "nbformat", marker = "extra == 'report'", specifier = ">=5.7" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "playwright", specifier = ">=1.40" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", marker = "extra == 'cluster'", specifier = ">=2.12.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-bdd", specifier = ">=7.0" },
@@ -2761,11 +2763,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pygments 2.20.0 patches CVE-2026-4539 (ReDoS in AdlLexer, CVSS 3.3). The fix is now available upstream.

- Pin `pygments>=2.20.0` in `pyproject.toml`
- Remove `--ignore-vuln CVE-2026-4539` from pip-audit in CI
- Update `uv.lock` (2.19.2 → 2.20.0)

Closes #103

## Test plan

- [ ] CI passes (pip-audit clean without the ignore flag)
- [ ] Selftests pass with new pygments version