### PR TITLE
fix(connect): correct rmd, jupyter, and shiny content bundles

### DIFF
--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -463,10 +463,10 @@ _EXPECTED_OUTPUT: dict[str, dict] = {
     },
     # Shiny apps serve an HTML page that contains the app's rendered content.
     # "shiny" is a framework marker present in the framework-injected <script>
-    # tags.  "vip test" appears in the page title/chrome (Connect uses the app
-    # name as the page title) and also as the text node rendered by
-    # `fluidPage("vip test")`.  Note: this is a chrome-level check — a
-    # failed render that still produces Shiny scaffolding would pass.
+    # tags.  "vip test" matches the text node rendered by
+    # `fluidPage("VIP test")` (checked case-insensitively).  Note: this is a
+    # chrome-level check — a failed render that still produces Shiny
+    # scaffolding would pass because "shiny" appears in error-page JS too.
     "vip-shiny-test": {
         "type": "html",
         "markers": ["shiny", "vip test"],

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -179,6 +179,8 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
         # (``rmarkdown``, ``knitr``) in the same shape used by Connect's
         # publishing clients.  See shiny_manifest.json for the reference
         # schema.
+        # Versions below are placeholders that satisfy packrat's column-shape
+        # requirement; they do not need to match what is installed on the server.
         rmd_packages = {
             "rmarkdown": {
                 "Source": "CRAN",
@@ -260,7 +262,9 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
         requirements_content = ""
 
         def _md5(text: str) -> str:
-            return hashlib.md5(text.encode("utf-8")).hexdigest()
+            # usedforsecurity=False: this is a non-cryptographic content checksum
+            # consumed by Connect; needed for FIPS-enabled runners.
+            return hashlib.md5(text.encode("utf-8"), usedforsecurity=False).hexdigest()
 
         return {
             "notebook.ipynb": notebook_content,

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -270,11 +270,12 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
                 ],
             }
         )
-        # Connect's jupyter-static renderer uses ``entrypoint`` (and a ``files``
-        # block listing every bundled file with an MD5 checksum) to find the
-        # notebook to pass to ``nbconvert``.  ``primary_document`` alone is
-        # insufficient: if ``files`` is missing or ``entrypoint`` is unset,
-        # nbconvert is invoked with an empty filename argument.
+        # Connect's jupyter-static renderer uses ``entrypoint`` and a ``files``
+        # block listing the bundled content files (notebook, requirements) each
+        # keyed by path with an MD5 checksum.  ``manifest.json`` itself is not
+        # listed in ``files``.  ``primary_document`` alone is insufficient: if
+        # ``files`` is missing or ``entrypoint`` is unset, nbconvert is invoked
+        # with an empty filename argument.
         requirements_content = ""
         return {
             "notebook.ipynb": notebook_content,
@@ -462,9 +463,11 @@ _EXPECTED_OUTPUT: dict[str, dict] = {
         "value": "VIP test OK",
     },
     # Shiny apps serve an HTML page that contains the app's rendered content.
+    # The test app renders `fluidPage("VIP test")` (capital letters).
     # "shiny" is a framework marker present in the framework-injected <script>
-    # tags.  "vip test" matches the text node rendered by
-    # `fluidPage("VIP test")` (checked case-insensitively).  Note: this is a
+    # tags.  "vip test" matches the rendered text node because the marker
+    # check lowercases the response body before comparing, so the lowercase
+    # marker matches the mixed-case rendered output.  Note: this is a
     # chrome-level check — a failed render that still produces Shiny
     # scaffolding would pass because "shiny" appears in error-page JS too.
     "vip-shiny-test": {

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -7,6 +7,7 @@ easy identification and cleanup.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import pathlib
 
@@ -170,6 +171,34 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
         r_versions = connect_client.r_versions()
         if not r_versions:
             pytest.skip("No R versions available on Connect — cannot deploy R Markdown")
+        # Connect's R-side pipeline calls ``packrat`` on the manifest's
+        # ``packages`` block; an empty dict triggers
+        # ``[.data.frame(lockInfo, , "Package") : undefined columns selected``
+        # because the expected ``Package`` column is missing.  We must
+        # populate ``packages`` with at least the packages this Rmd needs
+        # (``rmarkdown``, ``knitr``) in the same shape used by Connect's
+        # publishing clients.  See shiny_manifest.json for the reference
+        # schema.
+        rmd_packages = {
+            "rmarkdown": {
+                "Source": "CRAN",
+                "Repository": "https://cloud.r-project.org",
+                "description": {
+                    "Package": "rmarkdown",
+                    "Version": "2.25",
+                    "Imports": "knitr",
+                },
+            },
+            "knitr": {
+                "Source": "CRAN",
+                "Repository": "https://cloud.r-project.org",
+                "description": {
+                    "Package": "knitr",
+                    "Version": "1.45",
+                    "Imports": "",
+                },
+            },
+        }
         return {
             "index.Rmd": (
                 "---\ntitle: VIP RMarkdown Test\noutput: html_document\n---\n\n"
@@ -185,7 +214,7 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
                         "content_category": "",
                         "has_parameters": False,
                     },
-                    "packages": {},
+                    "packages": rmd_packages,
                 }
             ),
         }
@@ -223,6 +252,16 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
                 ],
             }
         )
