### PR TITLE
refactor(cli): share DEFAULT_TEST_TIMEOUT_SECONDS and fix TOML help wording

### DIFF
--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vip.cli import DEFAULT_TEST_TIMEOUT_SECONDS
+
 
 def _make_args(**overrides) -> argparse.Namespace:
     """Build a minimal args namespace for _run_verify_local."""
@@ -24,7 +26,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         "filter_expr": None,
         "pytest_args": [],
         "verbose": False,
-        "test_timeout": 3600,
+        "test_timeout": DEFAULT_TEST_TIMEOUT_SECONDS,
         "headless_auth": False,
         "idp": None,
     }
@@ -480,11 +482,41 @@ class TestNormalizeCategories:
 class TestVerifyLocalTestTimeout:
     """--test-timeout should limit how long the subprocess can run."""
 
-    def test_default_timeout_is_3600(self, tmp_path):
+    def test_argparse_default_matches_constant(self, tmp_path, monkeypatch):
+        """The real CLI parser must resolve ``--test-timeout`` to the shared
+        ``DEFAULT_TEST_TIMEOUT_SECONDS`` constant.
+
+        Guards against regressing the argparse default in isolation from the
+        constant (or vice versa) — the two must stay in lockstep.
+        """
+        import sys
+
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+
+        captured: dict[str, int] = {}
+
+        def fake_run_verify(args):
+            captured["test_timeout"] = args.test_timeout
+            raise SystemExit(0)
+
+        monkeypatch.setattr("vip.cli.run_verify", fake_run_verify)
+        monkeypatch.setattr(sys, "argv", ["vip", "verify", "--config", str(cfg)])
+
+        from vip.cli import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        assert captured["test_timeout"] == DEFAULT_TEST_TIMEOUT_SECONDS
+        # Guard against a surprise change to the expected default itself.
+        assert DEFAULT_TEST_TIMEOUT_SECONDS == 3600
+
+    def test_default_timeout_passed_to_subprocess(self, tmp_path):
         cfg = tmp_path / "vip.toml"
         cfg.write_text("[general]\n")
         _cmd, kwargs = _capture_call(_make_args(config=str(cfg)))
-        assert kwargs["timeout"] == 3600
+        assert kwargs["timeout"] == DEFAULT_TEST_TIMEOUT_SECONDS
 
     def test_custom_timeout_passed_through(self, tmp_path):
         cfg = tmp_path / "vip.toml"
@@ -499,7 +531,9 @@ class TestVerifyLocalTestTimeout:
         cfg.write_text("[general]\n")
 
         def fake_run(cmd, **kwargs):
