### PR TITLE
fix: remove warnings when running from install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,10 @@ This runs `showboat verify demo.md`, then moves it to `validation_docs/demo-my-f
 
 CI will run `showboat verify` on any new or changed files in `validation_docs/` for PRs that include them.
 
+## Pytest warning filters
+
+Register warning filters in `src/vip/plugin.py::pytest_configure` (via `config.addinivalue_line("filterwarnings", ...)`), not in `pyproject.toml`'s `[tool.pytest.ini_options]`. Filters in `pyproject.toml` only apply when pytest runs from this repo's rootdir -- users who install vip into another project pick up the plugin but not the config, so the warnings reappear there. Keeping the filters in the plugin means they travel with the installed package.
+
 ## Common mistakes to avoid
 
 -   Forgetting to include `examples/` in ruff check paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,19 +84,8 @@ packages = ["src/vip", "src/vip_tests"]
 [tool.pytest.ini_options]
 testpaths = ["src/vip_tests"]
 addopts = "--dist loadgroup"
-filterwarnings = [
-    # gherkin-official 29.0.0 passes maxsplit positionally to re.split;
-    # fixed upstream but pulled transitively via pytest-bdd.
-    "ignore:'maxsplit' is passed as positional argument:DeprecationWarning:gherkin",
-    # TLS downgrade tests deliberately use deprecated TLS 1.0/1.1 versions.
-    "ignore:ssl.TLSVersion.TLSv1:DeprecationWarning",
-    "ignore:ssl.TLSVersion.TLSv1_1:DeprecationWarning",
-    # pytest-bdd scenario functions return fixture values; not a real issue.
-    "ignore::pytest.PytestReturnNotNoneWarning",
-    # gevent monkey-patching happens after ssl is imported by other plugins;
-    # unavoidable without patching at process start.  Only affects Python ≤3.7.
-    "ignore:Monkey-patching ssl:gevent.monkey.MonkeyPatchWarning",
-]
+# Warning filters live in src/vip/plugin.py::pytest_configure so they apply
+# anywhere vip is installed, not just runs from this repo.
 markers = [
     "connect: tests for Posit Connect",
     "workbench: tests for Posit Workbench",

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -118,6 +118,9 @@ def pytest_configure(config: pytest.Config) -> None:
         "ignore:ssl.TLSVersion.TLSv1_1:DeprecationWarning",
         # pytest-bdd scenario functions return fixture values; not a real issue.
         "ignore::pytest.PytestReturnNotNoneWarning",
+        # gevent monkey-patching happens after ssl is imported by other plugins;
+        # unavoidable without patching at process start.  Only affects Python ≤3.7.
+        "ignore:Monkey-patching ssl:gevent.monkey.MonkeyPatchWarning",
     ):
         config.addinivalue_line("filterwarnings", line)
 

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -120,7 +120,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "ignore::pytest.PytestReturnNotNoneWarning",
         # gevent monkey-patching happens after ssl is imported by other plugins;
         # unavoidable without patching at process start.  Only affects Python ≤3.7.
-        "ignore:Monkey-patching ssl:gevent.monkey.MonkeyPatchWarning",
+        "ignore:Monkey-patching ssl",
     ):
         config.addinivalue_line("filterwarnings", line)
 

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -106,6 +106,21 @@ def pytest_configure(config: pytest.Config) -> None:
     global _active_config
     _active_config = config
 
+    # Register warning filters so they apply regardless of the pytest rootdir.
+    # Mirrors the filterwarnings list in pyproject.toml for users who install
+    # vip into an unrelated project.
+    for line in (
+        # gherkin-official 29.0.0 passes maxsplit positionally to re.split;
+        # fixed upstream but pulled transitively via pytest-bdd.
+        "ignore:'maxsplit' is passed as positional argument:DeprecationWarning:gherkin",
+        # TLS downgrade tests deliberately use deprecated TLS 1.0/1.1 versions.
+        "ignore:ssl.TLSVersion.TLSv1:DeprecationWarning",
+        "ignore:ssl.TLSVersion.TLSv1_1:DeprecationWarning",
+        # pytest-bdd scenario functions return fixture values; not a real issue.
+        "ignore::pytest.PytestReturnNotNoneWarning",
+    ):
+        config.addinivalue_line("filterwarnings", line)
+
     # Register markers
     config.addinivalue_line("markers", "connect: tests for Posit Connect")
     config.addinivalue_line("markers", "workbench: tests for Posit Workbench")

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -119,7 +119,7 @@ def pytest_configure(config: pytest.Config) -> None:
         # pytest-bdd scenario functions return fixture values; not a real issue.
         "ignore::pytest.PytestReturnNotNoneWarning",
         # gevent monkey-patching happens after ssl is imported by other plugins;
-        # unavoidable without patching at process start.  Only affects Python ≤3.7.
+        # unavoidable without patching at process start.
         "ignore:Monkey-patching ssl",
     ):
         config.addinivalue_line("filterwarnings", line)

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -106,9 +106,9 @@ def pytest_configure(config: pytest.Config) -> None:
     global _active_config
     _active_config = config
 
-    # Register warning filters so they apply regardless of the pytest rootdir.
-    # Mirrors the filterwarnings list in pyproject.toml for users who install
-    # vip into an unrelated project.
+    # Register the canonical warning filters in the plugin so they apply
+    # regardless of the pytest rootdir, including when vip is installed into
+    # an unrelated project.
     for line in (
         # gherkin-official 29.0.0 passes maxsplit positionally to re.split;
         # fixed upstream but pulled transitively via pytest-bdd.


### PR DESCRIPTION
I grabbed the latest from a pip install, and I saw some warnings that I thought I had removed.  Needed to fix this a different way.