### PR TITLE
ci(report): prevent Quarto render from hanging in example report job

### DIFF
--- a/.github/workflows/example-report.yml
+++ b/.github/workflows/example-report.yml
@@ -209,7 +209,7 @@ jobs:
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          cache: true
+          version: 1.9.37
 
       # Generate vip.toml from with-connect and PM outputs
       - name: Configure VIP for CI
@@ -278,7 +278,10 @@ jobs:
           || true
 
       - name: Render Quarto report
-        run: cd report && uv run quarto render
+        timeout-minutes: 10
+        env:
+          QUARTO_JUPYTER_FLUSH_LOGS: "true"
+        run: cd report && uv run quarto render --no-execute-daemon
 
       # Stop Connect
       - name: Stop Connect

--- a/report/_quarto.yml
+++ b/report/_quarto.yml
@@ -11,6 +11,12 @@ website:
       - href: details.qmd
         text: Detailed Results
 
+# Disable the Jupyter kernel daemon so `quarto render` exits cleanly after
+# the last document. The daemon is a known source of CI hangs — it keeps a
+# kernel alive between renders, but in one-shot CI runs it can block exit.
+execute:
+  daemon: false
+
 format:
   html:
     theme: cosmo


### PR DESCRIPTION
## Summary

The `Render Quarto report` step in the example-report workflow (used by `website.yml`, `preview.yml`, and `website-preview.yml`) regularly hangs in CI. Investigation pointed at three contributing factors:

1. **Jupyter kernel daemon keeps the process alive.** Both `report/index.qmd` and `report/details.qmd` declare `jupyter: python3`. By default Quarto keeps a persistent kernel daemon alive for each document so subsequent renders can reuse it. In a CI job that renders once and exits, that daemon can block the `quarto render` process from exiting even though every document has already rendered. This is documented in [quarto-cli#2676](https://github.com/quarto-dev/quarto-cli/issues/2676) and [quarto-cli#7291](https://github.com/quarto-dev/quarto-cli/issues/7291).
2. **No version pin on Quarto.** The workflow uses `quarto-dev/quarto-actions/setup@v2` with no `version:` input, so every run picks up whatever the latest release is. That makes the render's kernel-exit behavior non-deterministic across PRs — a green run today can hang tomorrow. Pinning to the current stable release (1.9.37) removes that class of drift.
3. **Invalid `cache: true` input.** The `quarto-actions/setup@v2` action only accepts `version` and `tinytex` — `cache` is silently ignored. It is harmless but misleading.

## Changes

- Pin Quarto to `1.9.37` (the current latest stable; see [Quarto releases](https://github.com/quarto-dev/quarto-cli/releases/)).
- Add `execute.daemon: false` to `report/_quarto.yml` and pass `--no-execute-daemon` on the CLI so each render exits cleanly after the last document.
- Set `QUARTO_JUPYTER_FLUSH_LOGS=true` so any remaining kernel issue shows up in the log instead of looking silent.
- Add `timeout-minutes: 10` to the render step so a hang fails the job fast instead of burning the default 6-hour job timeout.
- Drop the invalid `cache: true` input from the setup step.

## Why not upgrade to Quarto 1.10?

1.10 is still pre-release. Pinning to the latest stable (1.9.37) gives us deterministic CI without opting into a pre-release line.

## Test plan

- [ ] CI (`Report Preview` / `Website Preview` / `Deploy Website to GitHub Pages`) renders the example report without hanging.
- [ ] The rendered report in `report/_output/` still contains `index.html` and `details.html` with the same content as before.
- [ ] If a future regression re-introduces a hang, the job now fails within 10 minutes with a clear log instead of running for hours.

https://claude.ai/code/session_01VuVirvbYVnZjbmrvPjsJpN