### PR TITLE
fix(performance): skip on proxy errors and enforce PM token guard

### DIFF
--- a/selftests/test_performance_steps.py
+++ b/selftests/test_performance_steps.py
@@ -53,7 +53,7 @@ class TestLoginLoadTimeSkips:
         assert "proxy refused" in msg
 
     def test_connect_timeout_skips(self, monkeypatch):
-        msg = self._run_measure(monkeypatch, httpx.ConnectTimeout("timed out", request=None))
+        msg = self._run_measure(monkeypatch, httpx.ConnectTimeout("timed out"))
         assert "not reachable from test runner" in msg
 
     def test_connect_error_skips(self, monkeypatch):
@@ -77,9 +77,10 @@ class TestLoginLoadTimeSkips:
 class TestSimulatePmTokenGuard:
     """simulate_pm should skip when package_manager.token is falsy."""
 
-    # Use a user count that is in the default load_user_counts list so the
-    # _check_user_count guard does not fire before the token/URL guard.
-    _VALID_USERS = 10
+    # Derive from config defaults so the tests stay decoupled: if load_user_counts
+    # ever changes, _check_user_count fires with the first valid count rather than
+    # skipping before the token/URL guard and silently regressing coverage.
+    _VALID_USERS = PerformanceConfig().load_user_counts[0]
 
     def _run_simulate_pm(self, token: str, url: str = "http://pm.example.com"):
         """Call simulate_pm with a config built from *token* and *url*."""
@@ -106,7 +107,7 @@ class TestSimulatePmTokenGuard:
         assert "package manager" in msg.lower()
 
     def test_no_url_skips_before_token_check(self):
-        """If the URL is also missing, it should still skip (on URL check)."""
+        """URL guard fires before token guard when both are missing."""
         import vip_tests.performance.test_user_simulation as mod
 
         cfg = _make_config(url="", token="")
@@ -119,5 +120,5 @@ class TestSimulatePmTokenGuard:
                 performance_config=pc,
                 vip_verbose=False,
             )
-        # Either the URL check or the token check fires — both are skips.
-        assert exc_info.value.msg  # just confirm it's a non-empty skip message
+        # simulate_pm checks URL first, so the message should name the URL.
+        assert "url" in exc_info.value.msg.lower()

