### PR TITLE
fix(cli): raise default --test-timeout to 3600s for Connect deploys

### DIFF
--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -24,7 +24,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         "filter_expr": None,
         "pytest_args": [],
         "verbose": False,
-        "test_timeout": 180,
+        "test_timeout": 3600,
         "headless_auth": False,
         "idp": None,
     }
@@ -480,11 +480,11 @@ class TestNormalizeCategories:
 class TestVerifyLocalTestTimeout:
     """--test-timeout should limit how long the subprocess can run."""
 
-    def test_default_timeout_is_180(self, tmp_path):
+    def test_default_timeout_is_3600(self, tmp_path):
         cfg = tmp_path / "vip.toml"
         cfg.write_text("[general]\n")
         _cmd, kwargs = _capture_call(_make_args(config=str(cfg)))
-        assert kwargs["timeout"] == 180
+        assert kwargs["timeout"] == 3600
 
     def test_custom_timeout_passed_through(self, tmp_path):
         cfg = tmp_path / "vip.toml"
@@ -499,7 +499,7 @@ class TestVerifyLocalTestTimeout:
         cfg.write_text("[general]\n")
 
         def fake_run(cmd, **kwargs):
-            raise real_subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 180))
+            raise real_subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 3600))
 
         with (
             patch("vip.cli.subprocess.run", side_effect=fake_run),

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -856,8 +856,12 @@ def main() -> None:
     verify_parser.add_argument(
         "--test-timeout",
         type=int,
-        default=180,
-        help="Timeout in seconds for the pytest subprocess (default: 180)",
+        default=3600,
+        help="Timeout in seconds for the pytest subprocess (default: 3600). "
+        "A full Connect run includes content deployments that each take several "
+        "minutes (R package restore, Python venv creation), so raise this further "
+        "for large suites or slow servers. For per-deploy limits, see "
+        "connect.deploy_timeout in vip.toml.",
     )
 
     # K8s mode

--- a/uv.lock
+++ b/uv.lock
@@ -2480,7 +2480,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.24.1"
+version = "0.24.3"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-issue-178-test-timeout.md
+++ b/validation_docs/demo-issue-178-test-timeout.md
@@ -1,0 +1,59 @@
+# Fix: default --test-timeout too short for Connect deploys
+
+*2026-04-18T01:14:21Z by Showboat 0.6.1*
+<!-- showboat-id: 02f8bc3b-613e-490c-b880-ccdfe7295dc9 -->
+
+Issue #178 reported that the default --test-timeout of 180 seconds is too short for Connect content-deployment tests (e.g. test_deploy_shiny), which need to install packages server-side and routinely take 3-5 minutes each.
+
+This change raises the default from 180 seconds (3 min) to 3600 seconds (60 min) and updates the --help text to point users at connect.deploy_timeout in vip.toml for per-deploy limits.
+
+### New default surfaced via --help
+
+```bash
+uv run vip verify --help 2>&1 | grep -A4 -- '--test-timeout'
+```
+
+```output
+                  [--test-timeout TEST_TIMEOUT] [--k8s] [--site SITE]
+                  [--namespace NAMESPACE] [--name NAME] [--image IMAGE]
+                  [--timeout TIMEOUT] [--config-only]
+                  [pytest_args ...]
+
+--
+  --test-timeout TEST_TIMEOUT
+                        Timeout in seconds for the pytest subprocess (default:
+                        3600). A full Connect run includes content deployments
+                        that each take several minutes (R package restore,
+                        Python venv creation), so raise this further for large
+```
+
+### Selftests pass, including the updated default-timeout assertion
+
+```bash
+uv run pytest selftests/test_cli_verify.py::TestVerifyLocalTestTimeout -v 2>&1 | grep -E 'PASSED|FAILED|ERROR' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_default_timeout_is_3600 PASSED [ 33%]
+selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_custom_timeout_passed_through PASSED [ 66%]
+selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_timeout_expired_exits_with_error PASSED [100%]
+```
+
+```bash
+uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+243 passed, 4 warnings
+```
+
+### Lint and format pass
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+99 files already formatted
+```


### PR DESCRIPTION
## Summary

- Raised the default `--test-timeout` from 180s (3 min) to 3600s (60 min). 180s was not enough for Connect content-deployment tests like `test_deploy_shiny`, which install packages server-side and routinely take 3–5 minutes each.
- Expanded the `--help` text to explain why full-suite Connect runs can be long and to point users at `connect.deploy_timeout` in `vip.toml` for per-deploy limits.
- Updated the corresponding selftest (`test_default_timeout_is_3600`).

Fixes #178

## Test plan

- [x] `uv run pytest selftests/` — 243 passed
- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run vip verify --help` shows the new default and guidance

## Demo

# Fix: default --test-timeout too short for Connect deploys

Issue #178 reported that the default --test-timeout of 180 seconds is too short for Connect content-deployment tests (e.g. test_deploy_shiny), which need to install packages server-side and routinely take 3-5 minutes each.

This change raises the default from 180 seconds (3 min) to 3600 seconds (60 min) and updates the --help text to point users at connect.deploy_timeout in vip.toml for per-deploy limits.

### New default surfaced via --help

```bash
uv run vip verify --help 2>&1 | grep -A4 -- '--test-timeout'
```

```output
                  [--test-timeout TEST_TIMEOUT] [--k8s] [--site SITE]
                  [--namespace NAMESPACE] [--name NAME] [--image IMAGE]
                  [--timeout TIMEOUT] [--config-only]
                  [pytest_args ...]

--
  --test-timeout TEST_TIMEOUT
                        Timeout in seconds for the pytest subprocess (default:
                        3600). A full Connect run includes content deployments
                        that each take several minutes (R package restore,
                        Python venv creation), so raise this further for large
```

### Selftests pass, including the updated default-timeout assertion

```bash
uv run pytest selftests/test_cli_verify.py::TestVerifyLocalTestTimeout -v 2>&1 | grep -E 'PASSED|FAILED|ERROR' | sed 's/ in [0-9.]*s//'
```

```output
selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_default_timeout_is_3600 PASSED [ 33%]
selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_custom_timeout_passed_through PASSED [ 66%]
selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_timeout_expired_exits_with_error PASSED [100%]
```

```bash
uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
243 passed, 4 warnings
```

### Lint and format pass

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
99 files already formatted
```