-            raise real_subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 3600))
+            raise real_subprocess.TimeoutExpired(
+                cmd, kwargs.get("timeout", DEFAULT_TEST_TIMEOUT_SECONDS)
+            )
 
         with (
             patch("vip.cli.subprocess.run", side_effect=fake_run),

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 _JOB_CLEANUP_BUFFER_SECONDS = 60
 _JOB_MIN_PYTEST_TIMEOUT_SECONDS = 60
 
+# Default for ``vip verify --test-timeout``.  Generous enough for a full
+# Connect suite with several content deployments (each can take 3-5 minutes
+# for R package restore or Python venv creation).
+DEFAULT_TEST_TIMEOUT_SECONDS = 3600
+
 # Valid test categories. Maps every accepted spelling (hyphenated and
 # underscored) to the internal pytest marker name.
 VALID_CATEGORIES: dict[str, str] = {
@@ -856,12 +861,15 @@ def main() -> None:
     verify_parser.add_argument(
         "--test-timeout",
         type=int,
-        default=3600,
-        help="Timeout in seconds for the pytest subprocess (default: 3600). "
-        "A full Connect run includes content deployments that each take several "
-        "minutes (R package restore, Python venv creation), so raise this further "
-        "for large suites or slow servers. For per-deploy limits, see "
-        "connect.deploy_timeout in vip.toml.",
+        default=DEFAULT_TEST_TIMEOUT_SECONDS,
+        help=(
+            "Timeout in seconds for the pytest subprocess "
+            f"(default: {DEFAULT_TEST_TIMEOUT_SECONDS}). "
+            "A full Connect run includes content deployments that each take "
+            "several minutes (R package restore, Python venv creation), so "
+            "raise this further for large suites or slow servers. For "
+            "per-deploy limits, set deploy_timeout under [connect] in vip.toml."
+        ),
     )
 
     # K8s mode

--- a/validation_docs/demo-issue-178-followup.md
+++ b/validation_docs/demo-issue-178-followup.md
@@ -1,0 +1,74 @@
+# Follow-up: Address Copilot review comments for #191
+
+*2026-04-18T01:24:36Z by Showboat 0.6.1*
+<!-- showboat-id: de2120da-de9b-409a-8fd3-5ff58d08ff00 -->
+
+#191 merged with three Copilot review comments still open. This follow-up addresses all three:
+
+1. **cli.py --help wording** — use TOML section syntax (`set deploy_timeout under [connect]`) rather than a dotted path (`connect.deploy_timeout`), since users edit vip.toml by section, not by dotted key.
+2. **Shared `DEFAULT_TEST_TIMEOUT_SECONDS` constant** — argparse default and selftest helper now reference the same module-level constant, so they stay in lockstep.
+3. **Real argparse-default test** — added `test_argparse_default_matches_constant` which invokes the real `vip verify` parser via `main()` and asserts the parsed default equals the constant. This guards against drift even if the helper's own default is changed in isolation.
+
+### Updated --help text uses TOML section syntax
+
+```bash
+uv run vip verify --help 2>&1 | grep -A5 -- '--test-timeout'
+```
+
+```output
+                  [--test-timeout TEST_TIMEOUT] [--k8s] [--site SITE]
+                  [--namespace NAMESPACE] [--name NAME] [--image IMAGE]
+                  [--timeout TIMEOUT] [--config-only]
+                  [pytest_args ...]
+
+Run VIP tests against a Posit Team deployment.
+--
+  --test-timeout TEST_TIMEOUT
+                        Timeout in seconds for the pytest subprocess (default:
+                        3600). A full Connect run includes content deployments
+                        that each take several minutes (R package restore,
+                        Python venv creation), so raise this further for large
+                        suites or slow servers. For per-deploy limits, set
+```
+
+### Shared constant is reachable and holds the expected value
+
+```bash
+uv run python -c 'from vip.cli import DEFAULT_TEST_TIMEOUT_SECONDS; print(DEFAULT_TEST_TIMEOUT_SECONDS)'
+```
+
+```output
+3600
+```
+
+### The timeout-group selftests all pass, including the new argparse test
+
+```bash
+uv run pytest selftests/test_cli_verify.py::TestVerifyLocalTestTimeout -v 2>&1 | grep -E 'PASSED|FAILED|ERROR' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_argparse_default_matches_constant PASSED [ 25%]
+selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_default_timeout_passed_to_subprocess PASSED [ 50%]
+selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_custom_timeout_passed_through PASSED [ 75%]
+selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_timeout_expired_exits_with_error PASSED [100%]
+```
+
+### Full selftest suite and lint/format still pass
+
+```bash
+uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+244 passed, 4 warnings
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+99 files already formatted
+```


### PR DESCRIPTION
## Summary

Follow-up to #191 addressing the three Copilot review comments that landed after merge.

- Expose a module-level `DEFAULT_TEST_TIMEOUT_SECONDS = 3600` constant in `vip.cli` and reference it from both the argparse default and the selftest `_make_args` helper. The two can no longer drift.
- Reword `vip verify --help` to say `set deploy_timeout under [connect] in vip.toml` instead of the misleading dotted path `connect.deploy_timeout`. Users edit `vip.toml` by TOML section header, not by dotted key.
- Add `test_argparse_default_matches_constant`, which invokes the real `vip verify` parser via `main()` and asserts the parsed default equals the shared constant. The previous `test_default_timeout_is_3600` test only exercised `_make_args` itself, so a regression in the argparse default alone would have gone unnoticed.

Ref #178, #191.

## Test plan

- [x] `uv run pytest selftests/` — 244 passed (was 243; +1 for the new test)
- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run vip verify --help` shows the updated TOML wording
- [x] Intentionally setting the argparse default to a different value (e.g. `900`) now fails `test_argparse_default_matches_constant`, while the old helper-only test would have continued to pass

## Demo

# Follow-up: Address Copilot review comments for #191

#191 merged with three Copilot review comments still open. This follow-up addresses all three:

1. **cli.py --help wording** — use TOML section syntax (`set deploy_timeout under [connect]`) rather than a dotted path (`connect.deploy_timeout`), since users edit vip.toml by section, not by dotted key.
2. **Shared `DEFAULT_TEST_TIMEOUT_SECONDS` constant** — argparse default and selftest helper now reference the same module-level constant, so they stay in lockstep.
3. **Real argparse-default test** — added `test_argparse_default_matches_constant` which invokes the real `vip verify` parser via `main()` and asserts the parsed default equals the constant. This guards against drift even if the helper's own default is changed in isolation.

### Updated --help text uses TOML section syntax

```bash
uv run vip verify --help 2>&1 | grep -A5 -- '--test-timeout'
```

```output
                  [--test-timeout TEST_TIMEOUT] [--k8s] [--site SITE]
                  [--namespace NAMESPACE] [--name NAME] [--image IMAGE]
                  [--timeout TIMEOUT] [--config-only]
                  [pytest_args ...]

Run VIP tests against a Posit Team deployment.
--
  --test-timeout TEST_TIMEOUT
                        Timeout in seconds for the pytest subprocess (default:
                        3600). A full Connect run includes content deployments
                        that each take several minutes (R package restore,
                        Python venv creation), so raise this further for large
                        suites or slow servers. For per-deploy limits, set
```

### Shared constant is reachable and holds the expected value

```bash
uv run python -c 'from vip.cli import DEFAULT_TEST_TIMEOUT_SECONDS; print(DEFAULT_TEST_TIMEOUT_SECONDS)'
```

```output
3600
```

### The timeout-group selftests all pass, including the new argparse test

```bash
uv run pytest selftests/test_cli_verify.py::TestVerifyLocalTestTimeout -v 2>&1 | grep -E 'PASSED|FAILED|ERROR' | sed 's/ in [0-9.]*s//'
```

```output
selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_argparse_default_matches_constant PASSED [ 25%]
selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_default_timeout_passed_to_subprocess PASSED [ 50%]
selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_custom_timeout_passed_through PASSED [ 75%]
selftests/test_cli_verify.py::TestVerifyLocalTestTimeout::test_timeout_expired_exits_with_error PASSED [100%]
```

### Full selftest suite and lint/format still pass

```bash
uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
244 passed, 4 warnings
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
99 files already formatted
```
