### PR TITLE
fix(security): move config hygiene tests to opt-in category

### DIFF
--- a/IMPLEMENTATION_GUIDE.md
+++ b/IMPLEMENTATION_GUIDE.md
@@ -79,7 +79,7 @@ paired with a `.py` file containing step definitions.
 | | `test_resource_usage` | Load avg and memory during traffic burst | Implemented |
 | **Security** | `test_https` | HTTPS enforced, no version headers | Implemented |
 | | `test_auth_policy` | Provider matches config, unauthed denied | Implemented |
-| | `test_secrets` | No plaintext secrets in config, API key from env | Implemented |
+| **Config hygiene** (opt-in) | `test_secrets` | No plaintext secrets in config, API key from env | Implemented |
 
 **Selftests** (38 tests): config loading, plugin behavior (via pytester),
 reporting module. All pass in CI.
@@ -159,7 +159,7 @@ anything.  To implement it:
 - Option C (session): Start a session, run `getOption("repos")` in the R
   console, and verify the output contains the expected URL.
 
-**`src/vip_tests/security/test_secrets.py` - plaintext detection**
+**`src/vip_tests/config_hygiene/test_secrets.py` - plaintext detection**
 
 The current placeholder list (`{"...", "your-api-key", "changeme", ""}`) works
 for basic cases.  To harden it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ markers = [
     "cross_product: tests that span multiple products",
     "performance: performance validation tests",
     "security: security validation tests",
+    "config_hygiene: checks of VIP's own configuration (opt-in; excluded by default)",
     "min_version(product, version): only run when product meets minimum version",
     "if_applicable: test is skipped when the feature is not configured",
 ]

--- a/scripts/generate-feature-matrix.py
+++ b/scripts/generate-feature-matrix.py
@@ -5,7 +5,8 @@ USAGE:
 
 Derives semantic "test areas" by normalising feature file stems across
 categories, then cross-tabulates which products each area covers.  For
