### PR TITLE
fix(connect): declare rmarkdown closure and raise deploy timeout

### DIFF
--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -81,7 +81,7 @@ class TestConnectConfig:
 
     def test_default_deploy_timeout(self):
         cc = ConnectConfig(url="https://connect.example.com")
-        assert cc.deploy_timeout == 600
+        assert cc.deploy_timeout == 1200
 
     def test_explicit_deploy_timeout(self):
         cc = ConnectConfig(url="https://connect.example.com", deploy_timeout=1200)
@@ -309,7 +309,7 @@ url = "https://connect.example.com"
 """
         )
         cfg = load_config(path)
-        assert cfg.connect.deploy_timeout == 600
+        assert cfg.connect.deploy_timeout == 1200
 
     def test_full_config(self, tmp_toml):
         path = tmp_toml(

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -80,7 +80,7 @@ class ConnectConfig(ProductConfig):
     """Connect-specific configuration."""
 
     api_key: str = ""
-    deploy_timeout: int = 600
+    deploy_timeout: int = 1200
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -94,7 +94,7 @@ class ConnectConfig(ProductConfig):
             url=raw.get("url", ""),
             version=raw.get("version"),
             api_key=raw.get("api_key", ""),
-            deploy_timeout=raw.get("deploy_timeout", 600),
+            deploy_timeout=raw.get("deploy_timeout", 1200),
         )
 
 

--- a/src/vip_tests/connect/rmarkdown_manifest.json
+++ b/src/vip_tests/connect/rmarkdown_manifest.json
@@ -1,0 +1,293 @@
+{
+  "version": 1,
+  "platform": "4.2.2",
+  "metadata": {
+    "appmode": "rmd-static",
+    "primary_rmd": "index.Rmd",
+    "primary_html": null,
+    "content_category": "",
+    "has_parameters": false,
+    "entrypoint": null
+  },
+  "environment": {
+    "r": {
+      "requires": ">=4.1"
+    }
+  },
+  "packages": {
+    "R6": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "R6",
+        "Version": "2.6.1",
+        "Depends": "R (>= 3.6)"
+      }
+    },
+    "base64enc": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "base64enc",
+        "Version": "0.1-3",
+        "Depends": "R (>= 2.9.0)"
+      }
+    },
+    "bslib": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "bslib",
+        "Version": "0.8.0",
+        "Imports": "base64enc, cachem, fastmap (>= 1.1.1), grDevices, htmltools (>= 0.5.7), jquerylib (>= 0.1.3), jsonlite (>= 0.9.16), lifecycle (>= 1.0.1), memoise (>= 2.0.1), mime (>= 0.1), rlang (>= 1.0.0), sass (>= 0.4.9)"
+      }
+    },
+    "cachem": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "cachem",
+        "Version": "1.1.0",
+        "Imports": "fastmap, rlang"
+      }
+    },
+    "cli": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "cli",
+        "Version": "3.6.4",
+        "Imports": "utils"
+      }
+    },
+    "digest": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "digest",
+        "Version": "0.6.37",
+        "Imports": "utils"
+      }
+    },
+    "evaluate": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "evaluate",
+        "Version": "1.0.3",
+        "Imports": "methods"
+      }
+    },
+    "fastmap": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "fastmap",
+        "Version": "1.2.0"
+      }
+    },
+    "fontawesome": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "fontawesome",
+        "Version": "0.5.3",
+        "Imports": "htmltools (>= 0.5.1.1), rlang (>= 1.0.0)"
+      }
+    },
+    "fs": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "fs",
+        "Version": "1.6.5",
+        "Imports": "methods"
+      }
+    },
+    "glue": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "glue",
+        "Version": "1.8.0",
+        "Imports": "methods"
+      }
+    },
+    "highr": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "highr",
+        "Version": "0.11",
+        "Imports": "xfun (>= 0.18)"
+      }
+    },
+    "htmltools": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "htmltools",
+        "Version": "0.5.8.1",
+        "Imports": "base64enc, digest (>= 0.6), ellipsis, fastmap (>= 1.1.0), grDevices, rlang (>= 1.0.0), utils"
+      }
+    },
+    "ellipsis": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "ellipsis",
+        "Version": "0.3.2",
+        "Imports": "rlang (>= 0.2.0)"
+      }
+    },
+    "jquerylib": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "jquerylib",
+        "Version": "0.1.4",
+        "Imports": "htmltools"
+      }
+    },
+    "jsonlite": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "jsonlite",
+        "Version": "1.9.1",
+        "Imports": "methods"
+      }
+    },
+    "knitr": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "knitr",
+        "Version": "1.49",
+        "Imports": "evaluate (>= 0.15), highr, methods, tools, xfun (>= 0.44), yaml (>= 2.1.19)"
+      }
+    },
+    "lifecycle": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "lifecycle",
+        "Version": "1.0.4",
+        "Imports": "cli (>= 3.4.0), glue, rlang (>= 1.1.0)"
+      }
+    },
+    "magrittr": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "magrittr",
+        "Version": "2.0.3"
+      }
+    },
+    "memoise": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "memoise",
+        "Version": "2.0.1",
+        "Imports": "cachem, rlang"
+      }
+    },
+    "mime": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "mime",
+        "Version": "0.12",
+        "Imports": "tools"
+      }
+    },
+    "rappdirs": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "rappdirs",
+        "Version": "0.3.3"
+      }
+    },
+    "rlang": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "rlang",
+        "Version": "1.1.4",
+        "Imports": "utils"
+      }
+    },
+    "rmarkdown": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "rmarkdown",
+        "Version": "2.29",
+        "Imports": "bslib (>= 0.2.5.1), evaluate (>= 0.13), fontawesome (>= 0.5.0), htmltools (>= 0.5.1), jquerylib, jsonlite, knitr (>= 1.43), methods, stringr (>= 1.2.0), tinytex (>= 0.31), tools, utils, xfun (>= 0.36), yaml (>= 2.1.19)"
+      }
+    },
+    "sass": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "sass",
+        "Version": "0.4.9",
+        "Imports": "fs, htmltools (>= 0.5.1), R6, rlang (>= 0.4.0)"
+      }
+    },
+    "stringi": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "stringi",
+        "Version": "1.8.4"
+      }
+    },
+    "stringr": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "stringr",
+        "Version": "1.5.1",
+        "Imports": "cli, glue (>= 1.6.1), lifecycle (>= 1.0.3), magrittr, rlang (>= 1.0.0), stringi (>= 1.5.3), vctrs (>= 0.4.0)"
+      }
+    },
+    "tinytex": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "tinytex",
+        "Version": "0.54",
+        "Imports": "xfun (>= 0.31)"
+      }
+    },
+    "vctrs": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "vctrs",
+        "Version": "0.6.5",
+        "Imports": "cli (>= 3.4.0), glue, lifecycle (>= 1.0.3), rlang (>= 1.1.0)"
+      }
+    },
+    "xfun": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "xfun",
+        "Version": "0.50",
+        "Imports": "stats, tools"
+      }
+    },
+    "yaml": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "yaml",
+        "Version": "2.3.10"
+      }
+    }
+  }
+}

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -180,61 +180,21 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
         r_versions = connect_client.r_versions()
         if not r_versions:
             pytest.skip("No R versions available on Connect — cannot deploy R Markdown")
-        # Connect's R-side pipeline calls ``packrat`` on the manifest's
-        # ``packages`` block; an empty dict triggers
-        # ``[.data.frame(lockInfo, , "Package") : undefined columns selected``
-        # because the expected ``Package`` column is missing.  We must
-        # populate ``packages`` with at least the packages this Rmd needs
-        # (``rmarkdown``, ``knitr``) in the same shape used by Connect's
-        # publishing clients.  See shiny_manifest.json for the reference
-        # schema.
-        # Versions below are placeholders that satisfy packrat's column-shape
-        # requirement; they do not need to match what is installed on the server.
-        # TODO: if Connect starts validating additional fields (Hash, Requirements)
-        # from newer packrat/renv lockfile schemas, expand these entries accordingly.
-        rmd_packages = {
-            "rmarkdown": {
-                "Source": "CRAN",
-                "Repository": "https://cloud.r-project.org",
-                "description": {
-                    "Package": "rmarkdown",
-                    "Version": "2.25",
-                    "Imports": "knitr",
-                },
-            },
-            "knitr": {
-                "Source": "CRAN",
-                "Repository": "https://cloud.r-project.org",
-                "description": {
-                    "Package": "knitr",
-                    "Version": "1.45",
-                    "Imports": "",
-                },
-            },
-        }
-        rmd_content = (
-            "---\ntitle: VIP RMarkdown Test\noutput: html_document\n---\n\n"
-            "Hello from VIP RMarkdown.\n"
+        # Use the pre-built manifest with the full transitive dependency closure
+        # (rmarkdown → knitr → evaluate/highr/xfun/yaml, bslib, stringr, etc.).
+        # An incomplete ``packages`` block causes packrat-restore to fail with
+        # ``r-cannot-access-repo`` when PPM does not serve transitive deps
+        # anonymously.  See rmarkdown_manifest.json for the reference schema.
+        manifest = json.loads(
+            (pathlib.Path(__file__).parent / "rmarkdown_manifest.json").read_text()
         )
+        manifest["platform"] = r_versions[0]
         return {
-            "index.Rmd": rmd_content,
-            "manifest.json": json.dumps(
-                {
-                    "version": 1,
-                    "platform": r_versions[0],
-                    "metadata": {
-                        "appmode": "rmd-static",
-                        "entrypoint": "index.Rmd",
-                        "primary_rmd": "index.Rmd",
-                        "content_category": "",
-                        "has_parameters": False,
-                    },
-                    "packages": rmd_packages,
-                    "files": {
-                        "index.Rmd": {"checksum": _md5(rmd_content)},
-                    },
-                }
+            "index.Rmd": (
+                "---\ntitle: VIP RMarkdown Test\noutput: html_document\n---\n\n"
+                "Hello from VIP RMarkdown.\n"
             ),
+            "manifest.json": json.dumps(manifest),
         }
 
     if name == "vip-jupyter-test":

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -35,9 +35,9 @@ url = "https://connect.example.com"
 # Prefer setting the VIP_CONNECT_API_KEY environment variable.
 # api_key = "..."
 
-# Timeout in seconds for content deployments (default: 600)
+# Timeout in seconds for content deployments (default: 1200)
 # Increase this for environments with slower package installation.
-deploy_timeout = 600
+deploy_timeout = 1200
 
 [workbench]
 enabled = true


### PR DESCRIPTION
## Summary

- Replace the 2-package stub in `_get_bundle` for `vip-rmarkdown-test` with a full 31-package transitive closure loaded from a new `src/vip_tests/connect/rmarkdown_manifest.json` (mirrors the `vip-shiny-test` pattern). Empty `packages` caused `r-cannot-access-repo` on deployments where PPM doesn't serve transitive deps anonymously.
- Raise the default `connect.deploy_timeout` from 600s to 1200s. R-heavy content with many source-built packages (rmarkdown, shiny) legitimately needs >10 min on deployments where PPM falls back to CRAN source builds.
- Update `vip.toml.example` comment, config default, and two selftest assertions to reflect the new default.

## Test plan

- [x] `uv run ruff check src/ selftests/` — clean
- [x] `uv run ruff format --check src/ selftests/` — 102 files already formatted
- [x] `uv run pytest selftests/ -q` — 318 passed
- [x] `vip verify --connect-url https://pub.ganso.lab.staging.posit.team --filter deploy_rmarkdown -- -n 0` against ganso01-staging — `test_deploy_rmarkdown PASSED` in 603s. Packrat restores all 31 packages (PPM 401 → CRAN 200 fallback), rmd-static renders, HTML contains "VIP RMarkdown Test" marker.

Fixes #214