### PR TITLE
fix(security): skip with clear diagnostic on TLS cert verify failure

### DIFF
--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ssl
+
 import httpx
 import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
@@ -70,7 +72,28 @@ def inspect_headers(product, vip_config):
         pytest.skip(f"{product} is not configured")
     try:
         resp = httpx.get(pc.url, follow_redirects=True, timeout=15)
-    except httpx.ConnectError:
+    except httpx.ConnectError as exc:
+        # httpx wraps ssl.SSLCertVerificationError in httpx.ConnectError.
+        # A cert-verification failure is a trust-bundle issue on the test
+        # runner (e.g. missing public roots when fronted by an ALB with an
+        # ACM cert), not a server security finding — skip with clear
+        # guidance rather than failing as "connection refused".  See
+        # test_ssl.py (commit c057b80 / PR #198) for the same
+        # classification applied to the TLS-version test.
+        cause = exc.__cause__
+        if isinstance(cause, ssl.SSLCertVerificationError) or "CERTIFICATE_VERIFY_FAILED" in str(
+            exc
+        ):
+            pytest.skip(
+                f"Could not verify TLS certificate for {product} at {pc.url}: {exc}. "
+                "This is a certificate-trust issue on the test runner, not a "
+                "server security finding.  If the server uses a valid public "
+                "certificate (e.g. behind an AWS ALB with an ACM cert), set "
+                "SSL_CERT_FILE to a CA bundle that includes public roots: "
+                "/etc/ssl/certs/ca-certificates.crt on Debian/Ubuntu, "
+                "/etc/pki/tls/certs/ca-bundle.crt on RHEL, or the path "
+                "produced by `python -m certifi`."
+            )
         pytest.fail(
             f"Could not reach {product} at {pc.url}: connection refused. "
             "Check firewall rules, proxy configuration, DNS resolution, and port. "

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -17,6 +17,24 @@ scenarios("test_https.feature")
 
 
 # ---------------------------------------------------------------------------
+# Shared diagnostic text
+# ---------------------------------------------------------------------------
+
+# CA-bundle guidance reused in the cert-verification skip below.
+# src/vip_tests/cross_product/test_ssl.py has a similar message in the
+# ``modern_tls_succeeds`` step — keep the two in sync when updating guidance.
+_CERT_TRUST_HINT = (
+    "This is a certificate-trust issue on the test runner, not a "
+    "server security finding. If the server uses a valid public "
+    "certificate (e.g. behind an AWS ALB with an ACM cert), set "
+    "SSL_CERT_FILE to a CA bundle that includes public roots: "
+    "/etc/ssl/certs/ca-certificates.crt on Debian/Ubuntu, "
+    "/etc/pki/tls/certs/ca-bundle.crt on RHEL, or the path "
+    "produced by `python -m certifi`."
+)
+
+
+# ---------------------------------------------------------------------------
 # Steps - HTTPS enforcement
 # ---------------------------------------------------------------------------
 
@@ -80,9 +98,9 @@ def inspect_headers(product, vip_config):
         # ACM cert), not a server security finding — skip with clear
         # guidance rather than failing as "connection refused".
         # src/vip_tests/cross_product/test_ssl.py applies the same cert-trust
-        # classification — it raises there because that test is specifically
-        # about TLS enforcement; here we skip because the test is about
-        # response headers, not certificate validity.
+        # classification; it raises there because that test is specifically
+        # about TLS enforcement, whereas here we skip because the test is
+        # about response headers, not certificate validity.
         # Primary check: httpx sets __cause__ to ssl.SSLCertVerificationError when
         # the TLS handshake fails due to certificate verification.  String fallback
         # covers transports where httpx does not populate __cause__ but still
@@ -93,13 +111,7 @@ def inspect_headers(product, vip_config):
         ):
             pytest.skip(
                 f"Could not verify TLS certificate for {product} at {pc.url}: {exc}. "
-                "This is a certificate-trust issue on the test runner, not a "
-                "server security finding. If the server uses a valid public "
-                "certificate (e.g. behind an AWS ALB with an ACM cert), set "
-                "SSL_CERT_FILE to a CA bundle that includes public roots: "
-                "/etc/ssl/certs/ca-certificates.crt on Debian/Ubuntu, "
-                "/etc/pki/tls/certs/ca-bundle.crt on RHEL, or the path "
-                "produced by `python -m certifi`."
+                + _CERT_TRUST_HINT
             )
         pytest.fail(
             f"Could not reach {product} at {pc.url}: connection refused. "

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import ssl
 
 import httpx
@@ -77,8 +78,11 @@ def inspect_headers(product, vip_config):
         # A cert-verification failure is a trust-bundle issue on the test
         # runner (e.g. missing public roots when fronted by an ALB with an
         # ACM cert), not a server security finding — skip with clear
-        # guidance rather than failing as "connection refused". See
-        # test_ssl.py for the same classification applied to the TLS-version test.
+        # guidance rather than failing as "connection refused".
+        # src/vip_tests/cross_product/test_ssl.py applies the same cert-trust
+        # classification — it raises there because that test is specifically
+        # about TLS enforcement; here we skip because the test is about
+        # response headers, not certificate validity.
         cause = exc.__cause__
         if isinstance(cause, ssl.SSLCertVerificationError) or "CERTIFICATE_VERIFY_FAILED" in str(
             exc
@@ -109,8 +113,6 @@ def no_version_headers(response_headers):
         value = response_headers.get(header, "")
         # Having the header is OK, but it shouldn't contain version numbers.
         if value:
-            import re
-
             version_pattern = re.compile(r"\d+\.\d+")
             if version_pattern.search(value):
                 pytest.fail(

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -83,6 +83,10 @@ def inspect_headers(product, vip_config):
         # classification — it raises there because that test is specifically
         # about TLS enforcement; here we skip because the test is about
         # response headers, not certificate validity.
+        # Primary check: httpx sets __cause__ to ssl.SSLCertVerificationError when
+        # the TLS handshake fails due to certificate verification.  String fallback
+        # covers transports where httpx does not populate __cause__ but still
+        # surfaces the OpenSSL error token in the exception message.
         cause = exc.__cause__
         if isinstance(cause, ssl.SSLCertVerificationError) or "CERTIFICATE_VERIFY_FAILED" in str(
             exc

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -77,9 +77,8 @@ def inspect_headers(product, vip_config):
         # A cert-verification failure is a trust-bundle issue on the test
         # runner (e.g. missing public roots when fronted by an ALB with an
         # ACM cert), not a server security finding — skip with clear
-        # guidance rather than failing as "connection refused".  See
-        # test_ssl.py (commit c057b80 / PR #198) for the same
-        # classification applied to the TLS-version test.
+        # guidance rather than failing as "connection refused". See
+        # test_ssl.py for the same classification applied to the TLS-version test.
         cause = exc.__cause__
         if isinstance(cause, ssl.SSLCertVerificationError) or "CERTIFICATE_VERIFY_FAILED" in str(
             exc
@@ -87,7 +86,7 @@ def inspect_headers(product, vip_config):
             pytest.skip(
                 f"Could not verify TLS certificate for {product} at {pc.url}: {exc}. "
                 "This is a certificate-trust issue on the test runner, not a "
-                "server security finding.  If the server uses a valid public "
+                "server security finding. If the server uses a valid public "
                 "certificate (e.g. behind an AWS ALB with an ACM cert), set "
                 "SSL_CERT_FILE to a CA bundle that includes public roots: "
                 "/etc/ssl/certs/ca-certificates.crt on Debian/Ubuntu, "


### PR DESCRIPTION
## Summary

Issue #175 reported that `test_tls_12_or_higher_is_enforced_for_product` failed with an opaque `SSL: CERTIFICATE_VERIFY_FAILED` error behind an SSL-terminating proxy. That specific test lives in `src/vip_tests/cross_product/test_ssl.py` and was already fixed by #198 (commit `c057b80`), which classifies handshake outcomes and surfaces a trust-bundle hint when verification fails.

This PR applies the same classification to the sibling `inspect_headers` step in `src/vip_tests/security/test_https.py`, which was catching `httpx.ConnectError` and reporting "connection refused" for all failure modes — including cert-verify failures that `httpx` wraps inside `ConnectError`. The test now detects `ssl.SSLCertVerificationError` (via `__cause__` and a `CERTIFICATE_VERIFY_FAILED` substring fallback) and skips with a clear message pointing to `SSL_CERT_FILE` and common CA bundle paths (Debian/Ubuntu, RHEL, and `python -m certifi`).

## Test plan

- [x] Ruff: `just check` passes
- [x] Selftests: `uv run pytest selftests/` passes (303/303 locally)
- [x] Product tests against ganso01-staging Connect:
  - [x] With `SSL_CERT_FILE` pointed at a self-signed CA that doesn't trust the ACM cert, `test_product_does_not_expose_sensitive_headers[Connect]` skips with the new diagnostic: _"Could not verify TLS certificate for Connect at ...: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate ... This is a certificate-trust issue on the test runner, not a server security finding. If the server uses a valid public certificate (e.g. behind an AWS ALB with an ACM cert), set SSL_CERT_FILE to a CA bundle that includes public roots: /etc/ssl/certs/ca-certificates.crt on Debian/Ubuntu, /etc/pki/tls/certs/ca-bundle.crt on RHEL, or the path produced by `python -m certifi`."_
  - [x] With `SSL_CERT_FILE` unset (valid default CA bundle), the same test PASSES against Connect — the cert-verify branch does not swallow legitimate test runs

Fixes #175