### PR TITLE
chore: update gitignore with riptide artifacts and license files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,10 @@ __marimo__/
 .positai
 presentations/se-overview/index.html
 presentations/se-overview/index_files/
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/
+
+# local dev license files
+/*.lic
+


### PR DESCRIPTION
Add gitignore entries for:
- `.humanlayer/tasks/` (Riptide cloud-synced artifacts)
- `*.lic` (local dev license files)