### PR TITLE
fix(security): catch ConnectError with helpful skip message

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ian-flores @statik
+* @ian-flores @statik @bdeitte

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,24 @@ uvx showboat exec demo.md bash "just check"
 
 Use `uvx showboat image demo.md <path>` if screenshots are relevant.
 
+### Avoiding timing-sensitive output
+
+`showboat verify` re-runs every code block and diffs the output exactly. Commands that include wall-clock timing (e.g. pytest's `N passed in X.XXs`) will fail verification because the time changes on each run.
+
+Two safe patterns:
+
+1.  **Strip the timing suffix with `sed`:**
+
+    ``` bash
+    uv run pytest selftests/ -q 2>&1 | grep -E "passed|failed|error" | sed 's/ in [0-9.]*s//'
+    ```
+
+    Expected output becomes `243 passed, 4 warnings` (no time).
+
+2.  **Use `--no-header -rN` and filter aggressively** if you need a one-liner count without any pytest preamble.
+
+Similarly, avoid capturing absolute timestamps, PID numbers, or any other value that varies between runs. When `just` is not available in the environment, replace `just check` with the underlying `uv run ruff ...` commands directly.
+
 ### What to demonstrate
 
 -   **New tests:** run the new tests and show them passing

--- a/src/vip_tests/performance/test_login_load_times.py
+++ b/src/vip_tests/performance/test_login_load_times.py
@@ -29,13 +29,19 @@ def measure_load_time(product, vip_config, performance_config):
     if not pc.is_configured:
         pytest.skip(f"{product} is not configured")
     path = _LOGIN_PATHS[product]
-    start = time.monotonic()
-    resp = httpx.get(
-        f"{pc.url}{path}",
-        follow_redirects=True,
-        timeout=performance_config.page_load_timeout * 3,
-    )
-    elapsed = time.monotonic() - start
+    try:
+        start = time.monotonic()
+        resp = httpx.get(
+            f"{pc.url}{path}",
+            follow_redirects=True,
+            timeout=performance_config.page_load_timeout * 3,
+        )
+        elapsed = time.monotonic() - start
+    except httpx.ConnectError:
+        pytest.skip(
+            f"Could not reach {product} at {pc.url}{path}: connection refused. "
+            "Check firewall rules, proxy configuration, DNS resolution, and port."
+        )
     resp.raise_for_status()
     return elapsed
 

--- a/src/vip_tests/performance/test_login_load_times.py
+++ b/src/vip_tests/performance/test_login_load_times.py
@@ -38,7 +38,7 @@ def measure_load_time(product, vip_config, performance_config):
         )
         elapsed = time.monotonic() - start
     except httpx.ConnectError:
-        pytest.skip(
+        pytest.fail(
             f"Could not reach {product} at {pc.url}{path}: connection refused. "
             "Check firewall rules, proxy configuration, DNS resolution, and port."
         )

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -71,7 +71,7 @@ def inspect_headers(product, vip_config):
     try:
         resp = httpx.get(pc.url, follow_redirects=True, timeout=15)
     except httpx.ConnectError:
-        pytest.skip(
+        pytest.fail(
             f"Could not reach {product} at {pc.url}: connection refused. "
             "Check firewall rules, proxy configuration, DNS resolution, and port. "
             "This is a connectivity issue, not a security finding."

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -68,7 +68,14 @@ def inspect_headers(product, vip_config):
     pc = vip_config.product_config(product_key)
     if not pc.is_configured:
         pytest.skip(f"{product} is not configured")
-    resp = httpx.get(pc.url, follow_redirects=True, timeout=15)
+    try:
+        resp = httpx.get(pc.url, follow_redirects=True, timeout=15)
+    except httpx.ConnectError:
+        pytest.skip(
+            f"Could not reach {product} at {pc.url}: connection refused. "
+            "Check firewall rules, proxy configuration, DNS resolution, and port. "
+            "This is a connectivity issue, not a security finding."
+        )
     return dict(resp.headers)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2480,7 +2480,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.23.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-fix-issue-183.md
+++ b/validation_docs/demo-fix-issue-183.md
@@ -1,0 +1,24 @@
+# fix(security): catch ConnectError with helpful skip messages
+
+*2026-04-18T00:46:06Z by Showboat 0.6.1*
+<!-- showboat-id: 15e86f26-b8d4-444e-aba0-c2307c1d5642 -->
+
+Fixed issue #183: tests that make direct HTTP requests now catch httpx.ConnectError and call pytest.skip() with a clear message explaining the connectivity issue, rather than letting the raw httpcore.ConnectError propagate as an 'unexpected error'.
+
+```bash
+uv run pytest selftests/ -q 2>&1 | grep -E "passed|failed|error" | sed 's/ in [0-9.]*s//'
+```
+
+```output
+243 passed, 4 warnings
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/ && echo 'All checks passed'
+```
+
+```output
+All checks passed!
+99 files already formatted
+All checks passed
+```


### PR DESCRIPTION
## Summary

Fixes #183.

- In `test_https.py` (`inspect_headers` step): catch `httpx.ConnectError` and call `pytest.skip()` with a message that names the URL, common causes (firewall, proxy, DNS, port), and notes this is a connectivity issue—not a security finding.
- In `test_login_load_times.py` (`measure_load_time` step): same pattern—catch `httpx.ConnectError` and skip with a clear message instead of letting the raw `httpcore.ConnectError` surface as "an unexpected error occurred".

## Test plan

- [ ] Selftests pass (`uv run pytest selftests/ -v`)
- [ ] Ruff lint/format clean (`uv run ruff check` + `ruff format --check`)
- [ ] Product tests collect cleanly (`--collect-only` dry run)

## Demo

# fix(security): catch ConnectError with helpful skip messages

*2026-04-18T00:46:06Z by Showboat 0.6.1*

Fixed issue #183: tests that make direct HTTP requests now catch httpx.ConnectError and call pytest.skip() with a clear message explaining the connectivity issue, rather than letting the raw httpcore.ConnectError propagate as an 'unexpected error'.

```bash
uv run pytest selftests/ -q 2>&1 | grep -E "passed|failed|error" | sed 's/ in [0-9.]*s//'
```

```output
243 passed, 4 warnings
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/ && echo 'All checks passed'
```

```output
All checks passed!
99 files already formatted
All checks passed
```

https://claude.ai/code/session_01GjtvBs4jn9DBtxHhsJoBfZ