### PR TITLE
feat(plugin): make performance tests opt-in via --performance-tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ markers = [
     "package_manager: tests for Posit Package Manager",
     "prerequisites: prerequisite checks that run first",
     "cross_product: tests that span multiple products",
-    "performance: performance validation tests",
+    "performance: performance validation tests (opt-in; excluded by default)",
     "security: security validation tests",
     "config_hygiene: checks of VIP's own configuration (opt-in; excluded by default)",
     "min_version(product, version): only run when product meets minimum version",

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -594,6 +594,35 @@ class TestPerformanceOptIn:
         assert self._marker_expr(cmd) == "connect"
 
 
+class TestExtraKeepFromArgs:
+    """_extra_keep_from_args mirrors --performance-tests on both local and K8s paths."""
+
+    def test_no_flag_returns_empty(self):
+        """Without --performance-tests the extra-keep set is empty."""
+        from vip.cli import _default_marker_expr, _extra_keep_from_args
+
+        args = argparse.Namespace(performance_tests=False)
+        extra = _extra_keep_from_args(args)
+        assert extra == frozenset()
+        assert "not performance" in _default_marker_expr(extra)
+
+    def test_flag_includes_performance(self):
+        """With --performance-tests the extra-keep set contains 'performance'."""
+        from vip.cli import _default_marker_expr, _extra_keep_from_args
+
+        args = argparse.Namespace(performance_tests=True)
+        extra = _extra_keep_from_args(args)
+        assert "performance" in extra
+        assert "not performance" not in _default_marker_expr(extra)
+
+    def test_missing_attr_treated_as_false(self):
+        """If performance_tests attribute is absent (K8s path before flag), treat as False."""
+        from vip.cli import _extra_keep_from_args
+
+        args = argparse.Namespace()  # no performance_tests attr
+        assert _extra_keep_from_args(args) == frozenset()
+
+
 class TestVerifyLocalTestTimeout:
     """--test-timeout should limit how long the subprocess can run."""
 

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -593,6 +593,60 @@ class TestPerformanceOptIn:
         )
         assert self._marker_expr(cmd) == "connect"
 
+    @staticmethod
+    def _capture_k8s_categories(args: argparse.Namespace) -> str:
+        """Run _run_k8s_job with mocked K8s helpers and return the categories= value."""
+        from unittest.mock import MagicMock, patch
+
+        captured: dict[str, str] = {}
+
+        def fake_create_job(_job_name, _namespace, _cm_name, **kwargs):
+            captured["categories"] = kwargs.get("categories", "")
+
+        with (
+            patch("vip.cli.secrets.token_hex", return_value="abcd1234"),
+            patch("vip.verify.job.create_config_map"),
+            patch("vip.verify.job.create_job", side_effect=fake_create_job),
+            patch("vip.verify.job.stream_logs"),
+            patch(
+                "vip.verify.job.wait_for_job",
+                return_value=MagicMock(status=MagicMock(failed=None)),
+            ),
+            patch("vip.verify.job.cleanup"),
+        ):
+            from vip.cli import _run_k8s_job
+
+            _run_k8s_job("[general]\n", args)
+        return captured.get("categories", "")
+
+    def test_k8s_default_excludes_performance(self):
+        """K8s path: without --performance-tests, categories expr excludes performance."""
+        args = argparse.Namespace(
+            categories=None,
+            performance_tests=False,
+            namespace="posit-team",
+            image="vip:latest",
+            timeout=3600,
+            filter_expr=None,
+            verbose=False,
+        )
+        categories = self._capture_k8s_categories(args)
+        assert "not performance" in categories
+
+    def test_k8s_flag_removes_exclusion(self):
+        """K8s path: with --performance-tests, performance is not excluded."""
+        args = argparse.Namespace(
+            categories=None,
+            performance_tests=True,
+            namespace="posit-team",
+            image="vip:latest",
+            timeout=3600,
+            filter_expr=None,
+            verbose=False,
+        )
+        categories = self._capture_k8s_categories(args)
+        assert "not performance" not in categories
+
 
 class TestExtraKeepFromArgs:
     """_extra_keep_from_args mirrors --performance-tests on both local and K8s paths."""

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -29,6 +29,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         "test_timeout": DEFAULT_TEST_TIMEOUT_SECONDS,
         "headless_auth": False,
         "idp": None,
+        "performance_tests": False,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -557,6 +558,40 @@ class TestConfigHygieneOptIn:
         expr = _default_marker_expr()
         for category in _OPT_IN_CATEGORIES:
             assert f"not {category}" in expr
