### PR TITLE
fix(workbench): disambiguate IDE session names under xdist

### DIFF
--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -5,6 +5,7 @@ Page selectors are in the pages/ subpackage
 
 from __future__ import annotations
 
+import os
 import time
 
 import httpx
@@ -28,6 +29,20 @@ TIMEOUT_IDE_LOAD = 60_000
 TIMEOUT_SESSION_START = 90_000
 
 # ---------------------------------------------------------------------------
+
+
+def unique_session_name(filename: str) -> str:
+    """Generate a Workbench session name unique across xdist workers.
+
+    Session tests look up rows via aria-label locators. Using only
+    ``int(time.time())`` collided across workers that entered the same
+    second, producing strict-mode failures once locators were tightened
+    to ends-with matches. Worker id + nanosecond timestamp guarantees
+    uniqueness for any practical parallelism.
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    return f"VIP {filename} - {worker}-{time.time_ns()}"
+
 
 # Keywords indicating the URL is a login/auth page (used for OIDC detection)
 _LOGIN_KEYWORDS = ("sign-in", "login", "auth")

--- a/src/vip_tests/workbench/pages/homepage.py
+++ b/src/vip_tests/workbench/pages/homepage.py
@@ -153,7 +153,7 @@ class Homepage:
     @staticmethod
     def session_rename_button(name: str) -> str:
         """Selector for session rename button."""
-        return f"[aria-label*='{name}'] button[aria-label='Rename session']"
+        return f"[aria-label$='{name}'] button[aria-label='Rename session']"
 
     @staticmethod
     def session_state(state: str) -> str:
@@ -162,8 +162,13 @@ class Homepage:
 
     @staticmethod
     def session_row(name: str) -> str:
-        """Selector for session row by session name using aria-label."""
-        return f"tr[aria-label*='{name}']"
+        """Selector for session row by session name using aria-label.
+
+        Workbench sets aria-label to e.g. "No project: <session_name>",
+        so match with ends-with ($=) to anchor on the session name and
+        avoid strict-mode collisions when one name is a substring of another.
+        """
+        return f"tr[aria-label$='{name}']"
 
     @staticmethod
     def session_row_status(name: str, status: str) -> str:
@@ -172,4 +177,4 @@ class Homepage:
         Finds the row containing the session name, then matches if
         that row's status cell contains the given status.
         """
-        return f"tr[aria-label*='{name}'] div[aria-label='{status}']"
+        return f"tr[aria-label$='{name}'] div[aria-label='{status}']"

--- a/src/vip_tests/workbench/pages/homepage.py
+++ b/src/vip_tests/workbench/pages/homepage.py
@@ -153,7 +153,7 @@ class Homepage:
     @staticmethod
     def session_rename_button(name: str) -> str:
         """Selector for session rename button."""
-        return f"[aria-label$='{name}'] button[aria-label='Rename session']"
+        return f"tr[aria-label$='{name}'] button[aria-label='Rename session']"
 
     @staticmethod
     def session_state(state: str) -> str:

--- a/src/vip_tests/workbench/test_data_sources.py
+++ b/src/vip_tests/workbench/test_data_sources.py
@@ -16,6 +16,7 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_QUICK,
     TIMEOUT_SESSION_START,
     assert_homepage_loaded,
