### PR TITLE
fix(auth): skip headless auth when no auth-requiring products configured

### DIFF
--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -454,19 +454,30 @@ class TestPluginIntegration:
         assert result["scenario_title"] is None
         assert result["feature_description"] is None
 
-    def test_interactive_auth_requires_product_url(self, selftest_pytester):
-        """--interactive-auth fails fast when no product URL is configured."""
+    def test_interactive_auth_skipped_when_no_auth_products(self, selftest_pytester):
+        """--interactive-auth skips the browser flow when no auth-requiring products are enabled.
+
+        When only Package Manager (which needs no auth) is configured, running with
+        --interactive-auth should not error out; the auth flow should be skipped and
+        tests should proceed normally.  See issue #173.
+        """
         selftest_pytester.makepyfile(
             """
             def test_placeholder():
                 assert True
             """
         )
-        result = selftest_pytester.runpytest(
+        result = selftest_pytester.runpytest_subprocess(
             "--vip-config=vip.toml",
             "--interactive-auth",
+            "-W",
+            "always",
         )
-        result.stderr.fnmatch_lines(["*--interactive-auth requires at least one product URL*"])
+        assert result.ret == 0
+        result.assert_outcomes(passed=1)
+        result.stderr.fnmatch_lines(
+            ["*no auth-requiring products*skipping browser authentication*"]
+        )
 
     def test_json_report_includes_concise_error(self, selftest_pytester):
         selftest_pytester.makepyfile(
@@ -653,8 +664,12 @@ class TestHeadlessAuthOption:
 
 
 class TestHeadlessAuthFixture:
-    def test_headless_auth_requires_product_url(self, pytester):
-        """--headless-auth fails fast when no product URL is configured."""
+    def test_headless_auth_skipped_when_no_auth_products(self, pytester):
+        """--headless-auth skips the browser flow when no auth-requiring products are enabled.
+
+        If only Package Manager is enabled (or no products at all), --headless-auth
+        should warn and continue rather than failing with UsageError -- see issue #173.
+        """
         pytester.makefile(".toml", vip='[general]\ndeployment_name = "Selftest"')
         pytester.makepyfile(
             """
@@ -662,11 +677,51 @@ class TestHeadlessAuthFixture:
                 assert True
             """
         )
-        result = pytester.runpytest(
+        result = pytester.runpytest_subprocess(
             "--vip-config=vip.toml",
             "--headless-auth",
+            "-W",
+            "always",
         )
-        result.stderr.fnmatch_lines(["*--headless-auth requires at least one product URL*"])
+        assert result.ret == 0
+        result.assert_outcomes(passed=1)
+        result.stderr.fnmatch_lines(
+            ["*no auth-requiring products*skipping browser authentication*"]
+        )
+
+    def test_headless_auth_skipped_when_only_package_manager_enabled(self, pytester):
+        """--headless-auth skips auth when only Package Manager is enabled.
+
+        Reproduces the scenario from issue #173: Connect/Workbench disabled,
+        Package Manager enabled -- headless auth should be skipped.
+        """
+        pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                "[connect]\nenabled = false\n"
+                "[workbench]\nenabled = false\n"
+                "[package_manager]\nenabled = true\n"
+                'url = "https://pm.example.com"\n'
+            ),
+        )
+        pytester.makepyfile(
+            """
+            def test_placeholder():
+                assert True
+            """
+        )
+        result = pytester.runpytest_subprocess(
+            "--vip-config=vip.toml",
+            "--headless-auth",
+            "-W",
+            "always",
+        )
+        assert result.ret == 0
+        result.assert_outcomes(passed=1)
+        result.stderr.fnmatch_lines(
+            ["*no auth-requiring products*skipping browser authentication*"]
+        )
 
     def test_interactive_auth_fixture_true_for_headless(self, pytester):
         """The interactive_auth fixture should return True when --headless-auth is active."""

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -457,7 +457,7 @@ class TestPluginIntegration:
     def test_interactive_auth_skipped_when_no_auth_products(self, selftest_pytester):
         """--interactive-auth skips the browser flow when no auth-requiring products are enabled.
 
-        When only Package Manager (which needs no auth) is configured, running with
+        When no products requiring authentication are configured, running with
         --interactive-auth should not error out; the auth flow should be skipped and
         tests should proceed normally.  See issue #173.
         """

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -171,63 +171,71 @@ def pytest_configure(config: pytest.Config) -> None:
         wb_url = vip_cfg.workbench.url if vip_cfg.workbench.is_configured else None
 
         if not connect_url and not wb_url:
-            raise pytest.UsageError(
-                "--interactive-auth requires at least one product URL (Connect or Workbench)"
-            )
-
-        from pathlib import Path
-
-        from vip.auth import start_interactive_auth
-
-        cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
-        session = start_interactive_auth(
-            connect_url=connect_url, workbench_url=wb_url, cache_path=cache_path
-        )
-        config.stash[_auth_session_key] = session
-        if session.api_key:
-            vip_cfg.connect.api_key = session.api_key
-        elif connect_url:
+            # No auth-requiring product is enabled (e.g. only Package Manager).
+            # Skip the browser flow entirely rather than erroring out.
             warnings.warn(
-                "VIP: --interactive-auth could not mint an API key. "
-                "API-based tests will likely fail. Set VIP_CONNECT_API_KEY to fix.",
+                "VIP: --interactive-auth was requested but no auth-requiring products "
+                "(Connect, Workbench) are configured; skipping browser authentication.",
                 stacklevel=1,
             )
+        else:
+            from pathlib import Path
+
+            from vip.auth import start_interactive_auth
+
+            cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
+            session = start_interactive_auth(
+                connect_url=connect_url, workbench_url=wb_url, cache_path=cache_path
+            )
+            config.stash[_auth_session_key] = session
+            if session.api_key:
+                vip_cfg.connect.api_key = session.api_key
+            elif connect_url:
+                warnings.warn(
+                    "VIP: --interactive-auth could not mint an API key. "
+                    "API-based tests will likely fail. Set VIP_CONNECT_API_KEY to fix.",
+                    stacklevel=1,
+                )
     elif config.getoption("--headless-auth"):
         connect_url = vip_cfg.connect.url if vip_cfg.connect.is_configured else None
         wb_url = vip_cfg.workbench.url if vip_cfg.workbench.is_configured else None
 
         if not connect_url and not wb_url:
-            raise pytest.UsageError(
-                "--headless-auth requires at least one product URL (Connect or Workbench)"
-            )
-
-        from pathlib import Path
-
-        from vip.auth import AuthConfigError, start_headless_auth
-
-        cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
-        try:
-            session = start_headless_auth(
-                connect_url=connect_url,
-                workbench_url=wb_url,
-                idp=vip_cfg.auth.idp,
-                provider=vip_cfg.auth.provider,
-                username=vip_cfg.auth.username,
-                password=vip_cfg.auth.password,
-                cache_path=cache_path,
-                verbose=config.getoption("--vip-verbose", default=False),
-            )
-        except AuthConfigError as exc:
-            raise pytest.UsageError(str(exc)) from None
-        config.stash[_auth_session_key] = session
-        if session.api_key:
-            vip_cfg.connect.api_key = session.api_key
-        elif connect_url:
+            # No auth-requiring product is enabled (e.g. only Package Manager).
+            # Skip the browser flow entirely rather than erroring out.
             warnings.warn(
-                "VIP: --headless-auth could not mint an API key. "
-                "API-based tests will likely fail. Set VIP_CONNECT_API_KEY to fix.",
+                "VIP: --headless-auth was requested but no auth-requiring products "
+                "(Connect, Workbench) are configured; skipping browser authentication.",
                 stacklevel=1,
             )
+        else:
+            from pathlib import Path
+
+            from vip.auth import AuthConfigError, start_headless_auth
+
+            cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
+            try:
+                session = start_headless_auth(
+                    connect_url=connect_url,
+                    workbench_url=wb_url,
+                    idp=vip_cfg.auth.idp,
+                    provider=vip_cfg.auth.provider,
+                    username=vip_cfg.auth.username,
+                    password=vip_cfg.auth.password,
+                    cache_path=cache_path,
+                    verbose=config.getoption("--vip-verbose", default=False),
+                )
+            except AuthConfigError as exc:
+                raise pytest.UsageError(str(exc)) from None
+            config.stash[_auth_session_key] = session
+            if session.api_key:
+                vip_cfg.connect.api_key = session.api_key
+            elif connect_url:
+                warnings.warn(
+                    "VIP: --headless-auth could not mint an API key. "
+                    "API-based tests will likely fail. Set VIP_CONNECT_API_KEY to fix.",
+                    stacklevel=1,
+                )
 
 
 def _restore_worker_auth(config: pytest.Config, vip_cfg: VIPConfig) -> None:

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -171,7 +171,7 @@ def pytest_configure(config: pytest.Config) -> None:
         wb_url = vip_cfg.workbench.url if vip_cfg.workbench.is_configured else None
 
         if not connect_url and not wb_url:
-            # No auth-requiring product is enabled (e.g. only Package Manager).
+            # No auth-requiring product is configured (e.g. only Package Manager).
             # Skip the browser flow entirely rather than erroring out.
             warnings.warn(
                 "VIP: --interactive-auth was requested but no auth-requiring products "
@@ -179,8 +179,6 @@ def pytest_configure(config: pytest.Config) -> None:
                 stacklevel=1,
             )
         else:
-            from pathlib import Path
-
             from vip.auth import start_interactive_auth
 
             cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
@@ -201,7 +199,7 @@ def pytest_configure(config: pytest.Config) -> None:
         wb_url = vip_cfg.workbench.url if vip_cfg.workbench.is_configured else None
 
         if not connect_url and not wb_url:
-            # No auth-requiring product is enabled (e.g. only Package Manager).
+            # No auth-requiring product is configured (e.g. only Package Manager).
             # Skip the browser flow entirely rather than erroring out.
             warnings.warn(
                 "VIP: --headless-auth was requested but no auth-requiring products "
@@ -209,8 +207,6 @@ def pytest_configure(config: pytest.Config) -> None:
                 stacklevel=1,
             )
         else:
-            from pathlib import Path
-
             from vip.auth import AuthConfigError, start_headless_auth
 
             cache_path = Path(config.rootpath) / ".vip-auth-cache.json"

--- a/uv.lock
+++ b/uv.lock
@@ -2480,7 +2480,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.24.1"
+version = "0.24.3"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-fix-issue-173-headless-auth-skip.md
+++ b/validation_docs/demo-fix-issue-173-headless-auth-skip.md
@@ -1,7 +1,7 @@
 # fix(auth): skip headless auth when no auth-requiring products are enabled
 
-*2026-04-18T01:22:47Z by Showboat 0.6.1*
-<!-- showboat-id: 7150c7c1-0f33-442f-b511-e36de58ad255 -->
+*2026-04-18T01:31:19Z by Showboat 0.6.1*
+<!-- showboat-id: 5e22069d-ab1a-415e-998b-ae78e99ef887 -->
 
 Issue #173: When `vip verify --headless-auth` is invoked but neither Connect nor Workbench is configured (for instance, when only Package Manager is enabled), the plugin used to raise a `UsageError` and abort the run. Package Manager tests don't require browser authentication, so they should be able to run without any auth flow at all.
 
@@ -11,10 +11,28 @@ In `src/vip/plugin.py`, the `--interactive-auth` and `--headless-auth` branches 
 
 ## Reproducing the reported scenario
 
-We first reproduce the exact scenario from the issue: Connect/Workbench disabled, Package Manager enabled, `--headless-auth` specified. Before the fix this would abort with a `UsageError`. Afterward, the plugin warns, skips the browser flow, and the placeholder test runs to completion.
+We create an isolated fixture with Connect and Workbench disabled and Package Manager enabled, then invoke pytest with `--headless-auth`.  Before the fix this would abort with a `UsageError`.  After the fix, the plugin warns, skips the browser flow, and the placeholder test runs to completion.
 
 ```bash
-cat /tmp/vip-demo/vip.toml
+rm -rf /tmp/vip-demo-173 && mkdir -p /tmp/vip-demo-173 && cat > /tmp/vip-demo-173/vip.toml <<'EOF'
+[general]
+deployment_name = "Issue 173 Repro"
+
+[connect]
+enabled = false
+
+[workbench]
+enabled = false
+
+[package_manager]
+enabled = true
+url = "https://pm.example.com"
+EOF
+cat > /tmp/vip-demo-173/test_placeholder.py <<'EOF'
+def test_pm_only_run():
+    assert True
+EOF
+cat /tmp/vip-demo-173/vip.toml
 ```
 
 ```output
@@ -33,15 +51,15 @@ url = "https://pm.example.com"
 ```
 
 ```bash
-cd /tmp/vip-demo && uv --project /home/user/vip run pytest --vip-config=vip.toml --headless-auth test_placeholder.py 2>&1 | grep -E 'passed|failed|error|UserWarning|auth-requiring' | sed 's/ in [0-9.]*s//'
+VIP_ROOT=$PWD && cd /tmp/vip-demo-173 && uv --project "$VIP_ROOT" run pytest --vip-config=vip.toml --headless-auth test_placeholder.py 2>&1 | grep -E 'passed|failed|error|auth-requiring' | sed -E 's/ in [0-9.]+s//; s|.+/src/vip/plugin.py:[0-9]+:|src/vip/plugin.py:|'
 ```
 
 ```output
-/home/user/vip/src/vip/plugin.py:206: UserWarning: VIP: --headless-auth was requested but no auth-requiring products (Connect, Workbench) are configured; skipping browser authentication.
+src/vip/plugin.py: UserWarning: VIP: --headless-auth was requested but no auth-requiring products (Connect, Workbench) are configured; skipping browser authentication.
 ============================== 1 passed ===============================
 ```
 
-The placeholder test passes and the plugin emits a user-visible warning instead of aborting. Package Manager-only workflows now succeed with `--headless-auth`.
+The placeholder test passes and the plugin emits a user-visible warning instead of aborting.  Package Manager-only workflows now succeed with `--headless-auth`.
 
 ## Selftest coverage
 

--- a/validation_docs/demo-fix-issue-173-headless-auth-skip.md
+++ b/validation_docs/demo-fix-issue-173-headless-auth-skip.md
@@ -1,0 +1,85 @@
+# fix(auth): skip headless auth when no auth-requiring products are enabled
+
+*2026-04-18T01:22:47Z by Showboat 0.6.1*
+<!-- showboat-id: 7150c7c1-0f33-442f-b511-e36de58ad255 -->
+
+Issue #173: When `vip verify --headless-auth` is invoked but neither Connect nor Workbench is configured (for instance, when only Package Manager is enabled), the plugin used to raise a `UsageError` and abort the run. Package Manager tests don't require browser authentication, so they should be able to run without any auth flow at all.
+
+## Fix
+
+In `src/vip/plugin.py`, the `--interactive-auth` and `--headless-auth` branches of `pytest_configure` now warn and skip the browser flow instead of raising `UsageError` when no auth-requiring product (Connect or Workbench) is configured. Tests continue to run -- Package Manager tests that don't need auth still proceed normally.
+
+## Reproducing the reported scenario
+
+We first reproduce the exact scenario from the issue: Connect/Workbench disabled, Package Manager enabled, `--headless-auth` specified. Before the fix this would abort with a `UsageError`. Afterward, the plugin warns, skips the browser flow, and the placeholder test runs to completion.
+
+```bash
+cat /tmp/vip-demo/vip.toml
+```
+
+```output
+[general]
+deployment_name = "Issue 173 Repro"
+
+[connect]
+enabled = false
+
+[workbench]
+enabled = false
+
+[package_manager]
+enabled = true
+url = "https://pm.example.com"
+```
+
+```bash
+cd /tmp/vip-demo && uv --project /home/user/vip run pytest --vip-config=vip.toml --headless-auth test_placeholder.py 2>&1 | grep -E 'passed|failed|error|UserWarning|auth-requiring' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+/home/user/vip/src/vip/plugin.py:206: UserWarning: VIP: --headless-auth was requested but no auth-requiring products (Connect, Workbench) are configured; skipping browser authentication.
+============================== 1 passed ===============================
+```
+
+The placeholder test passes and the plugin emits a user-visible warning instead of aborting. Package Manager-only workflows now succeed with `--headless-auth`.
+
+## Selftest coverage
+
+Three selftests cover the new behavior:
+
+- `TestPluginIntegration::test_interactive_auth_skipped_when_no_auth_products` -- verifies `--interactive-auth` also skips gracefully.
+- `TestHeadlessAuthFixture::test_headless_auth_skipped_when_no_auth_products` -- exercises `--headless-auth` with no products configured at all.
+- `TestHeadlessAuthFixture::test_headless_auth_skipped_when_only_package_manager_enabled` -- reproduces the exact issue #173 scenario.
+
+```bash
+uv run pytest selftests/test_plugin.py -v -k 'auth_skipped or auth_skipped_when_only' 2>&1 | grep -E 'PASSED|FAILED|ERROR' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+selftests/test_plugin.py::TestPluginIntegration::test_interactive_auth_skipped_when_no_auth_products PASSED [ 33%]
+selftests/test_plugin.py::TestHeadlessAuthFixture::test_headless_auth_skipped_when_no_auth_products PASSED [ 66%]
+selftests/test_plugin.py::TestHeadlessAuthFixture::test_headless_auth_skipped_when_only_package_manager_enabled PASSED [100%]
+```
+
+## Full selftest suite
+
+The rest of the selftest suite still passes and the existing `--headless-auth requires idp` validation remains in effect.
+
+```bash
+uv run pytest selftests/ 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+======================= 244 passed, 4 warnings =======================
+```
+
+## Lint and format
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+99 files already formatted
+```


### PR DESCRIPTION
## Summary

- When `--interactive-auth` or `--headless-auth` is passed but neither Connect nor Workbench is configured (e.g. only Package Manager is enabled), the plugin now warns and skips the browser flow instead of aborting with `UsageError`.
- Package Manager-only test runs now succeed with `--headless-auth`, which they previously couldn't.
- Selftests updated: two existing tests retargeted to assert the new skip behavior, plus a new test that reproduces the exact scenario from the issue (Connect/Workbench disabled, Package Manager enabled).

Fixes #173.

## Test plan

- [x] `uv run pytest selftests/` — 244 passed
- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/`
- [x] Reproduced the issue scenario end-to-end (PM-only config + `--headless-auth` → tests run, warning emitted)

## Demo

# fix(auth): skip headless auth when no auth-requiring products are enabled

*2026-04-18T01:22:47Z by Showboat 0.6.1*

Issue #173: When `vip verify --headless-auth` is invoked but neither Connect nor Workbench is configured (for instance, when only Package Manager is enabled), the plugin used to raise a `UsageError` and abort the run. Package Manager tests don't require browser authentication, so they should be able to run without any auth flow at all.

### Fix

In `src/vip/plugin.py`, the `--interactive-auth` and `--headless-auth` branches of `pytest_configure` now warn and skip the browser flow instead of raising `UsageError` when no auth-requiring product (Connect or Workbench) is configured. Tests continue to run -- Package Manager tests that don't need auth still proceed normally.

### Reproducing the reported scenario

We first reproduce the exact scenario from the issue: Connect/Workbench disabled, Package Manager enabled, `--headless-auth` specified. Before the fix this would abort with a `UsageError`. Afterward, the plugin warns, skips the browser flow, and the placeholder test runs to completion.

```bash
cat /tmp/vip-demo/vip.toml
```

```output
[general]
deployment_name = "Issue 173 Repro"

[connect]
enabled = false

[workbench]
enabled = false

[package_manager]
enabled = true
url = "https://pm.example.com"
```

```bash
cd /tmp/vip-demo && uv --project /home/user/vip run pytest --vip-config=vip.toml --headless-auth test_placeholder.py 2>&1 | grep -E 'passed|failed|error|UserWarning|auth-requiring' | sed 's/ in [0-9.]*s//'
```

```output
/home/user/vip/src/vip/plugin.py:206: UserWarning: VIP: --headless-auth was requested but no auth-requiring products (Connect, Workbench) are configured; skipping browser authentication.
============================== 1 passed ===============================
```

The placeholder test passes and the plugin emits a user-visible warning instead of aborting. Package Manager-only workflows now succeed with `--headless-auth`.

### Selftest coverage

Three selftests cover the new behavior:

- `TestPluginIntegration::test_interactive_auth_skipped_when_no_auth_products` -- verifies `--interactive-auth` also skips gracefully.
- `TestHeadlessAuthFixture::test_headless_auth_skipped_when_no_auth_products` -- exercises `--headless-auth` with no products configured at all.
- `TestHeadlessAuthFixture::test_headless_auth_skipped_when_only_package_manager_enabled` -- reproduces the exact issue #173 scenario.

```bash
uv run pytest selftests/test_plugin.py -v -k 'auth_skipped or auth_skipped_when_only' 2>&1 | grep -E 'PASSED|FAILED|ERROR' | sed 's/ in [0-9.]*s//'
```

```output
selftests/test_plugin.py::TestPluginIntegration::test_interactive_auth_skipped_when_no_auth_products PASSED [ 33%]
selftests/test_plugin.py::TestHeadlessAuthFixture::test_headless_auth_skipped_when_no_auth_products PASSED [ 66%]
selftests/test_plugin.py::TestHeadlessAuthFixture::test_headless_auth_skipped_when_only_package_manager_enabled PASSED [100%]
```

### Full selftest suite

The rest of the selftest suite still passes and the existing `--headless-auth requires idp` validation remains in effect.

```bash
uv run pytest selftests/ 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
======================= 244 passed, 4 warnings =======================
```

### Lint and format

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
99 files already formatted
```

https://claude.ai/code/session_01V2A6Feo1KKUdKRajXhALTM