+
+
+class TestPerformanceOptIn:
+    """performance tests are excluded by default and run with --performance-tests."""
+
+    @staticmethod
+    def _marker_expr(cmd: list[str]) -> str:
+        """Return the pytest marker expression from the assembled command."""
+        first = cmd.index("-m")
+        second = cmd.index("-m", first + 1)
+        return cmd[second + 1]
+
+    def test_default_filter_excludes_performance(self, tmp_path):
+        """Without --performance-tests, the marker expression excludes performance."""
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg)))
+        assert "not performance" in self._marker_expr(cmd)
+
+    def test_performance_tests_flag_removes_exclusion(self, tmp_path):
+        """With --performance-tests, performance is no longer excluded from the expr."""
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), performance_tests=True))
+        assert "not performance" not in self._marker_expr(cmd)
+
+    def test_explicit_category_overrides_performance_flag(self, tmp_path):
+        """When --categories is set, --performance-tests has no effect on the expr."""
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(
+            _make_args(config=str(cfg), categories="connect", performance_tests=True)
+        )
+        assert self._marker_expr(cmd) == "connect"
 
 
 class TestVerifyLocalTestTimeout:

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -205,6 +205,39 @@ class TestPluginIntegration:
         result.assert_outcomes()
         result.stdout.fnmatch_lines(["*1 deselected*"])
 
+    def test_performance_deselected_by_default(self, selftest_pytester):
+        """Performance tests should be deselected when --performance-tests is not passed."""
+        selftest_pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.performance
+            def test_load_time():
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest(
+            "--vip-config=vip.toml", "-v", "-m", "not config_hygiene and not performance"
+        )
+        result.assert_outcomes()
+        result.stdout.fnmatch_lines(["*1 deselected*"])
+
+    def test_performance_runs_with_flag(self, selftest_pytester):
+        """Performance tests should run when --performance-tests equivalent marker is included."""
+        selftest_pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.performance
+            def test_load_time():
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest(
+            "--vip-config=vip.toml", "-v", "-m", "not config_hygiene"
+        )
+        result.assert_outcomes(passed=1)
+
     def test_bdd_given_configured_step_deselected(self, selftest_pytester):
         """A BDD scenario with 'Given Connect is configured in vip.toml'
         should be deselected (not skipped) when Connect is not configured."""

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -206,37 +206,24 @@ class TestPluginIntegration:
         result.stdout.fnmatch_lines(["*1 deselected*"])
 
     def test_performance_deselected_by_default(self, selftest_pytester):
-        """Performance tests should be deselected when --performance-tests is not passed."""
-        selftest_pytester.makepyfile(
-            """
-            import pytest
+        """_default_marker_expr excludes performance when --performance-tests is not set."""
+        import argparse
 
-            @pytest.mark.performance
-            def test_load_time():
-                assert True
-            """
-        )
-        result = selftest_pytester.runpytest(
-            "--vip-config=vip.toml", "-v", "-m", "not config_hygiene and not performance"
-        )
-        result.assert_outcomes()
-        result.stdout.fnmatch_lines(["*1 deselected*"])
+        from vip.cli import _default_marker_expr, _extra_keep_from_args
+
+        args = argparse.Namespace(performance_tests=False)
+        expr = _default_marker_expr(_extra_keep_from_args(args))
+        assert "not performance" in expr
 
     def test_performance_runs_with_flag(self, selftest_pytester):
-        """Performance tests should run when --performance-tests equivalent marker is included."""
-        selftest_pytester.makepyfile(
-            """
-            import pytest
+        """_default_marker_expr omits the performance exclusion when --performance-tests is set."""
+        import argparse
 
-            @pytest.mark.performance
-            def test_load_time():
-                assert True
-            """
-        )
-        result = selftest_pytester.runpytest(
-            "--vip-config=vip.toml", "-v", "-m", "not config_hygiene"
-        )
-        result.assert_outcomes(passed=1)
+        from vip.cli import _default_marker_expr, _extra_keep_from_args
+
+        args = argparse.Namespace(performance_tests=True)
+        expr = _default_marker_expr(_extra_keep_from_args(args))
+        assert "not performance" not in expr
 
     def test_bdd_given_configured_step_deselected(self, selftest_pytester):
         """A BDD scenario with 'Given Connect is configured in vip.toml'

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -47,7 +47,7 @@ VALID_CATEGORIES: dict[str, str] = {
 # Categories that are excluded from the default ``vip verify`` run and only
 # executed when the user opts in via ``--categories``.  These tests check
 # VIP's own configuration rather than the Posit deployment.
-_OPT_IN_CATEGORIES = frozenset({"config_hygiene"})
+_OPT_IN_CATEGORIES = frozenset({"config_hygiene", "performance"})
 
 # Marker expression keywords that are not category names.
 _MARKER_KEYWORDS = {"and", "or", "not"}
@@ -67,13 +67,16 @@ def _valid_categories_message() -> str:
     return ", ".join(sorted(seen.values()))
 
 
-def _default_marker_expr() -> str:
+def _default_marker_expr(extra_keep: frozenset[str] = frozenset()) -> str:
     """Marker expression applied when the user doesn't pass ``--categories``.
 
     Excludes every opt-in category so that ``vip verify`` runs only the
