### PR TITLE
fix(docs):  use venv in quick start instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ that can be published to a Connect server.
 ## Quick start
 
 ```bash
+uv venv
+source .venv/bin/activate
 uv pip install posit-vip
 uv run playwright install --with-deps chromium
 vip verify --connect-url https://connect.example.com --interactive-auth


### PR DESCRIPTION
Update the quickstart instructions to create a venv