-cross-cutting categories (cross_product, performance, security, prerequisites)
+cross-cutting categories (cross_product, performance, security, prerequisites,
+config_hygiene)
 product coverage is inferred from scenario step text and secondary tags.
 """
 
@@ -33,7 +34,13 @@ PRODUCT_LABELS = {
 
 # Product-specific categories map 1:1 to a product.
 PRODUCT_CATEGORIES = {"connect", "workbench", "package_manager"}
-CROSS_CUTTING_CATEGORIES = {"prerequisites", "cross_product", "performance", "security"}
+CROSS_CUTTING_CATEGORIES = {
+    "prerequisites",
+    "cross_product",
+    "performance",
+    "security",
+    "config_hygiene",
+}
 
 # Human-friendly area names keyed by feature file stem.
 AREA_NAMES: dict[str, str] = {
@@ -81,6 +88,7 @@ CATEGORY_LABELS: dict[str, str] = {
     "cross_product": "Cross-Product",
     "performance": "Performance",
     "security": "Security",
+    "config_hygiene": "Config Hygiene",
 }
 
 

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -478,6 +478,56 @@ class TestNormalizeCategories:
             _normalize_categories("1connect")
         assert exc_info.value.code == 1
 
+    def test_config_hygiene_category_accepted(self):
+        from vip.cli import _normalize_categories
+
+        assert _normalize_categories("config-hygiene") == "config_hygiene"
+        assert _normalize_categories("config_hygiene") == "config_hygiene"
+
+
+class TestConfigHygieneOptIn:
+    """config_hygiene tests are excluded from the default vip verify run."""
+
+    @staticmethod
+    def _marker_expr(cmd: list[str]) -> str:
+        """Return the pytest marker expression, skipping ``python -m pytest``."""
+        # cmd looks like [python, "-m", "pytest", ..., "-m", "<expr>", ...]
+        # The first "-m" introduces the pytest module; the second is the
+        # marker filter we want to inspect.
+        first = cmd.index("-m")
+        second = cmd.index("-m", first + 1)
+        return cmd[second + 1]
+
+    def test_default_filter_excludes_config_hygiene(self, tmp_path):
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg)))
+        assert "not config_hygiene" in self._marker_expr(cmd)
+
+    def test_explicit_category_overrides_default_filter(self, tmp_path):
+        """When the user passes --categories, the default exclusion is replaced."""
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), categories="package-manager"))
+        # Exactly two "-m" tokens: ``python -m pytest`` and ``-m <expr>``.
+        assert cmd.count("-m") == 2
+        assert self._marker_expr(cmd) == "package_manager"
+
+    def test_opt_in_runs_config_hygiene_tests(self, tmp_path):
+        """Passing --categories config-hygiene runs exactly that category."""
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), categories="config-hygiene"))
+        assert self._marker_expr(cmd) == "config_hygiene"
+
+    def test_default_marker_expr_names_every_opt_in_category(self):
+        """_default_marker_expr excludes each category in _OPT_IN_CATEGORIES."""
+        from vip.cli import _OPT_IN_CATEGORIES, _default_marker_expr
+
+        expr = _default_marker_expr()
+        for category in _OPT_IN_CATEGORIES:
+            assert f"not {category}" in expr
+
 
 class TestVerifyLocalTestTimeout:
     """--test-timeout should limit how long the subprocess can run."""

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -754,6 +754,39 @@ class TestHeadlessAuthFixture:
         result = pytester.runpytest("-v")
         result.assert_outcomes(passed=1)
 
+    def test_headless_auth_fixture_true_only_for_headless(self, pytester):
+        """The headless_auth fixture is True for --headless-auth, False for --interactive-auth."""
+        pytester.makeconftest(
+            """
+            import pytest
+            from vip.plugin import _auth_session_key
+            from vip.auth import InteractiveAuthSession
+            from pathlib import Path
+
+            @pytest.fixture(scope="session", autouse=True)
+            def fake_auth_session(request):
+                session = InteractiveAuthSession(
+                    storage_state_path=Path("/dev/null"),
+                )
+                request.config.stash[_auth_session_key] = session
+
+            @pytest.fixture(scope="session")
+            def headless_auth(request):
+                if not request.config.getoption("--headless-auth", default=False):
+                    return False
+                return request.config.stash.get(_auth_session_key, None) is not None
+            """
+        )
+        pytester.makepyfile(
+            """
+            def test_fixture_value(headless_auth):
+                assert headless_auth is False
+            """
+        )
+        # Without --headless-auth, the fixture should be False even with a session.
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1)
+
 
 class TestHeadlessAuthPluginWiring:
     """Verify that pytest_configure validates config for --headless-auth."""

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -754,21 +754,29 @@ class TestHeadlessAuthFixture:
         result = pytester.runpytest("-v")
         result.assert_outcomes(passed=1)
 
-    def test_headless_auth_fixture_true_only_for_headless(self, pytester):
-        """The headless_auth fixture is True for --headless-auth, False for --interactive-auth."""
+    def test_headless_auth_fixture_true_only_for_headless(self, pytester, monkeypatch):
+        """The headless_auth fixture is True for --headless-auth, False otherwise."""
+        # Patch the auth startup so the plugin doesn't launch a real browser.
+        # monkeypatch auto-undoes after the test, so later tests see the real
+        # functions (e.g. TestHeadlessAuthPluginWiring which asserts
+        # AuthConfigError propagates).
+        from pathlib import Path
+
+        import vip.auth
+        from vip.auth import InteractiveAuthSession
+
+        def fake_start_auth(*args, **kwargs):
+            return InteractiveAuthSession(storage_state_path=Path("/dev/null"))
+
+        monkeypatch.setattr(vip.auth, "start_headless_auth", fake_start_auth)
+        monkeypatch.setattr(vip.auth, "start_interactive_auth", fake_start_auth)
+
+        # Mirror the real headless_auth fixture — pytester's tmp dir doesn't
+        # auto-load src/vip_tests/conftest.py.
         pytester.makeconftest(
             """
             import pytest
             from vip.plugin import _auth_session_key
-            from vip.auth import InteractiveAuthSession
-            from pathlib import Path
-
-            @pytest.fixture(scope="session", autouse=True)
-            def fake_auth_session(request):
-                session = InteractiveAuthSession(
-                    storage_state_path=Path("/dev/null"),
-                )
-                request.config.stash[_auth_session_key] = session
 
             @pytest.fixture(scope="session")
             def headless_auth(request):
