### PR TITLE
fix(output): small fixup for output and docs

### DIFF
--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -722,6 +722,31 @@ class TestXdistCompatibility:
         data = json.loads(report_path.read_text())
         assert len(data["results"]) == 2
 
+    def test_gw_worker_prefix_suppressed(self, selftest_pytester):
+        """Under xdist with -v, the built-in ``[gw<N>]`` prefix should be hidden."""
+        selftest_pytester.makepyfile(
+            """
+            def test_one():
+                assert True
+
+            def test_two():
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest(
+            "--vip-config=vip.toml",
+            "-n",
+            "2",
+            "--dist",
+            "loadgroup",
+            "-v",
+        )
+        result.assert_outcomes(passed=2)
+        for line in result.stdout.lines:
+            assert not re.search(r"\[gw\d+\]", line), (
+                f"Found xdist worker prefix in output line: {line!r}"
+            )
+
     def test_vip_metadata_survives_xdist(self, selftest_pytester):
         """Custom report attributes (markers, scenario fields) survive xdist transit."""
         # Use a plain test file and verify markers/scenario fields are present in results.

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -677,6 +677,7 @@ def pytest_runtest_makereport(item: pytest.Item, call):  # noqa: ARG001
         report.vip_feature_description = scenario_meta.get("feature_description")  # type: ignore[attr-defined]
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     """Collect results for JSON report and apply concise terminal display.
 
@@ -686,6 +687,12 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     making it the right place to aggregate results.  The ``workerinput``
     guard skips processing on workers so results are collected exactly once.
     """
+    # Strip the xdist worker attribute so pytest's built-in TerminalReporter
+    # does not prefix each verbose line with ``[gw<N>]``.  Runs before the
+    # terminal reporter thanks to ``tryfirst=True``.
+    if hasattr(report, "node"):
+        del report.node
+
     if _active_config is None:
         return
 

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -154,8 +154,15 @@ vip verify --package-manager-url https://pm.example.com --categories package-man
 # Combine markers
 vip verify --connect-url https://connect.example.com --categories "performance and connect"
 
+# Filter by test name (shortcut for pytest -k)
+vip verify --connect-url https://connect.example.com --filter login
+vip verify --connect-url https://connect.example.com -f "login and not saml"
+
+# Skip tests whose names match an expression
+vip verify --connect-url https://connect.example.com --filter "not login"
+
 # Pass extra flags to pytest
-vip verify --connect-url https://connect.example.com -- -x --tb=long -k 'login'</code></pre>
+vip verify --connect-url https://connect.example.com -- -x --tb=long</code></pre>
 
           <h3>Test categories</h3>
           <div class="table-wrap">


### PR DESCRIPTION
As I went through the latest (so many good things in here), I noticed two things:
1. The tests are faster with the parallelization, but there's a new prefix ([gw1] and similar) that doesn't make the output as clean
2. I never documented the "--filter" flag