### PR TITLE
fix(workbench): skip IDE tests gracefully when IDE is unavailable

### DIFF
--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -157,9 +157,24 @@ def _start_session(page: Page, ide_type: str, session_name: str):
     ide_display = NewSessionDialog.ide_display_name(ide_type)
     ide_tab = dialog.get_by_role("tab", name=ide_display)
     if ide_tab.count() == 0:
-        page.locator(NewSessionDialog.CANCEL_BUTTON).click()
-        pytest.skip(f"{ide_type} IDE not available in this Workbench deployment")
+        _dismiss_dialog_and_skip(page, f"{ide_type} IDE not available in this Workbench deployment")
     ide_tab.click(timeout=TIMEOUT_QUICK)
+
+    # After selecting the IDE tab, the Launch button should become available
+    # within a couple of seconds.  If it doesn't, the tab is present but the
+    # IDE is not actually installed/functional on this Workbench instance
+    # (the dialog shows an error state without a Launch button).  Skip
+    # gracefully instead of letting the subsequent Launch click time out
+    # for 30s on #modalCancelBtn.
+    launch_btn = page.locator(NewSessionDialog.LAUNCH_BUTTON)
+    try:
+        launch_btn.wait_for(state="visible", timeout=TIMEOUT_QUICK)
+    except PlaywrightTimeoutError:
+        _dismiss_dialog_and_skip(
+            page,
+            f"{ide_type} tab opened but Launch button did not appear — "
+            f"the IDE may not be installed or fully available on this Workbench instance",
+        )
 
     page.fill(NewSessionDialog.SESSION_NAME, session_name)
 
@@ -169,7 +184,23 @@ def _start_session(page: Page, ide_type: str, session_name: str):
         checkbox.click()
     expect(checkbox).not_to_be_checked(timeout=TIMEOUT_QUICK)
 
-    page.locator(NewSessionDialog.LAUNCH_BUTTON).click(timeout=TIMEOUT_QUICK)
+    launch_btn.click(timeout=TIMEOUT_QUICK)
+
+
+def _dismiss_dialog_and_skip(page: Page, reason: str) -> None:
+    """Best-effort cancel of the New Session dialog, then ``pytest.skip``.
+
+    Uses a short timeout on the cancel click so a missing or unreachable
+    cancel button does not mask the real skip reason with a 30-second
+    Playwright default-timeout error on ``#modalCancelBtn``.
+    """
+    cancel = page.locator(NewSessionDialog.CANCEL_BUTTON)
+    if cancel.count() > 0:
+        try:
+            cancel.click(timeout=TIMEOUT_QUICK)
+        except PlaywrightTimeoutError:
+            pass
+    pytest.skip(reason)
 
 
 @then("the session transitions to Active state")
@@ -325,10 +356,12 @@ def positron_console_accessible(page: Page):
 
     Positron (VS Code-based) exposes a dedicated console pane.  We assert it
     is visible, confirming the runtime connection is established without
-    requiring a full code-execution round-trip.
+    requiring a full code-execution round-trip.  If the console panel
+    selector never appears, this may be an older Positron version or the
+    DOM structure may have changed — skip rather than hard-fail, matching
+    the ``_expect_ide_or_skip`` pattern used for the IDE workbench itself.
     """
-    console_panel = page.locator(PositronSession.CONSOLE_PANEL)
-    expect(console_panel).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
+    _expect_ide_or_skip(page, PositronSession.CONSOLE_PANEL, "Positron console")
 
 
 @then("the session is cleaned up")

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -187,7 +188,7 @@ def _start_session(page: Page, ide_type: str, session_name: str):
     launch_btn.click(timeout=TIMEOUT_QUICK)
 
 
-def _dismiss_dialog_and_skip(page: Page, reason: str) -> None:
+def _dismiss_dialog_and_skip(page: Page, reason: str) -> NoReturn:
     """Best-effort cancel of the New Session dialog, then ``pytest.skip``.
 
     Uses a short timeout on the cancel click so a missing or unreachable