+        # Connect's jupyter-static renderer uses ``entrypoint`` (and a ``files``
+        # block listing every bundled file with an MD5 checksum) to find the
+        # notebook to pass to ``nbconvert``.  ``primary_document`` alone is
+        # insufficient: if ``files`` is missing or ``entrypoint`` is unset,
+        # nbconvert is invoked with an empty filename argument.
+        requirements_content = ""
+
+        def _md5(text: str) -> str:
+            return hashlib.md5(text.encode("utf-8")).hexdigest()
+
         return {
             "notebook.ipynb": notebook_content,
             "manifest.json": json.dumps(
@@ -230,6 +269,7 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
                     "version": 1,
                     "metadata": {
                         "appmode": "jupyter-static",
+                        "entrypoint": "notebook.ipynb",
                         "primary_document": "notebook.ipynb",
                         "content_category": "",
                         "has_parameters": False,
@@ -242,9 +282,13 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
                             "package_file": "requirements.txt",
                         },
                     },
+                    "files": {
+                        "notebook.ipynb": {"checksum": _md5(notebook_content)},
+                        "requirements.txt": {"checksum": _md5(requirements_content)},
+                    },
                 }
             ),
-            "requirements.txt": "",
+            "requirements.txt": requirements_content,
         }
 
     if name == "vip-fastapi-test":
@@ -403,10 +447,13 @@ _EXPECTED_OUTPUT: dict[str, dict] = {
         "key": "message",
         "value": "VIP test OK",
     },