+    unique_session_name,
     workbench_login,
 )
 from vip_tests.workbench.pages import (
@@ -145,7 +146,7 @@ def verify_connectivity(
     )
     assert_homepage_loaded(page)
 
-    session_name = f"VIP {_FILENAME} - {int(time.time())}"
+    session_name = unique_session_name(_FILENAME)
     _start_session(page, session_name)
     _wait_for_active_and_join(page, session_name)
 

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -6,6 +6,7 @@ Patterns adapted from rstudio-pro/e2e tests.
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 from typing import NoReturn
@@ -116,7 +117,8 @@ def user_logged_in(
 
 def _start_ide_session(session_context: dict, page: Page, ide_name: str) -> None:
     """Set session context and start a new IDE session of the given type."""
-    session_name = f"VIP {_FILENAME} - {int(time.time())}"
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    session_name = f"VIP {_FILENAME} - {worker}-{time.time_ns()}"
     session_context["name"] = session_name
     session_context["ide_type"] = ide_name
     _start_session(page, ide_name, session_name)

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -6,8 +6,6 @@ Patterns adapted from rstudio-pro/e2e tests.
 
 from __future__ import annotations
 
-import os
-import time
 from pathlib import Path
 from typing import NoReturn
 
@@ -26,6 +24,7 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_QUICK,
     TIMEOUT_SESSION_START,
     assert_homepage_loaded,
+    unique_session_name,
     workbench_login,
 )
 from vip_tests.workbench.pages import (
@@ -117,8 +116,7 @@ def user_logged_in(
 
 def _start_ide_session(session_context: dict, page: Page, ide_name: str) -> None:
     """Set session context and start a new IDE session of the given type."""
-    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
-    session_name = f"VIP {_FILENAME} - {worker}-{time.time_ns()}"
+    session_name = unique_session_name(_FILENAME)
     session_context["name"] = session_name
     session_context["ide_type"] = ide_name
     _start_session(page, ide_name, session_name)

--- a/src/vip_tests/workbench/test_packages.py
+++ b/src/vip_tests/workbench/test_packages.py
@@ -17,6 +17,7 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_QUICK,
     TIMEOUT_SESSION_START,
     assert_homepage_loaded,
+    unique_session_name,
     workbench_login,
 )
 from vip_tests.workbench.pages import (
@@ -121,7 +122,7 @@ def _execute_r_command(page: Page, command: str) -> str:
 )
 def check_r_repos(page: Page, workbench_url: str):
     """Start an RStudio session, run getOption('repos'), and return found URLs."""
-    session_name = f"VIP {_FILENAME} - {int(time.time())}"
+    session_name = unique_session_name(_FILENAME)
 
     _start_session(page, session_name)
     _wait_for_active_and_join(page, session_name)

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -6,7 +6,6 @@ Patterns adapted from test_ide_launch.py.
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
 
 import pytest
@@ -20,6 +19,7 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_QUICK,
     TIMEOUT_SESSION_START,
     assert_homepage_loaded,
+    unique_session_name,
     workbench_login,
 )
 from vip_tests.workbench.pages import Homepage, NewSessionDialog
@@ -69,7 +69,7 @@ def user_logged_in(
 @when("the user starts a new RStudio Pro session")
 def start_rstudio_pro_session(page: Page, session_context: dict):
     """Start a new RStudio Pro session without auto-joining."""
-    session_name = f"VIP {_FILENAME} - {int(time.time())}"
+    session_name = unique_session_name(_FILENAME)
     session_context["name"] = session_name
 
     page.locator(Homepage.NEW_SESSION_BUTTON).first.click(timeout=TIMEOUT_DIALOG)


### PR DESCRIPTION
## Summary

- Session names generated by `_start_ide_session` used `int(time.time())`, producing identical values across xdist workers that enter within the same second. Two concurrent tests then requested the same session row via `tr[aria-label*='…']`, hitting Playwright strict-mode: "resolved to N elements."
- Extract `unique_session_name(filename)` into `src/vip_tests/workbench/conftest.py` (worker id + `time.time_ns()`), and migrate all four Workbench tests that create sessions by name: `test_ide_launch.py`, `test_packages.py`, `test_sessions.py`, `test_data_sources.py`.
- Tighten all three session-by-name locators on `Homepage` (`session_row`, `session_rename_button`, `session_row_status`) from substring match (`*=`) to ends-with (`$=`), scoped to `tr[…]` for consistency. Workbench sets `aria-label` to `"No project: <session_name>"`, so ends-with anchors cleanly on the session name and prevents collisions when one name is a substring of another.

## Test plan

- [x] `uv run ruff check src/ selftests/`
- [x] `uv run ruff format --check src/ selftests/`
- [x] `uv run pytest selftests/ -q` — 317 passed (occasional `test_load_engine::test_1k_users` timing flake is sandbox-side and unrelated)
- [x] Inspected actual Workbench aria-label format on ganso01-staging: `"No project: VIP test_ide_launch.py - 1776873251"` — confirms ends-with match is correct.
- [x] `vip verify --workbench-url https://dev.ganso.lab.staging.posit.team --interactive-auth --categories workbench -- -k "test_launch_rstudio or test_launch_vscode"` under default parallel xdist (12 workers) — **2 passed in 37.99s**, no strict-mode violations.
- [x] Same command with `test_launch_jupyter or test_launch_positron` — tests progressed past session creation and row detection, then auto-skipped at the IDE-content step (JupyterLab/Positron not installed on ganso). Clean environmental skips confirm the session row resolves to a unique match under parallel xdist; a broken locator would have raised strict-mode errors *before* reaching the IDE iframe wait.

Fixes #215