### PR TITLE
fix(connect): resolve relative Location headers on redirect

### DIFF
--- a/selftests/test_clients_connect.py
+++ b/selftests/test_clients_connect.py
@@ -1,0 +1,100 @@
+"""Selftests for ConnectClient.fetch_content redirect handling.
+
+These tests verify that relative Location headers are resolved against the
+current response URL before the same-origin check and the follow-up GET,
+preventing ``httpcore.UnsupportedProtocol`` when Connect returns paths like
+``/content/{guid}/notebook.html``.
+
+No real network connections are made: ``httpx.get`` is monkeypatched to
+return pre-baked ``httpx.Response`` objects.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from vip.clients.connect import ConnectClient
+
+
+def _make_response(
+    status_code: int,
+    *,
+    url: str,
+    location: str | None = None,
+    body: bytes = b"",
+) -> httpx.Response:
+    """Build a minimal httpx.Response suitable for testing."""
+    headers: dict[str, str] = {}
+    if location is not None:
+        headers["location"] = location
+    return httpx.Response(
+        status_code=status_code,
+        headers=headers,
+        content=body,
+        request=httpx.Request("GET", url),
+    )
+
+
+def test_fetch_content_follows_relative_redirect(monkeypatch):
+    """A relative Location like /content/abc/notebook.html is resolved and
+    followed without raising UnsupportedProtocol."""
+
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+    resolved_url = f"{base_url}/content/abc/notebook.html"
+    expected_body = b"<html>notebook</html>"
+
+    responses = {
+        initial_url: _make_response(
+            302,
+            url=initial_url,
+            location="/content/abc/notebook.html",
+        ),
+        resolved_url: _make_response(
+            200,
+            url=resolved_url,
+            body=expected_body,
+        ),
+    }
+
+    def fake_get(url, **kwargs):
+        return responses[url]
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="dummy-key")
+    resp = client.fetch_content(initial_url)
+
+    assert resp.status_code == 200
+    assert resp.content == expected_body
+
+
+def test_fetch_content_blocks_cross_origin_redirect(monkeypatch):
+    """A redirect to a different hostname must not be followed (API key leak
+    prevention).  The function should return the redirect response itself."""
+
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+
+    redirect_resp = _make_response(
+        302,
+        url=initial_url,
+        location="https://cdn.external.com/content/abc/notebook.html",
+    )
+
+    call_count = {"n": 0}
+
+    def fake_get(url, **kwargs):
+        call_count["n"] += 1
+        # Only the first call (for initial_url) should ever happen.
+        return redirect_resp
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="dummy-key")
+    resp = client.fetch_content(initial_url)
+
+    # The redirect was not followed — the 302 is returned as-is.
+    assert resp.status_code == 302
+    # Only one GET was made (no follow-up to the external host).
+    assert call_count["n"] == 1

--- a/selftests/test_clients_connect.py
+++ b/selftests/test_clients_connect.py
@@ -98,3 +98,113 @@ def test_fetch_content_blocks_cross_origin_redirect(monkeypatch):
     assert resp.status_code == 302
     # Only one GET was made (no follow-up to the external host).
     assert call_count["n"] == 1
+
+
+def test_fetch_content_blocks_scheme_downgrade(monkeypatch):
+    """A redirect from https to http on the same host must not be followed."""
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+
+    redirect_resp = _make_response(
+        302,
+        url=initial_url,
+        location="http://connect.example.com/content/abc/notebook.html",
+    )
+
+    call_count = {"n": 0}
+
+    def fake_get(url, **kwargs):
+        call_count["n"] += 1
+        return redirect_resp
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="dummy-key")
+    resp = client.fetch_content(initial_url)
+
+    assert resp.status_code == 302
+    assert call_count["n"] == 1
+
+
+def test_fetch_content_blocks_port_change(monkeypatch):
+    """A redirect to a different port on the same host must not be followed."""
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+
+    redirect_resp = _make_response(
+        302,
+        url=initial_url,
+        location="https://connect.example.com:8443/content/abc/notebook.html",
+    )
+
+    call_count = {"n": 0}
+
+    def fake_get(url, **kwargs):
+        call_count["n"] += 1
+        return redirect_resp
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="dummy-key")
+    resp = client.fetch_content(initial_url)
+
+    assert resp.status_code == 302
+    assert call_count["n"] == 1
+
+
+def test_fetch_content_blocks_non_http_scheme(monkeypatch):
+    """A redirect to a non-http(s) scheme must not be followed and must not raise."""
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+
+    redirect_resp = _make_response(
+        302,
+        url=initial_url,
+        location="file:///etc/passwd",
+    )
+
+    call_count = {"n": 0}
+
+    def fake_get(url, **kwargs):
+        call_count["n"] += 1
+        return redirect_resp
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="dummy-key")
+    resp = client.fetch_content(initial_url)
+
+    assert resp.status_code == 302
+    assert call_count["n"] == 1
+
+
+def test_fetch_content_allows_explicit_default_port(monkeypatch):
+    """A redirect to the same origin with an explicit default port (443) is followed."""
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+    resolved_url = "https://connect.example.com:443/content/abc/notebook.html"
+    expected_body = b"<html>notebook</html>"
+
+    responses = {
+        initial_url: _make_response(
+            302,
+            url=initial_url,
+            location="https://connect.example.com:443/content/abc/notebook.html",
+        ),
+        resolved_url: _make_response(
+            200,
+            url=resolved_url,
+            body=expected_body,
+        ),
+    }
+
+    def fake_get(url, **kwargs):
+        return responses[url]
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="dummy-key")
+    resp = client.fetch_content(initial_url)
+
+    assert resp.status_code == 200
+    assert resp.content == expected_body

--- a/src/vip/clients/connect.py
+++ b/src/vip/clients/connect.py
@@ -271,7 +271,7 @@ class ConnectClient(BaseClient):
         This avoids leaking the API key to external domains if Connect
         redirects to a CDN or OAuth provider.
         """
