### PR TITLE
fix(performance): update locust install instructions to use uv

### DIFF
--- a/src/vip/load_engine.py
+++ b/src/vip/load_engine.py
@@ -188,7 +188,11 @@ def _stop_plugin_heartbeat_before_gevent() -> None:
 def _run_locust(url: str, headers: dict[str, str], n: int, config) -> LoadTestResult:
     """Run a headless Locust load test and return aggregated results."""
     if not _locust_available():
-        msg = f"locust not installed; {n} users with tool='locust' requires: uv sync --extra load"
+        msg = (
+            f"locust not installed; {n} users with tool='locust' requires the load extra "
+            '(`uv pip install "posit-vip[load]"` for an installed package, '
+            "or `uv sync --extra load` from a source checkout)"
+        )
         raise RuntimeError(msg)
 
     _stop_plugin_heartbeat_before_gevent()
@@ -334,7 +338,11 @@ def run_user_simulation(
         ``{"token": "..."}`` for Package Manager).
     """
     if not _locust_available():
-        msg = "locust not installed; user simulation requires: uv sync --extra load"
+        msg = (
+            "locust not installed; user simulation requires the load extra "
+            '(`uv pip install "posit-vip[load]"` for an installed package, '
+            "or `uv sync --extra load` from a source checkout)"
+        )
         raise RuntimeError(msg)
 
     _stop_plugin_heartbeat_before_gevent()

--- a/src/vip/load_engine.py
+++ b/src/vip/load_engine.py
@@ -188,10 +188,7 @@ def _stop_plugin_heartbeat_before_gevent() -> None:
 def _run_locust(url: str, headers: dict[str, str], n: int, config) -> LoadTestResult:
     """Run a headless Locust load test and return aggregated results."""
     if not _locust_available():
-        msg = (
-            f"locust not installed; {n} users with tool='locust' requires: "
-            "pip install 'posit-vip[load]'"
-        )
+        msg = f"locust not installed; {n} users with tool='locust' requires: uv sync --extra load"
         raise RuntimeError(msg)
 
     _stop_plugin_heartbeat_before_gevent()
@@ -337,7 +334,7 @@ def run_user_simulation(
         ``{"token": "..."}`` for Package Manager).
     """
     if not _locust_available():
-        msg = "locust not installed; user simulation requires: pip install 'posit-vip[load]'"
+        msg = "locust not installed; user simulation requires: uv sync --extra load"
         raise RuntimeError(msg)
 
     _stop_plugin_heartbeat_before_gevent()

--- a/src/vip/load_users.py
+++ b/src/vip/load_users.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 try:
     from locust import HttpUser, between, task
 except ImportError as _err:
-    msg = "locust is required for user simulation: pip install 'posit-vip[load]'"
+    msg = "locust is required for user simulation: uv sync --extra load"
     raise ImportError(msg) from _err
 
 

--- a/src/vip/load_users.py
+++ b/src/vip/load_users.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 try:
     from locust import HttpUser, between, task
 except ImportError as _err:
-    msg = "locust is required for user simulation: uv sync --extra load"
+    msg = (
+        'locust is required for user simulation: install the "load" extra '
+        '(`uv pip install "posit-vip[load]"` for an installed package, '
+        "or `uv sync --extra load` from a source checkout)"
+    )
     raise ImportError(msg) from _err
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2480,7 +2480,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.23.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-fix-locust-install-instructions.md
+++ b/validation_docs/demo-fix-locust-install-instructions.md
@@ -1,0 +1,34 @@
+# fix(performance): update locust install instructions to use uv
+
+*2026-04-18T00:52:52Z by Showboat 0.6.1*
+<!-- showboat-id: cfe3f95c-d3fa-4eb0-8a45-66e2a1c9e8a9 -->
+
+Fixed three error messages that incorrectly suggested 'pip install posit-vip[load]' when locust is not installed. Updated all occurrences in src/vip/load_engine.py and src/vip/load_users.py to suggest 'uv sync --extra load' instead, consistent with VIP's uv-first toolchain policy.
+
+```bash
+grep -n 'uv sync' src/vip/load_engine.py src/vip/load_users.py
+```
+
+```output
+src/vip/load_engine.py:191:        msg = f"locust not installed; {n} users with tool='locust' requires: uv sync --extra load"
+src/vip/load_engine.py:337:        msg = "locust not installed; user simulation requires: uv sync --extra load"
+src/vip/load_users.py:16:    msg = "locust is required for user simulation: uv sync --extra load"
+```
+
+```bash
+uv run pytest selftests/ 2>&1 | grep -oE "[0-9]+ passed"
+```
+
+```output
+243 passed
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/ && echo 'Lint and format: OK'
+```
+
+```output
+All checks passed!
+99 files already formatted
+Lint and format: OK
+```