@@ -777,14 +785,32 @@ class TestHeadlessAuthFixture:
                 return request.config.stash.get(_auth_session_key, None) is not None
             """
         )
+        pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                '[connect]\nurl = "https://c.example.com"\n'
+                '[auth]\nprovider = "password"\n'
+            ),
+        )
         pytester.makepyfile(
             """
-            def test_fixture_value(headless_auth):
-                assert headless_auth is False
+            def test_fixture_value(request, headless_auth):
+                expected = bool(request.config.getoption("--headless-auth", default=False))
+                assert headless_auth is expected
             """
         )
-        # Without --headless-auth, the fixture should be False even with a session.
-        result = pytester.runpytest("-v")
+
+        # --headless-auth: fixture is True.
+        result = pytester.runpytest("-v", "--vip-config=vip.toml", "--headless-auth")
+        result.assert_outcomes(passed=1)
+
+        # --interactive-auth: session is populated but headless_auth is False.
+        result = pytester.runpytest("-v", "--vip-config=vip.toml", "--interactive-auth")
+        result.assert_outcomes(passed=1)
+
+        # No auth flag: headless_auth is False.
+        result = pytester.runpytest("-v", "--vip-config=vip.toml")
         result.assert_outcomes(passed=1)
 
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -40,7 +40,14 @@ VALID_CATEGORIES: dict[str, str] = {
     "cross_product": "cross_product",
     "performance": "performance",
     "security": "security",
+    "config-hygiene": "config_hygiene",
+    "config_hygiene": "config_hygiene",
 }
+
+# Categories that are excluded from the default ``vip verify`` run and only
+# executed when the user opts in via ``--categories``.  These tests check
+# VIP's own configuration rather than the Posit deployment.
+_OPT_IN_CATEGORIES = frozenset({"config_hygiene"})
 
 # Marker expression keywords that are not category names.
 _MARKER_KEYWORDS = {"and", "or", "not"}
@@ -58,6 +65,15 @@ def _valid_categories_message() -> str:
         if v not in seen or "-" in k:
             seen[v] = k
     return ", ".join(sorted(seen.values()))
+
+
+def _default_marker_expr() -> str:
+    """Marker expression applied when the user doesn't pass ``--categories``.
+
+    Excludes every opt-in category so that ``vip verify`` runs only the
+    product-verification tests by default.
+    """
+    return " and ".join(f"not {name}" for name in sorted(_OPT_IN_CATEGORIES))
 
 
 def _normalize_categories(expr: str) -> str:
@@ -489,6 +505,8 @@ def _run_verify_local(args: argparse.Namespace) -> None:
         cmd.append(f"--vip-extensions={ext}")
     if args.categories:
         cmd.extend(["-m", _normalize_categories(args.categories)])
+    else:
+        cmd.extend(["-m", _default_marker_expr()])
     if args.filter_expr:
         cmd.extend(["-k", args.filter_expr])
 
@@ -567,7 +585,11 @@ def _run_k8s_job(vip_config_toml: str, args: argparse.Namespace) -> None:
             namespace,
             cm_name,
             image=args.image,
-            categories=_normalize_categories(args.categories) if args.categories else None,
+            categories=(
+                _normalize_categories(args.categories)
+                if args.categories
+                else _default_marker_expr()
+            ),
             filter_expr=getattr(args, "filter_expr", None),
             timeout_seconds=pytest_timeout,
             verbose=getattr(args, "verbose", False),

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -134,6 +134,10 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "security: security validation tests")
     config.addinivalue_line(
         "markers",
+        "config_hygiene: checks of VIP's own configuration (opt-in; excluded by default)",
+    )
+    config.addinivalue_line(
+        "markers",
         "min_version(product, version): skip when product is below the specified version",
     )
     config.addinivalue_line(

--- a/src/vip_tests/config_hygiene/conftest.py
+++ b/src/vip_tests/config_hygiene/conftest.py
@@ -1,0 +1,5 @@
+"""Config hygiene test fixtures."""
+
+import pytest
+
+pytestmark = pytest.mark.config_hygiene

--- a/src/vip_tests/config_hygiene/test_secrets.feature
+++ b/src/vip_tests/config_hygiene/test_secrets.feature
@@ -1,8 +1,8 @@
-@security
-Feature: Secure storage of secrets and tokens
-  As a Posit Team administrator
-  I want to verify that secrets and tokens are stored securely
-  So that credentials are not exposed
+@config_hygiene
+Feature: Secure storage of VIP's own secrets and tokens
+  As a VIP user
+  I want to verify that my VIP configuration keeps credentials out of plaintext files
+  So that secrets are not accidentally committed or shared
 
   Scenario: API keys are not stored in the VIP config file
     Given a VIP configuration file is in use

--- a/src/vip_tests/config_hygiene/test_secrets.py
+++ b/src/vip_tests/config_hygiene/test_secrets.py
@@ -63,8 +63,10 @@ def connect_has_key(vip_config):
 
 @then("the API key was loaded from the VIP_CONNECT_API_KEY environment variable")
 def key_from_env(interactive_auth):
+    # VIP mints the API key itself under --interactive-auth / --headless-auth,
+    # so the env-var workflow doesn't apply in those flows.
     if interactive_auth:
-        pytest.skip("API key was minted via interactive auth, not from an environment variable")
+        pytest.skip("API key was minted by VIP auth, not read from an environment variable")
     env_key = os.environ.get("VIP_CONNECT_API_KEY", "")
     assert env_key, (
         "VIP_CONNECT_API_KEY environment variable is not set. "

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -89,9 +89,21 @@ def pm_url(vip_config: VIPConfig) -> str:
 
 @pytest.fixture(scope="session")
 def interactive_auth(request: pytest.FixtureRequest) -> bool:
-    """Whether interactive auth was used for this session."""
+    """Whether interactive auth was used for this session.
+
+    True for either ``--interactive-auth`` or ``--headless-auth`` — both
+    populate the auth session stash and produce a browser storage state.
+    """
     session = request.config.stash.get(_auth_session_key, None)
     return session is not None
+
+
+@pytest.fixture(scope="session")
+def headless_auth(request: pytest.FixtureRequest) -> bool:
+    """Whether ``--headless-auth`` specifically was used for this session."""
+    if not request.config.getoption("--headless-auth", default=False):
+        return False
+    return request.config.stash.get(_auth_session_key, None) is not None
 
 
 @pytest.fixture(scope="session")

--- a/validation_docs/demo-fix-issue-182.md
+++ b/validation_docs/demo-fix-issue-182.md
@@ -129,11 +129,11 @@ collected 100 items / 99 deselected / 1 skipped / 1 selected
 243 existing tests plus 6 new tests covering the new behavior (default exclusion, explicit opt-in, normalizer accepting `config-hygiene`, `_default_marker_expr`, `headless_auth` fixture):
 
 ```bash
-uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed -E 's/ in [0-9.]*s//; s/, [0-9]+ warnings?//'
 ```
 
 ```output
-249 passed, 5 warnings
+249 passed
 ```
 
 ## Lint and format checks

--- a/validation_docs/demo-fix-issue-182.md
+++ b/validation_docs/demo-fix-issue-182.md
@@ -60,6 +60,22 @@ src/vip_tests/config_hygiene/test_secrets.feature:@config_hygiene
 Set up a minimal vip.toml for the demo:
 
 ```bash
+cat > /tmp/vip-demo.toml <<'EOF'
+[general]
+deployment_name = "Demo"
+
+[connect]
+enabled = false
+
+[workbench]
+enabled = false
+
+[package_manager]
+enabled = false
+EOF
+```
+
+```bash
 uv run vip verify --config /tmp/vip-demo.toml --no-auth -- --collect-only -q 2>&1 | grep -v 'Note:' | sed 's/ in [0-9.]*s//' | tail -20
 ```
 

--- a/validation_docs/demo-fix-issue-182.md
+++ b/validation_docs/demo-fix-issue-182.md
@@ -37,7 +37,7 @@ when they want to audit their VIP configuration.
 ## New layout
 
 ```bash
-ls src/vip_tests/config_hygiene/ | grep -v __pycache__
+ls src/vip_tests/config_hygiene/ | grep -v __pycache__ | LC_ALL=C sort
 ```
 
 ```output
@@ -75,53 +75,30 @@ enabled = false
 EOF
 ```
 
+Check that no `config_hygiene` tests are collected when running the default
+`vip verify` — the filter looks for any module path under `config_hygiene/`:
+
 ```bash
-uv run vip verify --config /tmp/vip-demo.toml --no-auth -- --collect-only -q 2>&1 | grep -v 'Note:' | sed 's/ in [0-9.]*s//' | tail -20
+uv run vip verify --config /tmp/vip-demo.toml --no-auth -- --collect-only -q 2>&1 \
+    | grep -c 'config_hygiene' | awk '{print "config_hygiene matches:", $1}'
 ```
 
 ```output
-<Dir vip>
-  <Dir src>
-    <Package vip_tests>
-      <Package connect>
-        <Module test_data_sources.py>
-          <Function test_connectivity>
-      <Package cross_product>
-        <Module test_monitoring.py>
-          <Function test_monitoring_configured>
-        <Module test_resources.py>
-          <Function test_product_health>
-      <Package performance>
-        <Module test_resource_usage.py>
-          <Function test_response_time_under_load>
-          <Function test_prometheus_metrics>
-      <Package security>
-        <Module test_auth_policy.py>
-          <Function test_auth_provider>
-
-================ 6/100 tests collected (94 deselected) ================
+config_hygiene matches: 0
 ```
-
-Note that no `config_hygiene` tests were collected.
 
 ## Opt in with `--categories config-hygiene`
 
+With the opt-in flag, `test_no_plaintext_secrets` is collected:
+
 ```bash
-uv run vip verify --config /tmp/vip-demo.toml --no-auth --categories config-hygiene -- --collect-only -q 2>&1 | grep -v 'Note:' | sed 's/ in [0-9.]*s//' | tail -20
+uv run vip verify --config /tmp/vip-demo.toml --no-auth --categories config-hygiene -- --collect-only -q 2>&1 \
+    | grep -E 'Function test_no_plaintext_secrets|Package config_hygiene' | sed 's/^ *//'
 ```
 
 ```output
-============================= test session starts ==============================
-collected 100 items / 99 deselected / 1 skipped / 1 selected
-
-<Dir vip>
-  <Dir src>
-    <Package vip_tests>
-      <Package config_hygiene>
-        <Module test_secrets.py>
-          <Function test_no_plaintext_secrets>
-
-================ 1/100 tests collected (99 deselected) ================
+<Package config_hygiene>
+<Function test_no_plaintext_secrets>
 ```
 
 ## Selftests pass

--- a/validation_docs/demo-fix-issue-182.md
+++ b/validation_docs/demo-fix-issue-182.md
@@ -110,7 +110,7 @@ uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed -E 's/ in
 ```
 
 ```output
-249 passed
+251 passed
 ```
 
 ## Lint and format checks

--- a/validation_docs/demo-fix-issue-182.md
+++ b/validation_docs/demo-fix-issue-182.md
@@ -1,0 +1,139 @@
+# Fix: separate config hygiene tests from product verification (#182)
+
+*2026-04-18T01:37:25Z by Showboat 0.6.1*
+<!-- showboat-id: 2f3d999e-5a04-48f3-92f3-dafbd875fa47 -->
+
+Issue #182 reported that `test_no_plaintext_secrets` and `test_api_key_from_env` are self-tests of VIP's own configuration hygiene, not tests of the Posit product deployment. Mixing them into `vip verify` output confuses users.
+
+This change:
+- Moves those tests to a new `config_hygiene` category under `src/vip_tests/config_hygiene/`.
+- Registers the `config_hygiene` marker in the plugin and `pyproject.toml`.
+- Excludes `config_hygiene` from the default `vip verify` marker expression (opt-in via `--categories config-hygiene`).
+- Applies the same default exclusion in the K8s Job path.
+- Adds a `headless_auth` session fixture alongside the existing `interactive_auth` fixture.
+- Leaves `test_api_key_from_env` skipping for both interactive and headless auth (the existing `interactive_auth` fixture already covered both, but the skip message is now clearer).
+
+## Before
+
+Previously, `vip verify` against a Posit Team deployment surfaced two
+config hygiene failures that flagged the user's `vip.toml` rather than
+anything about the deployment:
+
+> `test_no_plaintext_secrets`: Plaintext secrets found in config file:
+> `['api_key']`. Use environment variables instead.
+>
+> `test_api_key_from_env`: `VIP_CONNECT_API_KEY` environment variable is
+> not set. Secrets should be provided via environment variables, not the
+> config file.
+
+These tests lived under the `security` category (auto-run by default).
+
+## After
+
+The tests live under a new `config_hygiene` category that is excluded from
+default `vip verify` runs. Users opt in with `--categories config-hygiene`
+when they want to audit their VIP configuration.
+
+## New layout
+
+```bash
+ls src/vip_tests/config_hygiene/ | grep -v __pycache__
+```
+
+```output
+__init__.py
+conftest.py
+test_secrets.feature
+test_secrets.py
+```
+
+```bash
+grep -H "^@" src/vip_tests/config_hygiene/test_secrets.feature
+```
+
+```output
+src/vip_tests/config_hygiene/test_secrets.feature:@config_hygiene
+```
+
+## Default `vip verify` excludes config_hygiene
+
+Set up a minimal vip.toml for the demo:
+
+```bash
+uv run vip verify --config /tmp/vip-demo.toml --no-auth -- --collect-only -q 2>&1 | grep -v 'Note:' | sed 's/ in [0-9.]*s//' | tail -20
+```
+
+```output
+<Dir vip>
+  <Dir src>
+    <Package vip_tests>
+      <Package connect>
+        <Module test_data_sources.py>
+          <Function test_connectivity>
+      <Package cross_product>
+        <Module test_monitoring.py>
+          <Function test_monitoring_configured>
+        <Module test_resources.py>
+          <Function test_product_health>
+      <Package performance>
+        <Module test_resource_usage.py>
+          <Function test_response_time_under_load>
+          <Function test_prometheus_metrics>
+      <Package security>
+        <Module test_auth_policy.py>
+          <Function test_auth_provider>
+
+================ 6/100 tests collected (94 deselected) ================
+```
+
+Note that no `config_hygiene` tests were collected.
+
+## Opt in with `--categories config-hygiene`
+
+```bash
+uv run vip verify --config /tmp/vip-demo.toml --no-auth --categories config-hygiene -- --collect-only -q 2>&1 | grep -v 'Note:' | sed 's/ in [0-9.]*s//' | tail -20
+```
+
+```output
+============================= test session starts ==============================
+collected 100 items / 99 deselected / 1 skipped / 1 selected
+
+<Dir vip>
+  <Dir src>
+    <Package vip_tests>
+      <Package config_hygiene>
+        <Module test_secrets.py>
+          <Function test_no_plaintext_secrets>
+
+================ 1/100 tests collected (99 deselected) ================
+```
+
+## Selftests pass
+
+243 existing tests plus 6 new tests covering the new behavior (default exclusion, explicit opt-in, normalizer accepting `config-hygiene`, `_default_marker_expr`, `headless_auth` fixture):
+
+```bash
+uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+249 passed, 5 warnings
+```
+
+## Lint and format checks
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+```
+
+```bash
+uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+101 files already formatted
+```


### PR DESCRIPTION
Fixes #182.

## Summary

- Moves `test_no_plaintext_secrets` and `test_api_key_from_env` from `src/vip_tests/security/` to a new `src/vip_tests/config_hygiene/` directory with the `@config_hygiene` tag. These are self-tests of VIP's own configuration, not product verification tests.
- Registers the `config_hygiene` marker in `src/vip/plugin.py` and `pyproject.toml`.
- `vip verify` excludes `config_hygiene` from its default marker expression (in both local and K8s Job paths). Users opt in with `--categories config-hygiene`.
- Adds `config-hygiene`/`config_hygiene` to `VALID_CATEGORIES` so the CLI accepts both spellings.
- Adds a `headless_auth` session fixture alongside `interactive_auth` for finer-grained detection of which auth flow was used.
- `test_api_key_from_env` already skipped under `--interactive-auth` (since the fixture returned True for both interactive and headless). The skip message is now clearer about why the env var workflow doesn't apply.

## Test plan

- [x] `uv run pytest selftests/ -v` (249 passed — 6 new tests)
- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run vip verify --config ... -- --collect-only` shows no `config_hygiene` tests by default
- [x] `uv run vip verify --categories config-hygiene -- --collect-only` collects only `config_hygiene` tests
- [x] `uv run pytest src/vip_tests/ --collect-only` (CI dry run)
- [x] `uvx showboat verify validation_docs/demo-fix-issue-182.md`

## Demo

See `validation_docs/demo-fix-issue-182.md`.