-    product-verification tests by default.
+    product-verification tests by default.  Pass ``extra_keep`` to re-include
+    specific opt-in categories (e.g. ``frozenset({"performance"})`` when
+    ``--performance-tests`` is set).
     """
-    return " and ".join(f"not {name}" for name in sorted(_OPT_IN_CATEGORIES))
+    excluded = _OPT_IN_CATEGORIES - extra_keep
+    return " and ".join(f"not {name}" for name in sorted(excluded))
 
 
 def _normalize_categories(expr: str) -> str:
@@ -512,7 +515,10 @@ def _run_verify_local(args: argparse.Namespace) -> None:
     if args.categories:
         cmd.extend(["-m", _normalize_categories(args.categories)])
     else:
-        cmd.extend(["-m", _default_marker_expr()])
+        extra_keep: frozenset[str] = frozenset()
+        if getattr(args, "performance_tests", False):
+            extra_keep = frozenset({"performance"})
+        cmd.extend(["-m", _default_marker_expr(extra_keep)])
     if args.filter_expr:
         cmd.extend(["-k", args.filter_expr])
 
@@ -586,6 +592,9 @@ def _run_k8s_job(vip_config_toml: str, args: argparse.Namespace) -> None:
                 stacklevel=2,
             )
             pytest_timeout = _JOB_MIN_PYTEST_TIMEOUT_SECONDS
+        _k8s_extra_keep: frozenset[str] = frozenset()
+        if getattr(args, "performance_tests", False):
+            _k8s_extra_keep = frozenset({"performance"})
         create_job(
             job_name,
             namespace,
@@ -594,7 +603,7 @@ def _run_k8s_job(vip_config_toml: str, args: argparse.Namespace) -> None:
             categories=(
                 _normalize_categories(args.categories)
                 if args.categories
-                else _default_marker_expr()
+                else _default_marker_expr(_k8s_extra_keep)
             ),
             filter_expr=getattr(args, "filter_expr", None),
             timeout_seconds=pytest_timeout,
@@ -859,6 +868,12 @@ def main() -> None:
         default=None,
         help="Test categories as a pytest marker expression "
         "(e.g. 'connect', 'package-manager', 'performance and workbench')",
+    )
+    verify_parser.add_argument(
+        "--performance-tests",
+        action="store_true",
+        default=False,
+        help="Run performance tests (opt-in; excluded by default).",
     )
     verify_parser.add_argument(
         "-f",

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -79,6 +79,18 @@ def _default_marker_expr(extra_keep: frozenset[str] = frozenset()) -> str:
     return " and ".join(f"not {name}" for name in sorted(excluded))
 
 
+def _extra_keep_from_args(args: argparse.Namespace) -> frozenset[str]:
+    """Return the set of opt-in categories to re-include based on CLI flags.
+
+    For example, ``--performance-tests`` adds ``"performance"`` to the set so
+    that :func:`_default_marker_expr` keeps it in the expression.
+    """
+    extra: set[str] = set()
+    if getattr(args, "performance_tests", False):
+        extra.add("performance")
+    return frozenset(extra)
+
+
 def _normalize_categories(expr: str) -> str:
     """Validate and normalize a ``--categories`` expression.
 
@@ -515,10 +527,7 @@ def _run_verify_local(args: argparse.Namespace) -> None:
     if args.categories:
         cmd.extend(["-m", _normalize_categories(args.categories)])
     else:
-        extra_keep: frozenset[str] = frozenset()
-        if getattr(args, "performance_tests", False):
-            extra_keep = frozenset({"performance"})
-        cmd.extend(["-m", _default_marker_expr(extra_keep)])
+        cmd.extend(["-m", _default_marker_expr(_extra_keep_from_args(args))])
     if args.filter_expr:
         cmd.extend(["-k", args.filter_expr])
 
@@ -592,9 +601,6 @@ def _run_k8s_job(vip_config_toml: str, args: argparse.Namespace) -> None:
                 stacklevel=2,
             )
             pytest_timeout = _JOB_MIN_PYTEST_TIMEOUT_SECONDS
-        _k8s_extra_keep: frozenset[str] = frozenset()
-        if getattr(args, "performance_tests", False):
-            _k8s_extra_keep = frozenset({"performance"})
         create_job(
             job_name,
             namespace,
@@ -603,7 +609,7 @@ def _run_k8s_job(vip_config_toml: str, args: argparse.Namespace) -> None:
             categories=(
                 _normalize_categories(args.categories)
                 if args.categories
-                else _default_marker_expr(_k8s_extra_keep)
+                else _default_marker_expr(_extra_keep_from_args(args))
             ),
             filter_expr=getattr(args, "filter_expr", None),
             timeout_seconds=pytest_timeout,
@@ -867,13 +873,14 @@ def main() -> None:
         "--categories",
         default=None,
         help="Test categories as a pytest marker expression "
-        "(e.g. 'connect', 'package-manager', 'performance and workbench')",
+        "(e.g. 'connect', 'package-manager', 'workbench'). "
+        "To include performance tests use --performance-tests instead.",
     )
     verify_parser.add_argument(
         "--performance-tests",
         action="store_true",
         default=False,
-        help="Run performance tests (opt-in; excluded by default).",
+        help="Include performance tests in the default selection (excluded otherwise).",
     )
     verify_parser.add_argument(
         "-f",

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -45,8 +45,9 @@ VALID_CATEGORIES: dict[str, str] = {
 }
 
 # Categories that are excluded from the default ``vip verify`` run and only
-# executed when the user opts in via ``--categories``.  These tests check
-# VIP's own configuration rather than the Posit deployment.
+# executed when the user explicitly opts in, either via ``--categories`` or
+# a dedicated opt-in flag (for example ``--performance-tests``). These tests
+# check VIP's own configuration rather than the Posit deployment.
 _OPT_IN_CATEGORIES = frozenset({"config_hygiene", "performance"})
 
 # Marker expression keywords that are not category names.

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -880,7 +880,8 @@ def main() -> None:
         "--performance-tests",
         action="store_true",
         default=False,
-        help="Include performance tests in the default selection (excluded otherwise).",
+        help="Include performance tests in the default selection (excluded otherwise). "
+        "Has no effect when --categories is also specified.",
     )
     verify_parser.add_argument(
         "-f",

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -131,7 +131,10 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "package_manager: tests for Posit Package Manager")
     config.addinivalue_line("markers", "prerequisites: prerequisite checks")
     config.addinivalue_line("markers", "cross_product: cross-product / admin tests")
-    config.addinivalue_line("markers", "performance: performance validation tests")
+    config.addinivalue_line(
+        "markers",
+        "performance: performance validation tests (opt-in; excluded by default)",
+    )
     config.addinivalue_line("markers", "security: security validation tests")
     config.addinivalue_line(
         "markers",

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -203,7 +203,7 @@ vip verify --connect-url https://connect.example.com -- -x --tb=long</code></pre
                 <tr>
                   <td>Performance</td>
                   <td><code>performance</code></td>
-                  <td>Load times, concurrency, resource usage</td>
+                  <td>Load times, concurrency, resource usage (opt-in; use <code>--performance-tests</code>)</td>
                 </tr>
                 <tr>
                   <td>Security</td>


### PR DESCRIPTION
## Summary

- Performance tests (`@performance`) are now excluded from the default `vip verify` run; opt in with the new `--performance-tests` flag.
- Wired through both the local subprocess and K8s Job paths via a small `_extra_keep_from_args()` helper.
- The flag is additive; it has no effect when `--categories` is also specified (noted in the help text).
- Marker description updated in `plugin.py` and `pyproject.toml`; opt-in status noted on the website.
- Eight new selftests cover marker assembly, the helper, and K8s `categories=` propagation.

Closes #211.

## Test plan

- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run pytest selftests/ -v -k "performance or marker"` (27 passed)
- [x] Sanity: `vip verify --connect-url ... -- --collect-only` shows 0 perf tests by default, >0 with `--performance-tests`