### PR TITLE
fix(deps): pin nbconvert>=7.17.1 for CVE-2026-39377/39378

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ report = [
     "ipykernel",
     "nbformat>=5.7",
     "nbclient>=0.8",
+    "nbconvert>=7.17.1",  # CVE-2026-39377, CVE-2026-39378 fix; transitive via jupyter
     "tornado>=6.5.5",  # CVE-2026-31958 fix; transitive via jupyter
 ]
 cluster = [

--- a/uv.lock
+++ b/uv.lock
@@ -2142,7 +2142,7 @@ wheels = [
 
 [[package]]
 name = "nbconvert"
-version = "7.17.0"
+version = "7.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -2160,9 +2160,9 @@ dependencies = [
     { name = "pygments" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/47/81f886b699450d0569f7bc551df2b1673d18df7ff25cc0c21ca36ed8a5ff/nbconvert-7.17.0.tar.gz", hash = "sha256:1b2696f1b5be12309f6c7d707c24af604b87dfaf6d950794c7b07acab96dda78", size = 862855 }
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/4b/8d5f796a792f8a25f6925a96032f098789f448571eb92011df1ae59e8ea8/nbconvert-7.17.0-py3-none-any.whl", hash = "sha256:4f99a63b337b9a23504347afdab24a11faa7d86b405e5c8f9881cd313336d518", size = 261510 },
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927 },
 ]
 
 [[package]]
@@ -2480,7 +2480,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.24.10"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },
@@ -2522,6 +2522,7 @@ report = [
     { name = "jinja2" },
     { name = "jupyter" },
     { name = "nbclient" },
+    { name = "nbconvert" },
     { name = "nbformat" },
     { name = "tornado" },
 ]
@@ -2541,6 +2542,7 @@ requires-dist = [
     { name = "locust", marker = "extra == 'load'", specifier = ">=2.20" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "nbclient", marker = "extra == 'report'", specifier = ">=0.8" },
+    { name = "nbconvert", marker = "extra == 'report'", specifier = ">=7.17.1" },
     { name = "nbformat", marker = "extra == 'report'", specifier = ">=5.7" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "playwright", specifier = ">=1.40" },


### PR DESCRIPTION
## Summary

Resolve two CVEs flagged by the Dependency Audit CI check:

- **CVE-2026-39377** — nbconvert 7.17.0
- **CVE-2026-39378** — nbconvert 7.17.0

Both are fixed in nbconvert 7.17.1.  `nbconvert` is a transitive dependency via `jupyter` in the `report` optional extra, so this PR pins it directly in `pyproject.toml` following the existing pattern used for `tornado`, `pygments`, `cryptography`, `pyjwt`, `python-multipart`, and `requests` (each annotated with the CVE it mitigates).

## Why it matters

Blocks the Dependency Audit check on every open PR — including #207, #208, #209, #210.  Once this merges, those PRs will need to merge main (or have main merged into them) to pick up the fix.

## Test plan

- [x] `uv lock` resolved cleanly (nbconvert 7.17.0 → 7.17.1)
- [x] `uv run pip-audit --skip-editable` reports "No known vulnerabilities found"
- [x] `uv run ruff check` + `ruff format --check` pass
- [x] Selftests: 302/303 pass (known load-engine sandbox flakes unchanged)