@@ -360,6 +361,12 @@ def positron_console_accessible(page: Page):
     selector never appears, this may be an older Positron version or the
     DOM structure may have changed — skip rather than hard-fail, matching
     the ``_expect_ide_or_skip`` pattern used for the IDE workbench itself.
+
+    The timeout used here is ``TIMEOUT_IDE_LOAD`` (60 s), which is longer than
+    the previous ``TIMEOUT_CODE_EXEC`` (30 s) used before this step delegated
+    to ``_expect_ide_or_skip``.  The extra headroom is intentional: the console
+    panel appearing confirms the runtime is live, so a generous wait is
+    preferable to a false skip on slow deployments.
     """
     _expect_ide_or_skip(page, PositronSession.CONSOLE_PANEL, "Positron console")
 

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import NoReturn
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page, expect
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from pytest_bdd import given, scenario, then, when
@@ -194,13 +195,20 @@ def _dismiss_dialog_and_skip(page: Page, reason: str) -> NoReturn:
     Uses a short timeout on the cancel click so a missing or unreachable
     cancel button does not mask the real skip reason with a 30-second
     Playwright default-timeout error on ``#modalCancelBtn``.
+
+    Catches both ``PlaywrightTimeoutError`` and the base ``PlaywrightError``
+    (raised for detached/covered elements and other non-actionable states) so
+    that dialog-dismiss failures never mask the intended skip.
     """
-    cancel = page.locator(NewSessionDialog.CANCEL_BUTTON)
-    if cancel.count() > 0:
-        try:
-            cancel.click(timeout=TIMEOUT_QUICK)
-        except PlaywrightTimeoutError:
-            pass
+    try:
+        cancel = page.locator(NewSessionDialog.CANCEL_BUTTON)
+        if cancel.count() > 0:
+            try:
+                cancel.click(timeout=TIMEOUT_QUICK)
+            except (PlaywrightTimeoutError, PlaywrightError):
+                pass
+    except (PlaywrightTimeoutError, PlaywrightError):
+        pass
     pytest.skip(reason)
 
 
@@ -231,20 +239,43 @@ def rstudio_functional(page: Page):
     expect(page.locator(RStudioSession.PROJECT_MENU)).to_be_visible(timeout=TIMEOUT_DIALOG)
 
 
-def _expect_ide_or_skip(page: Page, locator_str: str, ide_name: str) -> None:
+def _expect_ide_or_skip(
+    page: Page,
+    locator_str: str,
+    ide_name: str,
+    *,
+    timeout: int | None = None,
+    skip_reason: str | None = None,
+) -> None:
     """Wait for the primary IDE element; skip if it times out (IDE may not be installed).
 
     Uses ``Locator.wait_for(state="visible")`` which raises a Playwright
     ``TimeoutError`` on timeout — a stable, typed distinction from other
     assertion failures.  Any other exception propagates normally.
+
+    Args:
+        page: The Playwright page object.
+        locator_str: CSS/XPath selector for the element to wait for.
+        ide_name: Human-readable IDE name used in the default skip message.
+        timeout: Wait timeout in milliseconds.  Defaults to ``TIMEOUT_IDE_LOAD``
+            (60 s) when not specified.
+        skip_reason: Custom skip message.  When omitted the default message
+            ``"{ide_name} did not load within timeout — ..."`` is used.
+            The string may contain ``{exc}`` which will be substituted with the
+            caught ``PlaywrightTimeoutError`` instance.
     """
+    effective_timeout = TIMEOUT_IDE_LOAD if timeout is None else timeout
     try:
-        page.locator(locator_str).wait_for(state="visible", timeout=TIMEOUT_IDE_LOAD)
+        page.locator(locator_str).wait_for(state="visible", timeout=effective_timeout)
     except PlaywrightTimeoutError as exc:
-        pytest.skip(
-            f"{ide_name} did not load within timeout — "
-            f"the IDE may not be installed on this Workbench instance ({exc})"
-        )
+        if skip_reason is None:
+            reason = (
+                f"{ide_name} did not load within timeout — "
+                f"the IDE may not be installed on this Workbench instance ({exc})"
+            )
+        else:
+            reason = skip_reason.format(exc=exc) if "{exc}" in skip_reason else skip_reason
+        pytest.skip(reason)
 
 
 @then("the VS Code IDE is displayed")
@@ -358,17 +389,24 @@ def positron_console_accessible(page: Page):
     Positron (VS Code-based) exposes a dedicated console pane.  We assert it
     is visible, confirming the runtime connection is established without
     requiring a full code-execution round-trip.  If the console panel
-    selector never appears, this may be an older Positron version or the
-    DOM structure may have changed — skip rather than hard-fail, matching
-    the ``_expect_ide_or_skip`` pattern used for the IDE workbench itself.
+    selector never appears, the DOM structure may have changed (e.g. a
+    Positron update) — skip rather than hard-fail.
 
-    The timeout used here is ``TIMEOUT_IDE_LOAD`` (60 s), which is longer than
-    the previous ``TIMEOUT_CODE_EXEC`` (30 s) used before this step delegated
-    to ``_expect_ide_or_skip``.  The extra headroom is intentional: the console
-    panel appearing confirms the runtime is live, so a generous wait is
-    preferable to a false skip on slow deployments.
+    Uses ``TIMEOUT_CODE_EXEC`` (30 s) to match the original intent: the
+    console panel should appear promptly once the IDE has loaded.  A
+    console-specific skip message is used to distinguish this failure from
+    the IDE-not-installed skip emitted by the workbench check.
     """
-    _expect_ide_or_skip(page, PositronSession.CONSOLE_PANEL, "Positron console")
+    _expect_ide_or_skip(
+        page,
+        PositronSession.CONSOLE_PANEL,
+        "Positron console",
+        timeout=TIMEOUT_CODE_EXEC,
+        skip_reason=(
+            "Positron console element not found within timeout — "
+            "selector may have changed or Positron may not be fully available ({exc})"
+        ),
+    )
 
 
 @then("the session is cleaned up")


### PR DESCRIPTION
## Summary

Two IDE-launch tests hard-failed with cryptic Playwright timeouts when the IDE wasn't installed or the DOM selector drifted. Both now convert those cases into a clean `pytest.skip` with a descriptive reason.

- **#186** — `test_launch_jupyter` timed out 30s waiting for `#modalCancelBtn` when Jupyter was not actually available: the tab was present but clicking it showed an error state without a Launch button. Added a short `wait_for(state="visible")` on the Launch button after the tab click; on `PlaywrightTimeoutError` we dismiss the dialog and skip with a clear message. Also hardened the existing "tab absent" branch so a missing cancel button no longer triggers the 30-second default timeout.
- **#187** — `test_launch_positron` hard-failed on `.positron-console` visibility when the selector had drifted or Positron was not available. `positron_console_accessible` now uses the existing `_expect_ide_or_skip` helper (same pattern used for the Positron workbench element).

## Test plan

- [x] Ruff: `just check` passes
- [x] Selftests: `uv run pytest selftests/` passes (303/303 locally)
- [x] Product tests against ganso01-staging Workbench (`https://dev.ganso.lab.staging.posit.team`, OIDC interactive auth):
  - [x] `test_launch_positron` — skipped with my new message and parameterized 30s timeout: _"Positron console element not found within timeout — selector may have changed or Positron may not be fully available (Locator.wait_for: Timeout 30000ms exceeded ... waiting for locator('.positron-console'))"_. Directly validates the `_expect_ide_or_skip` parameterization added in response to Copilot's feedback.
  - [x] `test_launch_jupyter` — skipped via the pre-existing `_expect_ide_or_skip` path on `.jp-Launcher` (Jupyter UI didn't load inside the session). My new "Launch button did not appear" guard was **not** exercised on this Workbench because the Launch button appeared normally; the guard is defensive code for a specific misconfiguration (tab present but no Launch button) that doesn't manifest on ganso01. Selftests + code review cover that path.

Fixes #186
Fixes #187