-        from urllib.parse import urlparse
+        from urllib.parse import urljoin, urlparse
 
         origin = urlparse(self.base_url)
         max_redirects = 10
@@ -285,12 +285,15 @@ class ConnectClient(BaseClient):
             if not resp.is_redirect:
                 break
             location = resp.headers.get("location", "")
-            target = urlparse(location)
+            # Resolve relative Location values (e.g. "/content/{guid}/x.html")
+            # against the current response URL before checking the origin.
+            absolute_location = urljoin(str(resp.url), location)
+            target = urlparse(absolute_location)
             # Only follow redirects to the same origin.
             if target.hostname and target.hostname != origin.hostname:
                 break
             resp = httpx.get(
-                location,
+                absolute_location,
                 headers={"Authorization": self._client.headers["Authorization"]},
                 follow_redirects=False,
                 timeout=timeout,

--- a/src/vip/clients/connect.py
+++ b/src/vip/clients/connect.py
@@ -15,6 +15,17 @@ from vip.clients.base import BaseClient
 _VIP_CONTENT_TAG = "_vip_test"
 
 
+def _normalized_port(scheme: str | None, port: int | None) -> int | None:
+    """Return the effective TCP port for a URL, filling in defaults for http/https."""
+    if port is not None:
+        return port
+    if scheme == "https":
+        return 443
+    if scheme == "http":
+        return 80
+    return None
+
+
 class ConnectClient(BaseClient):
     """Minimal Connect API wrapper."""
 
@@ -269,11 +280,14 @@ class ConnectClient(BaseClient):
         """Fetch a content URL with API-key auth, following only same-origin redirects.
 
         This avoids leaking the API key to external domains if Connect
-        redirects to a CDN or OAuth provider.
+        redirects to a CDN or OAuth provider.  A redirect is followed only
+        when ALL of scheme, hostname, and effective port match the client's
+        base URL, and the target scheme is http or https.
         """
         from urllib.parse import urljoin, urlparse
 
         origin = urlparse(self.base_url)
+        origin_key = (origin.scheme, origin.hostname, _normalized_port(origin.scheme, origin.port))
         max_redirects = 10
         resp = httpx.get(
             url,
@@ -289,8 +303,16 @@ class ConnectClient(BaseClient):
             # against the current response URL before checking the origin.
             absolute_location = urljoin(str(resp.url), location)
             target = urlparse(absolute_location)
-            # Only follow redirects to the same origin.
-            if target.hostname and target.hostname != origin.hostname:
+            # Reject non-http(s) schemes (e.g. file:, javascript:, ftp:).
+            if target.scheme not in ("http", "https"):
+                break
+            # Only follow redirects to the exact same origin (scheme + host + port).
+            target_key = (
+                target.scheme,
+                target.hostname,
+                _normalized_port(target.scheme, target.port),
+            )
+            if target_key != origin_key:
                 break
             resp = httpx.get(
                 absolute_location,


### PR DESCRIPTION
## Summary

- `ConnectClient.fetch_content` raised `httpcore.UnsupportedProtocol` when Connect returned a relative `Location` header (e.g. `/content/{guid}/notebook.html`) because the raw path was handed to `httpx.get`.
- Fix: resolve each `Location` value against `str(resp.url)` with `urljoin` before the same-origin check and the follow-up GET.
- Same-origin safety is preserved — cross-origin redirects still short-circuit without leaking the API key.

## Test plan

- [x] `uv run ruff check src/ selftests/`
- [x] `uv run ruff format --check src/ selftests/`
- [x] `uv run pytest selftests/test_clients_connect.py -v` — 2 new tests pass (relative redirect followed; cross-origin redirect blocked)
- [x] `uv run pytest selftests/ -q` — 312 passed, 1 known timing flake (`test_1k_users`)
- [x] `vip verify --connect-url https://pub.ganso.lab.staging.posit.team --categories connect --filter "deploy and not rmarkdown"` against ganso01-staging — 6 deploy tests pass (jupyter, quarto, plumber, fastapi, dash, gitbacked, all of which call `fetch_content`). Shiny timed out during packrat-restore, unrelated to this change.

Fixes #213