--- a/selftests/test_performance_steps.py
+++ b/selftests/test_performance_steps.py
@@ -1,0 +1,125 @@
+"""Selftests for performance test step skip-path behavior.
+
+Covers:
+- test_login_load_times: pre-connect errors are converted to pytest.skip
+- test_user_simulation: simulate_pm skips when PM token is missing
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vip.config import PackageManagerConfig, PerformanceConfig, VIPConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**pm_kwargs) -> VIPConfig:
+    """Return a VIPConfig with PackageManagerConfig built from kwargs."""
+    return VIPConfig(package_manager=PackageManagerConfig(**pm_kwargs))
+
+
+# ---------------------------------------------------------------------------
+# test_login_load_times: pre-connect skip path
+# ---------------------------------------------------------------------------
+
+
+class TestLoginLoadTimeSkips:
+    """measure_load_time should skip (not fail) on pre-connect transport errors."""
+
+    def _run_measure(self, monkeypatch, exc, product="Connect"):
+        """Invoke measure_load_time with httpx.get patched to raise *exc*."""
+        import vip_tests.performance.test_login_load_times as mod
+
+        monkeypatch.setattr(
+            "vip_tests.performance.test_login_load_times.httpx.get",
+            lambda *_a, **_kw: (_ for _ in ()).throw(exc),
+        )
+        pc = PerformanceConfig()
+        cfg = VIPConfig()
+        # product_config("connect") returns cfg.connect which has url="" by
+        # default, so set it to something non-empty so is_configured is True.
+        cfg.connect.url = "http://connect.example.com"
+        cfg.connect.enabled = True
+
+        with pytest.raises(pytest.skip.Exception) as exc_info:
+            mod.measure_load_time(product, cfg, pc)
+        return exc_info.value.msg
+
+    def test_proxy_error_skips(self, monkeypatch):
+        msg = self._run_measure(monkeypatch, httpx.ProxyError("proxy refused"))
+        assert "not reachable from test runner" in msg
+        assert "proxy refused" in msg
+
+    def test_connect_timeout_skips(self, monkeypatch):
+        msg = self._run_measure(monkeypatch, httpx.ConnectTimeout("timed out", request=None))
+        assert "not reachable from test runner" in msg
+
+    def test_connect_error_skips(self, monkeypatch):
+        msg = self._run_measure(monkeypatch, httpx.ConnectError("connection refused"))
+        assert "not reachable from test runner" in msg
+
+    def test_skip_message_contains_url(self, monkeypatch):
+        msg = self._run_measure(monkeypatch, httpx.ProxyError("proxy refused"))
+        assert "http://connect.example.com" in msg
+
+    def test_skip_message_mentions_network_path(self, monkeypatch):
+        msg = self._run_measure(monkeypatch, httpx.ProxyError("proxy refused"))
+        assert "network path" in msg.lower() or "proxy" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# test_user_simulation: simulate_pm token guard
+# ---------------------------------------------------------------------------
+
+
+class TestSimulatePmTokenGuard:
+    """simulate_pm should skip when package_manager.token is falsy."""
+
+    # Use a user count that is in the default load_user_counts list so the
+    # _check_user_count guard does not fire before the token/URL guard.
+    _VALID_USERS = 10
+
+    def _run_simulate_pm(self, monkeypatch, token: str, url: str = "http://pm.example.com"):
+        """Call simulate_pm with a config built from *token* and *url*."""
+        import vip_tests.performance.test_user_simulation as mod
+
+        cfg = _make_config(url=url, token=token)
+        pc = PerformanceConfig()
+
+        with pytest.raises(pytest.skip.Exception) as exc_info:
+            mod.simulate_pm(
+                users=self._VALID_USERS,
+                vip_config=cfg,
+                performance_config=pc,
+                vip_verbose=False,
+            )
+        return exc_info.value.msg
+
+    def test_empty_token_skips(self, monkeypatch):
+        msg = self._run_simulate_pm(monkeypatch, token="")
+        assert "token" in msg.lower()
+
+    def test_skip_message_mentions_package_manager(self, monkeypatch):
+        msg = self._run_simulate_pm(monkeypatch, token="")
+        assert "package manager" in msg.lower()
+
+    def test_no_url_skips_before_token_check(self, monkeypatch):
+        """If the URL is also missing, it should still skip (on URL check)."""
+        import vip_tests.performance.test_user_simulation as mod
+
+        cfg = _make_config(url="", token="")
+        pc = PerformanceConfig()
+
+        with pytest.raises(pytest.skip.Exception) as exc_info:
+            mod.simulate_pm(
+                users=self._VALID_USERS,
+                vip_config=cfg,
+                performance_config=pc,
+                vip_verbose=False,
+            )
+        # Either the URL check or the token check fires — both are skips.
+        assert exc_info.value.msg  # just confirm it's a non-empty skip message

--- a/selftests/test_performance_steps.py
+++ b/selftests/test_performance_steps.py
@@ -34,16 +34,14 @@ class TestLoginLoadTimeSkips:
         """Invoke measure_load_time with httpx.get patched to raise *exc*."""
         import vip_tests.performance.test_login_load_times as mod
 
-        monkeypatch.setattr(
-            "vip_tests.performance.test_login_load_times.httpx.get",
-            lambda *_a, **_kw: (_ for _ in ()).throw(exc),
-        )
+        def _raise(*_a, **_kw):
+            raise exc
+
+        monkeypatch.setattr("vip_tests.performance.test_login_load_times.httpx.get", _raise)
         pc = PerformanceConfig()
         cfg = VIPConfig()
-        # product_config("connect") returns cfg.connect which has url="" by
-        # default, so set it to something non-empty so is_configured is True.
+        # Set a non-empty URL so is_configured is True (enabled defaults to True).
         cfg.connect.url = "http://connect.example.com"
-        cfg.connect.enabled = True
 
         with pytest.raises(pytest.skip.Exception) as exc_info:
             mod.measure_load_time(product, cfg, pc)
@@ -83,7 +81,7 @@ class TestSimulatePmTokenGuard:
     # _check_user_count guard does not fire before the token/URL guard.
     _VALID_USERS = 10
 
-    def _run_simulate_pm(self, monkeypatch, token: str, url: str = "http://pm.example.com"):
+    def _run_simulate_pm(self, token: str, url: str = "http://pm.example.com"):
         """Call simulate_pm with a config built from *token* and *url*."""
         import vip_tests.performance.test_user_simulation as mod
 
@@ -99,15 +97,15 @@ class TestSimulatePmTokenGuard:
             )
         return exc_info.value.msg
 
-    def test_empty_token_skips(self, monkeypatch):
-        msg = self._run_simulate_pm(monkeypatch, token="")
+    def test_empty_token_skips(self):
+        msg = self._run_simulate_pm(token="")
         assert "token" in msg.lower()
 
-    def test_skip_message_mentions_package_manager(self, monkeypatch):
-        msg = self._run_simulate_pm(monkeypatch, token="")
+    def test_skip_message_mentions_package_manager(self):
+        msg = self._run_simulate_pm(token="")
         assert "package manager" in msg.lower()
 
-    def test_no_url_skips_before_token_check(self, monkeypatch):
+    def test_no_url_skips_before_token_check(self):
         """If the URL is also missing, it should still skip (on URL check)."""
         import vip_tests.performance.test_user_simulation as mod
 

--- a/src/vip_tests/performance/test_login_load_times.py
+++ b/src/vip_tests/performance/test_login_load_times.py
@@ -29,18 +29,23 @@ def measure_load_time(product, vip_config, performance_config):
     if not pc.is_configured:
         pytest.skip(f"{product} is not configured")
     path = _LOGIN_PATHS[product]
+    url = f"{pc.url}{path}"
     try:
         start = time.monotonic()
         resp = httpx.get(
-            f"{pc.url}{path}",
+            url,
             follow_redirects=True,
             timeout=performance_config.page_load_timeout * 3,
         )
         elapsed = time.monotonic() - start
-    except httpx.ConnectError:
-        pytest.fail(
-            f"Could not reach {product} at {pc.url}{path}: connection refused. "
-            "Check firewall rules, proxy configuration, DNS resolution, and port."
+    except (httpx.ConnectError, httpx.ProxyError, httpx.ConnectTimeout) as exc:
+        # Connectivity problem between the test runner and the product URL
+        # (proxy/firewall/DNS/closed port) is not a login-performance
+        # finding — skip with a clear diagnostic instead of failing.
+        pytest.skip(
+            f"{product} login URL not reachable from test runner "
+            f"({url}): {exc}. Check network path, proxy configuration, "
+            "DNS resolution, and that the port is open from the runner."
         )
     resp.raise_for_status()
     return elapsed

--- a/src/vip_tests/performance/test_login_load_times.py
+++ b/src/vip_tests/performance/test_login_load_times.py
@@ -40,8 +40,12 @@ def measure_load_time(product, vip_config, performance_config):
         elapsed = time.monotonic() - start
     except (httpx.ConnectError, httpx.ProxyError, httpx.ConnectTimeout) as exc:
         # Connectivity problem between the test runner and the product URL
-        # (proxy/firewall/DNS/closed port) is not a login-performance
-        # finding — skip with a clear diagnostic instead of failing.
+        # (proxy/firewall/DNS/closed port) is not a login-performance finding.
+        # We catch exactly these three pre-connect failures (not the broader
+        # httpx.TransportError) so that mid-transfer errors like ReadError or
+        # ReadTimeout still surface as hard failures rather than silently skipping.
+        # Reachability itself is already verified by the prerequisites suite
+        # (test_components.py), so a skip here avoids double-reporting.
         pytest.skip(
             f"{product} login URL not reachable from test runner "
             f"({url}): {exc}. Check network path, proxy configuration, "

--- a/src/vip_tests/performance/test_user_simulation.py
+++ b/src/vip_tests/performance/test_user_simulation.py
@@ -81,11 +81,11 @@ def simulate_pm(users, vip_config, performance_config, vip_verbose):
     _check_user_count(users, performance_config)
     if not vip_config.package_manager.url:
         pytest.skip("Package Manager URL is not configured")
-    # Match the token guard in test_load.py so the PM tests behave
-    # symmetrically: both skip when the token is missing rather than one
-    # silently running unauthenticated.  Running load against PM's
-    # authenticated endpoints without a token produces 401s that masquerade
-    # as load-capacity results.
+    # Mirror the identical guard in test_load.py (line 67:
+    # `if not vip_config.package_manager.token`) so both PM test modules
+    # skip when the token is missing rather than one silently running
+    # unauthenticated.  Running load against PM's authenticated endpoints
+    # without a token produces 401s that masquerade as load-capacity results.
     if not vip_config.package_manager.token:
         pytest.skip("Package Manager token is not configured")
     return run_user_simulation(

--- a/src/vip_tests/performance/test_user_simulation.py
+++ b/src/vip_tests/performance/test_user_simulation.py
@@ -81,11 +81,9 @@ def simulate_pm(users, vip_config, performance_config, vip_verbose):
     _check_user_count(users, performance_config)
     if not vip_config.package_manager.url:
         pytest.skip("Package Manager URL is not configured")
-    # Mirror the `if not vip_config.package_manager.token` guard in
-    # test_load.py so both PM test modules skip when the token is missing
-    # rather than one silently running unauthenticated.  Running load against
-    # PM's authenticated endpoints without a token produces 401s that
-    # masquerade as load-capacity results.
+    # Skip when the token is missing: running load against PM's authenticated
+    # endpoints without a token produces 401s that masquerade as load-capacity
+    # results rather than surfacing a configuration error.
     if not vip_config.package_manager.token:
         pytest.skip("Package Manager token is not configured")
     return run_user_simulation(

--- a/src/vip_tests/performance/test_user_simulation.py
+++ b/src/vip_tests/performance/test_user_simulation.py
@@ -81,13 +81,19 @@ def simulate_pm(users, vip_config, performance_config, vip_verbose):
     _check_user_count(users, performance_config)
     if not vip_config.package_manager.url:
         pytest.skip("Package Manager URL is not configured")
-    token = vip_config.package_manager.token or ""
+    # Match the token guard in test_load.py so the PM tests behave
+    # symmetrically: both skip when the token is missing rather than one
+    # silently running unauthenticated.  Running load against PM's
+    # authenticated endpoints without a token produces 401s that masquerade
+    # as load-capacity results.
+    if not vip_config.package_manager.token:
+        pytest.skip("Package Manager token is not configured")
     return run_user_simulation(
         host=vip_config.package_manager.url,
         user_class_name="package_manager",
         users=users,
         config=performance_config,
-        credentials={"token": token},
+        credentials={"token": vip_config.package_manager.token},
         verbose=vip_verbose,
     )
 

--- a/src/vip_tests/performance/test_user_simulation.py
+++ b/src/vip_tests/performance/test_user_simulation.py
@@ -81,11 +81,11 @@ def simulate_pm(users, vip_config, performance_config, vip_verbose):
     _check_user_count(users, performance_config)
     if not vip_config.package_manager.url:
         pytest.skip("Package Manager URL is not configured")
-    # Mirror the identical guard in test_load.py (line 67:
-    # `if not vip_config.package_manager.token`) so both PM test modules
-    # skip when the token is missing rather than one silently running
-    # unauthenticated.  Running load against PM's authenticated endpoints
-    # without a token produces 401s that masquerade as load-capacity results.
+    # Mirror the `if not vip_config.package_manager.token` guard in
+    # test_load.py so both PM test modules skip when the token is missing
+    # rather than one silently running unauthenticated.  Running load against
+    # PM's authenticated endpoints without a token produces 401s that
+    # masquerade as load-capacity results.
     if not vip_config.package_manager.token:
         pytest.skip("Package Manager token is not configured")
     return run_user_simulation(


### PR DESCRIPTION
## Summary

Two performance-test issues — one a real bug (opaque connection failures behind a proxy), one a symmetry fix that makes Package Manager load tests behave consistently.

- **#177** — `test_login_load_times.py` only caught `httpx.ConnectError` and hard-failed with "connection refused" even when the real problem was a proxy/firewall/DNS/closed-port issue between the test runner and the product. Now catches `httpx.ProxyError` and `httpx.ConnectTimeout` too, and converts all three into `pytest.skip` with a clear network-path diagnostic.
- **#174** — `test_load.py` skips Package Manager tests when the PM token is missing; `test_user_simulation.py` silently coerced the missing token to `""` and ran unauthenticated, producing 401s that masqueraded as load-capacity results. Added the same token guard to `test_user_simulation.simulate_pm`. The two tests measure different things (burst concurrency vs. session-simulation traffic) and are complementary — they now skip symmetrically when the token is missing.

## Test plan

- [x] Ruff: `just check` passes
- [x] Selftests: `uv run pytest selftests/` passes (311/311; includes 8 new tests added during review cycles for the skip paths)
- [x] Product tests:
  - [x] `test_login_load_times` — with an unreachable URL (`https://this-does-not-resolve-abc-xyz-9999.internal.invalid`) the test skips with my new diagnostic: _"Connect login URL not reachable from test runner (...): [Errno 8] nodename nor servname provided, or not known. Check network path, proxy configuration, DNS resolution, and that the port is open from the runner."_
  - [x] `test_user_simulation` — PM step skipped with _"Skipped: Package Manager token is not configured"_ when `package_manager.token` is unset (matching the pre-existing guard in `test_load.py`)

Fixes #177
Fixes #174