### PR TITLE
revert: undo xdist parallelization (breaks report generation)

### DIFF
--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -159,7 +159,7 @@ jobs:
             src/vip_tests/workbench/test_ide_launch.py \
             src/vip_tests/workbench/test_packages.py \
             src/vip_tests/workbench/test_data_sources.py \
-            -v -k "workbench" -n 0 \
+            -v -k "workbench" \
             --vip-config=vip.toml \
             --junitxml=smoke-results.xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ packages = ["src/vip", "src/vip_tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["src/vip_tests"]
-addopts = "-n auto --dist loadgroup"
+addopts = "--dist loadgroup"
 filterwarnings = [
     # gherkin-official 29.0.0 passes maxsplit positionally to re.split;
     # fixed upstream but pulled transitively via pytest-bdd.

--- a/src/vip_tests/connect/test_auth.py
+++ b/src/vip_tests/connect/test_auth.py
@@ -28,18 +28,16 @@ def navigate_to_login(page, connect_url):
 
 @when("enters valid credentials")
 def enter_credentials(page, test_username, test_password, auth_provider, interactive_auth):
-    if interactive_auth:
+    if auth_provider != "password":
+        if not interactive_auth:
+            pytest.skip(
+                f"Login form not available for auth provider {auth_provider!r}. "
+                "Pass --interactive-auth when browser storage state is pre-loaded."
+            )
         # With --interactive-auth the browser is already authenticated via storage
-        # state.  The login page will redirect immediately — no form to fill.
+        # state - just wait for any redirect away from the login page to complete.
         page.wait_for_load_state("networkidle")
         return
-    if auth_provider != "password":
-        pytest.skip(
-            f"Login form not available for auth provider {auth_provider!r}. "
-            "Pass --interactive-auth when browser storage state is pre-loaded."
-        )
-    if not test_username or not test_password:
-        pytest.skip("UI login test requires username and password credentials.")
     page.fill("[name='username'], #username", test_username)
     page.fill("[name='password'], #password", test_password)
     page.click("[data-automation='login-panel-submit']")

--- a/src/vip_tests/workbench/test_auth.py
+++ b/src/vip_tests/workbench/test_auth.py
@@ -13,8 +13,6 @@ from vip_tests.workbench.conftest import (
 )
 from vip_tests.workbench.pages import Homepage
 
-pytestmark = pytest.mark.xdist_group("workbench")
-
 
 @scenario("test_auth.feature", "User can log in to Workbench via the web UI")
 def test_workbench_login():

--- a/src/vip_tests/workbench/test_data_sources.py
+++ b/src/vip_tests/workbench/test_data_sources.py
@@ -25,8 +25,6 @@ from vip_tests.workbench.pages import (
     RStudioSession,
 )
 
-pytestmark = pytest.mark.xdist_group("workbench")
-
 _FILENAME = Path(__file__).name
 
 # Types that support an HTTP connectivity check via base R

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -37,8 +37,6 @@ from vip_tests.workbench.pages import (
 # Get filename for session naming
 _FILENAME = Path(__file__).name
 
-pytestmark = pytest.mark.xdist_group("workbench")
-
 
 @scenario("test_ide_launch.feature", "RStudio IDE session can be launched")
 def test_launch_rstudio():
@@ -190,25 +188,13 @@ def vscode_displayed(page: Page):
 @then("the JupyterLab IDE is displayed")
 def jupyter_displayed(page: Page):
     """Verify JupyterLab IDE core elements are visible."""
-    try:
-        expect(page.locator(JupyterLabSession.LAUNCHER)).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
-    except AssertionError:
-        pytest.skip(
-            "JupyterLab did not load within timeout — "
-            "the IDE may not be installed on this Workbench instance"
-        )
+    expect(page.locator(JupyterLabSession.LAUNCHER)).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
 
 
 @then("the Positron IDE is displayed")
 def positron_displayed(page: Page):
     """Verify Positron IDE core elements are visible."""
-    try:
-        expect(page.locator(PositronSession.WORKBENCH)).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
-    except AssertionError:
-        pytest.skip(
-            "Positron did not load within timeout — "
-            "the IDE may not be installed on this Workbench instance"
-        )
+    expect(page.locator(PositronSession.WORKBENCH)).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
     expect(page.locator(PositronSession.STATUS_BAR)).to_be_visible(timeout=TIMEOUT_DIALOG)
 
 

--- a/src/vip_tests/workbench/test_packages.py
+++ b/src/vip_tests/workbench/test_packages.py
@@ -28,8 +28,6 @@ from vip_tests.workbench.pages import (
 
 _FILENAME = Path(__file__).name
 
-pytestmark = pytest.mark.xdist_group("workbench")
-
 # Time (ms) to wait for the R console input to become visible after IDE load
 _TIMEOUT_CONSOLE_READY = 30_000
 # Time (ms) to wait for console output to appear after pressing Enter

--- a/src/vip_tests/workbench/test_session_capacity.py
+++ b/src/vip_tests/workbench/test_session_capacity.py
@@ -32,8 +32,6 @@ from vip_tests.workbench.pages import Homepage, NewSessionDialog
 
 scenarios("test_session_capacity.feature")
 
-pytestmark = pytest.mark.xdist_group("workbench")
-
 # Unique prefix for session names. Timestamp ensures no collision with
 # leftover sessions from previous runs.
 _SESSION_PREFIX = f"_vip_cap_{int(__import__('time').time())}_"

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -27,8 +27,6 @@ from vip_tests.workbench.pages import Homepage, NewSessionDialog
 # Get filename for session naming
 _FILENAME = Path(__file__).name
 
-pytestmark = pytest.mark.xdist_group("workbench")
-
 
 @scenario("test_sessions.feature", "Session can be suspended and resumed")
 def test_session_suspend_resume():
@@ -164,13 +162,7 @@ def session_becomes_active_again(page: Page, session_context: dict):
     session_name = session_context["name"]
 
     session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
-    try:
-        expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
-    except AssertionError:
-        pytest.skip(
-            "Session did not return to Active state after resume — "
-            "suspend/resume may not be supported in this Workbench configuration"
-        )
+    expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
 
 
 @then("the session is cleaned up")


### PR DESCRIPTION
Reverts #139. The `-n auto` default breaks report generation — the plugin's `pytest_sessionfinish` hook doesn't fire on the controller when xdist workers are active, so `results.json` ends up with 0 test results.

The robustness fixes (interactive-auth skip, IDE skip, session skip) were good but bundled with the xdist change. We'll re-land those separately without the parallelization.