--- a/validation_docs/demo-fix-locust-install-instructions.md
+++ b/validation_docs/demo-fix-locust-install-instructions.md
@@ -1,22 +1,22 @@
 # fix(performance): update locust install instructions to use uv
 
-*2026-04-18T00:52:52Z by Showboat 0.6.1*
-<!-- showboat-id: cfe3f95c-d3fa-4eb0-8a45-66e2a1c9e8a9 -->
+*2026-04-18T01:00:18Z by Showboat 0.6.1*
+<!-- showboat-id: 3ca4640c-58db-4a03-abe0-ad5bb43e6c75 -->
 
-Fixed three error messages that incorrectly suggested 'pip install posit-vip[load]' when locust is not installed. Updated all occurrences in src/vip/load_engine.py and src/vip/load_users.py to suggest 'uv sync --extra load' instead, consistent with VIP's uv-first toolchain policy.
+Fixed three error messages that incorrectly suggested 'pip install posit-vip[load]' when locust is not installed. Updated all occurrences in src/vip/load_engine.py and src/vip/load_users.py to suggest both install paths: uv pip install for PyPI users and uv sync --extra load for source checkout developers.
 
 ```bash
-grep -n 'uv sync' src/vip/load_engine.py src/vip/load_users.py
+grep -n 'posit-vip\[load\]' src/vip/load_engine.py src/vip/load_users.py
 ```
 
 ```output
-src/vip/load_engine.py:191:        msg = f"locust not installed; {n} users with tool='locust' requires: uv sync --extra load"
-src/vip/load_engine.py:337:        msg = "locust not installed; user simulation requires: uv sync --extra load"
-src/vip/load_users.py:16:    msg = "locust is required for user simulation: uv sync --extra load"
+src/vip/load_engine.py:193:            '(`uv pip install "posit-vip[load]"` for an installed package, '
+src/vip/load_engine.py:343:            '(`uv pip install "posit-vip[load]"` for an installed package, '
+src/vip/load_users.py:18:        '(`uv pip install "posit-vip[load]"` for an installed package, '
 ```
 
 ```bash
-uv run pytest selftests/ 2>&1 | grep -oE "[0-9]+ passed"
+uv run pytest selftests/ 2>&1 | grep -oE '[0-9]+ passed'
 ```
 
 ```output


### PR DESCRIPTION
## Summary

- Replace `pip install 'posit-vip[load]'` with `uv sync --extra load` in all error messages shown when locust is not installed
- Affected files: `src/vip/load_engine.py` (2 messages) and `src/vip/load_users.py` (1 message)
- Consistent with VIP's uv-first toolchain policy documented in CLAUDE.md

Closes #176

## Demo

# fix(performance): update locust install instructions to use uv

*2026-04-18T00:52:52Z by Showboat 0.6.1*

Fixed three error messages that incorrectly suggested 'pip install posit-vip[load]' when locust is not installed. Updated all occurrences in src/vip/load_engine.py and src/vip/load_users.py to suggest 'uv sync --extra load' instead, consistent with VIP's uv-first toolchain policy.

```bash
grep -n 'uv sync' src/vip/load_engine.py src/vip/load_users.py
```

```output
src/vip/load_engine.py:191:        msg = f"locust not installed; {n} users with tool='locust' requires: uv sync --extra load"
src/vip/load_engine.py:337:        msg = "locust not installed; user simulation requires: uv sync --extra load"
src/vip/load_users.py:16:    msg = "locust is required for user simulation: uv sync --extra load"
```

```bash
uv run pytest selftests/ 2>&1 | grep -oE "[0-9]+ passed"
```

```output
243 passed
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/ && echo 'Lint and format: OK'
```

```output
All checks passed!
99 files already formatted
Lint and format: OK
```