-    # Shiny apps serve an HTML page with Shiny bootstrap markup.
+    # Shiny apps serve an HTML page that contains the app's rendered content.
+    # The test app renders `fluidPage("vip test")`, so the text "vip test"
+    # appears inside the HTML.  We also check for "shiny" as a framework
+    # marker (present in the framework-injected <script> tags).
     "vip-shiny-test": {
         "type": "html",
-        "markers": ["shiny", "bootstraplib"],
+        "markers": ["shiny", "vip test"],
     },
     # Dash apps serve an HTML page with Dash-specific markup.
     "vip-dash-test": {

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -24,6 +24,15 @@ _GIT_BRANCH = "main"
 _GIT_DIRECTORY = "extensions/quarto-document"
 
 
+def _md5(text: str) -> str:
+    """Return the MD5 hex digest of *text*.
+
+    ``usedforsecurity=False`` is required on FIPS-enabled runners; this is a
+    non-cryptographic content checksum consumed by Connect's manifest schema.
+    """
+    return hashlib.md5(text.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+
 @scenario("test_content_deploy.feature", "Deploy and execute a Quarto document")
 def test_deploy_quarto():
     pass
@@ -181,6 +190,8 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
         # schema.
         # Versions below are placeholders that satisfy packrat's column-shape
         # requirement; they do not need to match what is installed on the server.
+        # TODO: if Connect starts validating additional fields (Hash, Requirements)
+        # from newer packrat/renv lockfile schemas, expand these entries accordingly.
         rmd_packages = {
             "rmarkdown": {
                 "Source": "CRAN",
@@ -201,22 +212,27 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
                 },
             },
         }
+        rmd_content = (
+            "---\ntitle: VIP RMarkdown Test\noutput: html_document\n---\n\n"
+            "Hello from VIP RMarkdown.\n"
+        )
         return {
-            "index.Rmd": (
-                "---\ntitle: VIP RMarkdown Test\noutput: html_document\n---\n\n"
-                "Hello from VIP RMarkdown.\n"
-            ),
+            "index.Rmd": rmd_content,
             "manifest.json": json.dumps(
                 {
                     "version": 1,
                     "platform": r_versions[0],
                     "metadata": {
                         "appmode": "rmd-static",
+                        "entrypoint": "index.Rmd",
                         "primary_rmd": "index.Rmd",
                         "content_category": "",
                         "has_parameters": False,
                     },
                     "packages": rmd_packages,
+                    "files": {
+                        "index.Rmd": {"checksum": _md5(rmd_content)},
+                    },
                 }
             ),
         }
@@ -260,12 +276,6 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
         # insufficient: if ``files`` is missing or ``entrypoint`` is unset,
         # nbconvert is invoked with an empty filename argument.
         requirements_content = ""
-
-        def _md5(text: str) -> str:
-            # usedforsecurity=False: this is a non-cryptographic content checksum
-            # consumed by Connect; needed for FIPS-enabled runners.
-            return hashlib.md5(text.encode("utf-8"), usedforsecurity=False).hexdigest()
-
         return {
             "notebook.ipynb": notebook_content,
             "manifest.json": json.dumps(
@@ -452,9 +462,11 @@ _EXPECTED_OUTPUT: dict[str, dict] = {
         "value": "VIP test OK",
     },
     # Shiny apps serve an HTML page that contains the app's rendered content.
-    # The test app renders `fluidPage("vip test")`, so the text "vip test"
-    # appears inside the HTML.  We also check for "shiny" as a framework
-    # marker (present in the framework-injected <script> tags).
+    # "shiny" is a framework marker present in the framework-injected <script>
+    # tags.  "vip test" appears in the page title/chrome (Connect uses the app
+    # name as the page title) and also as the text node rendered by
+    # `fluidPage("vip test")`.  Note: this is a chrome-level check — a
+    # failed render that still produces Shiny scaffolding would pass.
     "vip-shiny-test": {
         "type": "html",
         "markers": ["shiny", "vip test"],


### PR DESCRIPTION
## Summary

Three content-deploy test bugs, all in `src/vip_tests/connect/test_content_deploy.py`:

- **#181** — The R Markdown manifest had `"packages": {}`, which triggered `[.data.frame(lockInfo, , "Package") : undefined columns selected` in Connect's packrat parser. Now populated with `rmarkdown` and `knitr` entries in the same schema used by `shiny_manifest.json`.
- **#180** — The Jupyter `jupyter-static` manifest set `primary_document` but omitted `entrypoint` and a top-level `files` block, causing `nbconvert` to be invoked with an empty filename argument. Now sets `entrypoint` and emits a `files` block with MD5 checksums for every bundled file.
- **#179** — The Shiny content-type marker `"bootstraplib"` never appears in actual Shiny HTML output. Replaced with `"vip test"` (the text the app renders) plus the existing `"shiny"` framework marker.

## Test plan

- [x] Ruff: `just check` passes
- [x] Selftests: `uv run pytest selftests/` passes (303/303 locally; `test_1k_users` is a known sandbox flake that passes on rerun)
- [x] Product tests against ganso01-staging Connect (`https://pub.ganso.lab.staging.posit.team`):
  - [x] `test_deploy_shiny` — deploy completed in 643s, response body contained both `"shiny"` and `"vip test"` markers, test PASSED
  - [x] `test_deploy_jupyter` — deploy completed in 67s, Connect produced `notebook.html` at the content URL, proving `nbconvert` received the filename (the #180 bug). Verification step then fails on a pre-existing orthogonal bug in `fetch_content` handling relative `Location` redirects — filed as #213
  - [x] `test_deploy_rmarkdown` — packrat now parses the manifest without the `[.data.frame(lockInfo, , "Package") : undefined columns selected` error; the original #181 bug is fixed. Deploy still fails on a separate downstream issue (Rmd manifest is missing `knitr`'s transitive deps `evaluate`, `highr`, `xfun`, `yaml`) — filed as #214

Fixes #181
Fixes #180
Fixes #179