### PR TITLE
fix(connect): use correct /v1/system/checks API for system checks

### DIFF
--- a/report/index.qmd
+++ b/report/index.qmd
@@ -11,8 +11,9 @@ jupyter: python3
 ```{python}
 #| echo: false
 
+import json
 from pathlib import Path
-from IPython.display import Markdown, display
+from IPython.display import Markdown, HTML, display
 from vip.reporting import load_results
 
 data = load_results(Path("results.json"))
@@ -418,20 +419,39 @@ document.querySelectorAll('.vip-copy-btn').forEach(function(btn) {
 ```{python}
 #| echo: false
 
-checks_path = Path("connect_system_checks.html")
+checks_path = Path("connect_system_checks.json")
 if not checks_path.exists():
     display(Markdown(
         "_No Connect system checks report found. "
         "Run `tests/connect/test_system_checks.py` against a configured Connect instance._"
     ))
 else:
-    content = checks_path.read_text(encoding="utf-8", errors="replace")
-    # Escape double quotes for use in the srcdoc attribute
-    srcdoc = content.replace("&", "&amp;").replace('"', "&quot;")
-    display(HTML(
-        '<iframe srcdoc="' + srcdoc + '" '
-        'style="width:100%;height:700px;border:1px solid #e5e7eb;border-radius:6px;" '
-        'sandbox="allow-same-origin allow-scripts">'
-        "</iframe>"
+    checks_data = json.loads(checks_path.read_text())
+    run_info = checks_data.get("run", {})
+    results = checks_data.get("results", [])
+    passed = sum(1 for r in results if r.get("passed"))
+    failed = len(results) - passed
+
+    display(Markdown(
+        f"**Host:** {run_info.get('hostname', 'unknown')} · "
+        f"**Status:** {run_info.get('status', 'unknown')} · "
+        f"**Passed:** {passed} · **Failed:** {failed}"
     ))
+
+    rows = []
+    for r in results:
+        group = r.get("group", {}).get("name", "")
+        test = r.get("test", {}).get("name", "")
+        status = "✅" if r.get("passed") else "❌"
+        output = r.get("output", "").strip().replace("\n", "<br>")
+        error = r.get("error", "").strip().replace("\n", "<br>")
+        detail = error if error else output
+        rows.append(f"| {status} | {group} | {test} | {detail} |")
+
+    table = (
+        "| | Group | Check | Detail |\n"
+        "|---|-------|-------|--------|\n"
+        + "\n".join(rows)
+    )
+    display(Markdown(table))
 ```

--- a/report/index.qmd
+++ b/report/index.qmd
@@ -423,7 +423,7 @@ checks_path = Path("connect_system_checks.json")
 if not checks_path.exists():
     display(Markdown(
         "_No Connect system checks report found. "
-        "Run `tests/connect/test_system_checks.py` against a configured Connect instance._"
+        "Run `src/vip_tests/connect/test_system_checks.py` against a configured Connect instance._"
     ))
 else:
     checks_data = json.loads(checks_path.read_text())

--- a/report/index.qmd
+++ b/report/index.qmd
@@ -11,6 +11,7 @@ jupyter: python3
 ```{python}
 #| echo: false
 
+import html
 import json
 from pathlib import Path
 from IPython.display import Markdown, HTML, display
@@ -438,13 +439,18 @@ else:
         f"**Passed:** {passed} · **Failed:** {failed}"
     ))
 
+    def _escape_md_table_cell(value):
+        text = html.escape(str(value or ""), quote=True)
+        text = text.replace("|", "&#124;")
+        return text.replace("\n", "<br>")
+
     rows = []
     for r in results:
-        group = r.get("group", {}).get("name", "")
-        test = r.get("test", {}).get("name", "")
+        group = _escape_md_table_cell(r.get("group", {}).get("name", ""))
+        test = _escape_md_table_cell(r.get("test", {}).get("name", ""))
         status = "✅" if r.get("passed") else "❌"
-        output = r.get("output", "").strip().replace("\n", "<br>")
-        error = r.get("error", "").strip().replace("\n", "<br>")
+        output = _escape_md_table_cell(r.get("output", "").strip())
+        error = _escape_md_table_cell(r.get("error", "").strip())
         detail = error if error else output
         rows.append(f"| {status} | {group} | {test} | {detail} |")
 

--- a/src/vip/clients/connect.py
+++ b/src/vip/clients/connect.py
@@ -299,23 +299,41 @@ class ConnectClient(BaseClient):
 
     # -- System checks ------------------------------------------------------
 
-    def list_server_checks(self) -> list[dict[str, Any]]:
-        """Return a list of server check reports."""
-        resp = self._client.get("/v1/server_checks")
-        resp.raise_for_status()
-        return resp.json().get("results", [])
-
-    def run_server_check(self) -> dict[str, Any]:
-        """Trigger a new server check run and return the report object."""
-        resp = self._client.post("/v1/server_checks")
+    def list_system_checks(self) -> list[dict[str, Any]]:
+        """Return a list of system check runs."""
+        resp = self._client.get("/v1/system/checks")
         resp.raise_for_status()
         return resp.json()
 
-    def get_server_check_report(self, check_id: str | int) -> bytes:
-        """Download the server check report as bytes."""
-        resp = self._client.get(f"/v1/server_checks/{check_id}/download")
+    def run_system_check(self) -> dict[str, Any]:
+        """Trigger a new system check run and return the run object."""
+        resp = self._client.post("/v1/system/checks", json={})
         resp.raise_for_status()
-        return resp.content
+        return resp.json()
+
+    def get_system_check(self, check_id: str | int) -> dict[str, Any]:
+        """Get the status of a system check run."""
+        resp = self._client.get(f"/v1/system/checks/{check_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_system_check_results(self, check_id: str | int) -> dict[str, Any]:
+        """Return the system check results as structured JSON."""
+        resp = self._client.get(f"/v1/system/checks/{check_id}/results")
+        resp.raise_for_status()
+        return resp.json()
+
+    def wait_for_system_check(self, check_id: str | int, timeout: float = 120.0) -> dict[str, Any]:
+        """Poll a system check run until it completes or timeout is reached."""
+        import time
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            check = self.get_system_check(check_id)
+            if check.get("status") == "done":
+                return check
+            time.sleep(3)
+        return self.get_system_check(check_id)
 
     # -- Email --------------------------------------------------------------
 

--- a/src/vip/clients/connect.py
+++ b/src/vip/clients/connect.py
@@ -327,12 +327,42 @@ class ConnectClient(BaseClient):
         """Poll a system check run until it completes or timeout is reached."""
         import time
 
+        transient_status_codes = {404, 502, 503, 504}
         deadline = time.time() + timeout
+        last_exception: Exception | None = None
+
         while time.time() < deadline:
-            check = self.get_system_check(check_id)
+            try:
+                check = self.get_system_check(check_id)
+            except httpx.ReadTimeout as exc:
+                last_exception = exc
+                time.sleep(3)
+                continue
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code not in transient_status_codes:
+                    raise
+                last_exception = exc
+                time.sleep(3)
+                continue
+
+            last_exception = None
             if check.get("status") == "done":
                 return check
             time.sleep(3)
+
+        for _ in range(3):
+            try:
+                return self.get_system_check(check_id)
+            except httpx.ReadTimeout as exc:
+                last_exception = exc
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code not in transient_status_codes:
+                    raise
+                last_exception = exc
+            time.sleep(1)
+
+        if last_exception is not None:
+            raise last_exception
         return self.get_system_check(check_id)
 
     # -- Email --------------------------------------------------------------

--- a/src/vip_tests/connect/test_system_checks.py
+++ b/src/vip_tests/connect/test_system_checks.py
@@ -53,4 +53,7 @@ def download_report_artifact(connect_client, system_check, pytestconfig):
     if vip_report:
         artifact_path = Path(vip_report).parent / "connect_system_checks.json"
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
-        artifact_path.write_text(json.dumps(results, indent=2))
+        artifact_path.write_text(
+            json.dumps(results, indent=2) + "\n",
+            encoding="utf-8",
+        )

--- a/src/vip_tests/connect/test_system_checks.py
+++ b/src/vip_tests/connect/test_system_checks.py
@@ -37,7 +37,14 @@ def check_report_returned(system_check):
 @then("I can download the system check report artifact")
 def download_report_artifact(connect_client, system_check, pytestconfig):
     check_id = system_check["id"]
-    connect_client.wait_for_system_check(check_id)
+    completed_run = connect_client.wait_for_system_check(check_id)
+    assert completed_run is not None, (
+        f"Waiting for system check id={check_id!r} returned no run details"
+    )
+    assert completed_run.get("status") == "done", (
+        "System check did not complete before fetching results. "
+        f"id={check_id!r}, final status={completed_run.get('status')!r}"
+    )
     results = connect_client.get_system_check_results(check_id)
     assert results, f"System check results for id={check_id!r} were empty"
 

--- a/src/vip_tests/connect/test_system_checks.py
+++ b/src/vip_tests/connect/test_system_checks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from pytest_bdd import scenario, then, when
@@ -20,28 +21,29 @@ def test_connect_system_checks():
 # ---------------------------------------------------------------------------
 
 
-@when("I trigger a new system check run via the Connect API", target_fixture="server_check")
+@when("I trigger a new system check run via the Connect API", target_fixture="system_check")
 def trigger_system_check(connect_client):
-    return connect_client.run_server_check()
+    return connect_client.run_system_check()
 
 
 @then("the system check report is returned")
-def check_report_returned(server_check):
-    assert server_check is not None, "System check API returned no result"
-    assert "id" in server_check, (
-        f"System check response missing 'id' field. Got: {list(server_check.keys())}"
+def check_report_returned(system_check):
+    assert system_check is not None, "System check API returned no result"
+    assert "id" in system_check, (
+        f"System check response missing 'id' field. Got: {list(system_check.keys())}"
     )
 
 
 @then("I can download the system check report artifact")
-def download_report_artifact(connect_client, server_check, pytestconfig):
-    check_id = server_check["id"]
-    report_bytes = connect_client.get_server_check_report(check_id)
-    assert report_bytes, f"System check report for id={check_id!r} was empty"
+def download_report_artifact(connect_client, system_check, pytestconfig):
+    check_id = system_check["id"]
+    connect_client.wait_for_system_check(check_id)
+    results = connect_client.get_system_check_results(check_id)
+    assert results, f"System check results for id={check_id!r} were empty"
 
     # Persist alongside results.json so the Quarto report can embed it.
     vip_report = pytestconfig.getoption("--vip-report")
     if vip_report:
-        artifact_path = Path(vip_report).parent / "connect_system_checks.html"
+        artifact_path = Path(vip_report).parent / "connect_system_checks.json"
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
-        artifact_path.write_bytes(report_bytes)
+        artifact_path.write_text(json.dumps(results, indent=2))


### PR DESCRIPTION
## Summary

- Fix Connect system checks client to use the correct `/v1/system/checks` API endpoints (the old `/v1/server_checks` path returns 404)
- Fix several API contract mismatches discovered by running the test against a live Connect v2026.03.1 Docker instance
- Update the Quarto report to render system checks from JSON instead of expecting an HTML download

## What was wrong

The original code used `/v1/server_checks` — an endpoint that does not exist. PR #141 correctly identified the path should be `/v1/system/checks`, but was written without access to a live Connect instance and got several details wrong:

| Bug | PR #141 | Actual API |
|-----|---------|-----------|
| POST body | No body | Requires `json={}` (bare POST returns 400) |
| List response shape | `.get("results", [])` | Returns bare array `[...]` |
| Results format | `bytes` with `Accept: text/html` | Always returns JSON |
| Completion status | `"complete"` / `"completed"` | `"done"` |

## Supersedes

Supersedes #141 — this PR is based on `main` with a clean diff (PR #141's branch had diverged and included unrelated deletions).

## Test plan

- [x] Ran `test_system_checks.py` against Connect v2026.03.1 in Docker — passes (53/55 checks pass, 2 expected failures in Docker env)
- [x] Verified `connect_system_checks.json` artifact is written to the report directory
- [x] Verified JSON renders correctly in the Quarto report template
- [x] `just check` (ruff lint + format) passes
- [x] All 110 selftests pass