### PR TITLE
feat(cli): add --insecure and --ca-bundle for self-signed CAs

### DIFF
--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -858,7 +858,7 @@ class TestHeadlessAuthTLSFlags:
         assert kwargs.get("ignore_https_errors") is True
 
     def test_no_insecure_does_not_set_ignore_https_errors(self):
-        """Without insecure, new_context should not receive ignore_https_errors=True."""
+        """Without insecure, new_context must receive ignore_https_errors=False."""
         stub = self._make_playwright_stub()
         browser = stub.start.return_value.chromium.launch.return_value
 
@@ -873,12 +873,11 @@ class TestHeadlessAuthTLSFlags:
 
         browser.new_context.assert_called_once()
         kwargs = browser.new_context.call_args.kwargs
-        assert not kwargs.get("ignore_https_errors")
+        assert kwargs.get("ignore_https_errors") is False
 
     def test_ca_bundle_sets_node_extra_ca_certs(self, tmp_path, monkeypatch):
         """ca_bundle must set NODE_EXTRA_CA_CERTS before sync_playwright().start()."""
         import os
-
         from pathlib import Path
 
         ca_file = tmp_path / "ca.pem"
@@ -914,7 +913,6 @@ class TestHeadlessAuthTLSFlags:
     def test_ca_bundle_env_restored_after_call(self, tmp_path, monkeypatch):
         """NODE_EXTRA_CA_CERTS must be restored to its prior value after auth."""
         import os
-
         from pathlib import Path
 
         ca_file = tmp_path / "ca.pem"

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -874,3 +874,63 @@ class TestHeadlessAuthTLSFlags:
         browser.new_context.assert_called_once()
         kwargs = browser.new_context.call_args.kwargs
         assert not kwargs.get("ignore_https_errors")
+
+    def test_ca_bundle_sets_node_extra_ca_certs(self, tmp_path, monkeypatch):
+        """ca_bundle must set NODE_EXTRA_CA_CERTS before sync_playwright().start()."""
+        import os
+
+        from pathlib import Path
+
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("# fake CA")
+
+        stub = self._make_playwright_stub()
+        captured: list[str | None] = []
+
+        original_start = stub.start
+
+        def capturing_start():
+            captured.append(os.environ.get("NODE_EXTRA_CA_CERTS"))
+            return original_start()
+
+        stub.start = capturing_start
+
+        monkeypatch.delenv("NODE_EXTRA_CA_CERTS", raising=False)
+
+        with patch("vip.auth.sync_playwright", return_value=stub):
+            with pytest.raises(Exception):
+                start_headless_auth(
+                    connect_url="https://c.example.com",
+                    username="user",
+                    password="pass",
+                    ca_bundle=Path(ca_file),
+                )
+
+        assert len(captured) == 1
+        assert captured[0] == str(ca_file)
+        # Verify env is restored after the call
+        assert os.environ.get("NODE_EXTRA_CA_CERTS") is None
+
+    def test_ca_bundle_env_restored_after_call(self, tmp_path, monkeypatch):
+        """NODE_EXTRA_CA_CERTS must be restored to its prior value after auth."""
+        import os
+
+        from pathlib import Path
+
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("# fake CA")
+        prev_value = "/prior/ca.pem"
+        monkeypatch.setenv("NODE_EXTRA_CA_CERTS", prev_value)
+
+        stub = self._make_playwright_stub()
+
+        with patch("vip.auth.sync_playwright", return_value=stub):
+            with pytest.raises(Exception):
+                start_headless_auth(
+                    connect_url="https://c.example.com",
+                    username="user",
+                    password="pass",
+                    ca_bundle=Path(ca_file),
+                )
+
+        assert os.environ.get("NODE_EXTRA_CA_CERTS") == prev_value

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -216,7 +216,9 @@ class TestInteractiveAuthSessionCleanup:
         with patch("vip.auth._delete_api_key") as deleter:
             session.cleanup()
 
-        deleter.assert_called_once_with("https://c.example.com", "LIVE", "_vip_interactive_1")
+        deleter.assert_called_once_with(
+            "https://c.example.com", "LIVE", "_vip_interactive_1", insecure=False, ca_bundle=None
+        )
 
     def test_deletes_when_cache_state_file_is_missing(self, tmp_path):
         """Meta without state is stale metadata — there is no cache the next
@@ -248,7 +250,9 @@ class TestInteractiveAuthSessionCleanup:
         with patch("vip.auth._delete_api_key") as deleter:
             session.cleanup()
 
-        deleter.assert_called_once_with("https://c.example.com", "LIVE", "_vip_interactive_1")
+        deleter.assert_called_once_with(
+            "https://c.example.com", "LIVE", "_vip_interactive_1", insecure=False, ca_bundle=None
+        )
 
     def test_deletes_when_cache_state_file_is_malformed(self, tmp_path):
         """A corrupted cache state file is unusable — Playwright will fail to
@@ -276,7 +280,9 @@ class TestInteractiveAuthSessionCleanup:
         with patch("vip.auth._delete_api_key") as deleter:
             session.cleanup()
 
-        deleter.assert_called_once_with("https://c.example.com", "LIVE", "_vip_interactive_1")
+        deleter.assert_called_once_with(
+            "https://c.example.com", "LIVE", "_vip_interactive_1", insecure=False, ca_bundle=None
+        )
 
     def test_deletes_when_cache_references_a_different_key(self, tmp_path):
         """Concurrent run overwrote the cache with its own key → our key is
@@ -286,7 +292,9 @@ class TestInteractiveAuthSessionCleanup:
         with patch("vip.auth._delete_api_key") as deleter:
             session.cleanup()
 
-        deleter.assert_called_once_with("https://c.example.com", "MINE", "_vip_interactive_1")
+        deleter.assert_called_once_with(
+            "https://c.example.com", "MINE", "_vip_interactive_1", insecure=False, ca_bundle=None
+        )
 
     def test_deletes_when_session_has_no_cache_path(self, tmp_path):
         """Sessions created outside the caching flow (``_cache_path`` unset)
@@ -305,7 +313,9 @@ class TestInteractiveAuthSessionCleanup:
         with patch("vip.auth._delete_api_key") as deleter:
             session.cleanup()
 
-        deleter.assert_called_once_with("https://c.example.com", "LIVE", "_vip_interactive_1")
+        deleter.assert_called_once_with(
+            "https://c.example.com", "LIVE", "_vip_interactive_1", insecure=False, ca_bundle=None
+        )
 
 
 class TestAuthenticateWorkbench:
@@ -813,3 +823,54 @@ class TestCreateApiKeyViaSession:
         assert result == "K" * 30
         assert req.get.called, "GET /v1/user must route through page.context.request"
         assert req.post.call_args.kwargs["headers"]["X-Rsc-Xsrf"] == "live-token"
+
+
+class TestHeadlessAuthTLSFlags:
+    """start_headless_auth passes TLS config to browser.new_context()."""
+
+    def _make_playwright_stub(self) -> MagicMock:
+        """Stub sync_playwright() that raises PlaywrightTimeoutError on goto
+        (so the test terminates quickly without completing auth)."""
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+        pw = MagicMock()
+        browser = pw.start.return_value.chromium.launch.return_value
+        page = browser.new_context.return_value.new_page.return_value
+        page.goto.side_effect = PlaywrightTimeoutError("stub timeout")
+        return pw
+
+    def test_insecure_passes_ignore_https_errors(self):
+        """insecure=True must call new_context(ignore_https_errors=True)."""
+        stub = self._make_playwright_stub()
+        browser = stub.start.return_value.chromium.launch.return_value
+
+        with patch("vip.auth.sync_playwright", return_value=stub):
+            with pytest.raises(Exception):  # timeout or AuthConfigError
+                start_headless_auth(
+                    connect_url="https://c.example.com",
+                    username="user",
+                    password="pass",
+                    insecure=True,
+                )
+
+        browser.new_context.assert_called_once()
+        kwargs = browser.new_context.call_args.kwargs
+        assert kwargs.get("ignore_https_errors") is True
+
+    def test_no_insecure_does_not_set_ignore_https_errors(self):
+        """Without insecure, new_context should not receive ignore_https_errors=True."""
+        stub = self._make_playwright_stub()
+        browser = stub.start.return_value.chromium.launch.return_value
+
+        with patch("vip.auth.sync_playwright", return_value=stub):
+            with pytest.raises(Exception):
+                start_headless_auth(
+                    connect_url="https://c.example.com",
+                    username="user",
+                    password="pass",
+                    insecure=False,
+                )
+
+        browser.new_context.assert_called_once()
+        kwargs = browser.new_context.call_args.kwargs
+        assert not kwargs.get("ignore_https_errors")

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -843,3 +843,27 @@ class TestVerifyLocalTLSFlags:
             assert "[tls]" not in content
         finally:
             Path(path).unlink(missing_ok=True)
+
+    def test_both_insecure_and_ca_bundle_emits_warning(self, tmp_path, monkeypatch):
+        """Passing both --insecure and --ca-bundle must emit a UserWarning."""
+        import warnings
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        bundle = tmp_path / "ca.pem"
+        bundle.write_text("fake-pem")
+        from vip.cli import _generate_temp_config
+
+        path = None
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                path = _generate_temp_config(
+                    _make_args(connect_url="https://c.example.com", insecure=True, ca_bundle=bundle)
+                )
+            assert any("--insecure" in str(warning.message) for warning in w), (
+                "Expected a UserWarning about --insecure and --ca-bundle"
+            )
+        finally:
+            if path:
+                Path(path).unlink(missing_ok=True)

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -867,3 +867,39 @@ class TestVerifyLocalTLSFlags:
         finally:
             if path:
                 Path(path).unlink(missing_ok=True)
+
+    def test_insecure_omits_ca_bundle_from_temp_config(self, tmp_path, monkeypatch):
+        """When --insecure is set, ca_bundle must NOT be written to the temp config.
+
+        load_config() validates ca_bundle existence; writing a nonexistent path
+        when the user passes --insecure --ca-bundle <missing> would fail
+        validation despite the user's intent to skip TLS verification entirely.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        # Deliberately use a *missing* file to prove validation is not triggered.
+        missing_bundle = tmp_path / "does_not_exist.pem"
+        from vip.cli import _generate_temp_config
+
+        path = None
+        try:
+            import warnings
+
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                path = _generate_temp_config(
+                    _make_args(
+                        connect_url="https://c.example.com",
+                        insecure=True,
+                        ca_bundle=missing_bundle,
+                    )
+                )
+            content = Path(path).read_text()
+            assert "ca_bundle" not in content, (
+                "ca_bundle must not appear in the temp config when --insecure is set"
+            )
+            # insecure=true must still be present
+            assert "insecure = true" in content
+        finally:
+            if path:
+                Path(path).unlink(missing_ok=True)

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -29,6 +29,8 @@ def _make_args(**overrides) -> argparse.Namespace:
         "test_timeout": DEFAULT_TEST_TIMEOUT_SECONDS,
         "headless_auth": False,
         "idp": None,
+        "insecure": False,
+        "ca_bundle": None,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -790,5 +792,54 @@ class TestAuthCliFlags:
             cfg = load_config(path)
             assert cfg.auth.idp == "keycloak"
             assert cfg.auth.provider == "oidc"
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+
+class TestVerifyLocalTLSFlags:
+    """--insecure and --ca-bundle are encoded in the temp config."""
+
+    def test_insecure_written_to_temp_config(self, tmp_path, monkeypatch):
+        """--insecure=True is written to the generated temp TOML."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import _generate_temp_config
+        from vip.config import load_config
+
+        path = _generate_temp_config(_make_args(connect_url="https://c.example.com", insecure=True))
+        try:
+            cfg = load_config(path)
+            assert cfg.insecure is True
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_ca_bundle_written_to_temp_config(self, tmp_path, monkeypatch):
+        """--ca-bundle path is written to the generated temp TOML."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        bundle = tmp_path / "ca.pem"
+        bundle.write_text("fake-pem")
+        from vip.cli import _generate_temp_config
+        from vip.config import load_config
+
+        path = _generate_temp_config(
+            _make_args(connect_url="https://c.example.com", ca_bundle=bundle)
+        )
+        try:
+            cfg = load_config(path)
+            assert cfg.ca_bundle == bundle
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_no_tls_section_when_flags_absent(self, tmp_path, monkeypatch):
+        """When neither --insecure nor --ca-bundle is passed, no [tls] section."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import _generate_temp_config
+
+        path = _generate_temp_config(_make_args(connect_url="https://c.example.com"))
+        try:
+            content = Path(path).read_text()
+            assert "[tls]" not in content
         finally:
             Path(path).unlink(missing_ok=True)

--- a/selftests/test_clients_connect.py
+++ b/selftests/test_clients_connect.py
@@ -208,3 +208,67 @@ def test_fetch_content_allows_explicit_default_port(monkeypatch):
 
     assert resp.status_code == 200
     assert resp.content == expected_body
+
+
+# ---------------------------------------------------------------------------
+# TLS configuration round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def test_connect_client_verify_false_when_insecure(monkeypatch):
+    """ConnectClient with insecure=True passes verify=False to httpx.get."""
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+    captured: list[dict] = []
+
+    def fake_get(url, **kwargs):
+        captured.append(kwargs)
+        return _make_response(200, url=url, body=b"ok")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="key", insecure=True)
+    client.fetch_content(initial_url)
+
+    assert captured, "httpx.get was not called"
+    assert captured[0].get("verify") is False
+
+
+def test_connect_client_verify_ca_bundle(monkeypatch, tmp_path):
+    """ConnectClient with ca_bundle set passes verify=<path> to httpx.get."""
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("fake-pem")
+    captured: list[dict] = []
+
+    def fake_get(url, **kwargs):
+        captured.append(kwargs)
+        return _make_response(200, url=url, body=b"ok")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="key", ca_bundle=bundle)
+    client.fetch_content(initial_url)
+
+    assert captured, "httpx.get was not called"
+    assert captured[0].get("verify") == str(bundle)
+
+
+def test_connect_client_verify_true_by_default(monkeypatch):
+    """ConnectClient without TLS flags passes verify=True to httpx.get."""
+    base_url = "https://connect.example.com"
+    initial_url = f"{base_url}/content/abc/"
+    captured: list[dict] = []
+
+    def fake_get(url, **kwargs):
+        captured.append(kwargs)
+        return _make_response(200, url=url, body=b"ok")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = ConnectClient(base_url=base_url, api_key="key")
+    client.fetch_content(initial_url)
+
+    assert captured, "httpx.get was not called"
+    assert captured[0].get("verify") is True

--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -411,6 +411,12 @@ class TestLoadConfigTLS:
         assert cfg.insecure is False
         assert cfg.ca_bundle is None
 
+    def test_ca_bundle_missing_file_raises_valueerror(self, tmp_toml):
+        """_resolve_ca_bundle must raise ValueError for a non-existent path."""
+        path = tmp_toml('[tls]\nca_bundle = "/nonexistent/path/ca.pem"\n')
+        with pytest.raises(ValueError, match="ca_bundle path does not exist"):
+            load_config(path)
+
 
 class TestMode:
     def test_enum_values(self):

--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -135,6 +135,26 @@ class TestPerformanceConfig:
         assert pc.load_test_spawn_rate == 20
 
 
+class TestVIPConfigTLS:
+    def test_insecure_default(self):
+        cfg = VIPConfig()
+        assert cfg.insecure is False
+
+    def test_ca_bundle_default(self):
+        cfg = VIPConfig()
+        assert cfg.ca_bundle is None
+
+    def test_insecure_explicit(self):
+        cfg = VIPConfig(insecure=True)
+        assert cfg.insecure is True
+
+    def test_ca_bundle_explicit(self, tmp_path):
+        bundle = tmp_path / "ca.pem"
+        bundle.write_text("fake-pem")
+        cfg = VIPConfig(ca_bundle=bundle)
+        assert cfg.ca_bundle == bundle
+
+
 class TestVIPConfig:
     def test_product_config_lookup(self):
         cfg = VIPConfig(
@@ -362,6 +382,34 @@ policy_checks_enabled = true
         assert cfg.email_enabled is True
         assert cfg.monitoring_enabled is True
         assert cfg.security_policy_checks_enabled is True
+
+
+class TestLoadConfigTLS:
+    def test_tls_defaults_when_section_missing(self, tmp_toml):
+        path = tmp_toml('[general]\ndeployment_name = "Test"\n')
+        cfg = load_config(path)
+        assert cfg.insecure is False
+        assert cfg.ca_bundle is None
+
+    def test_insecure_from_toml(self, tmp_toml):
+        path = tmp_toml("[tls]\ninsecure = true\n")
+        cfg = load_config(path)
+        assert cfg.insecure is True
+
+    def test_ca_bundle_from_toml(self, tmp_toml, tmp_path):
+        bundle = tmp_path / "corp-ca.pem"
+        bundle.write_text("fake-pem")
+        path = tmp_toml(f'[tls]\nca_bundle = "{bundle}"\n')
+        cfg = load_config(path)
+        from pathlib import Path
+
+        assert cfg.ca_bundle == Path(str(bundle))
+
+    def test_insecure_false_by_default_in_tls_section(self, tmp_toml):
+        path = tmp_toml("[tls]\n# empty section\n")
+        cfg = load_config(path)
+        assert cfg.insecure is False
+        assert cfg.ca_bundle is None
 
 
 class TestMode:

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -269,6 +269,7 @@ def start_interactive_auth(
 
     pw = None
     browser = None
+    _prev_node_ca = os.environ.get("NODE_EXTRA_CA_CERTS")
     if ca_bundle is not None:
         os.environ["NODE_EXTRA_CA_CERTS"] = str(ca_bundle)
     try:
@@ -360,6 +361,13 @@ def start_interactive_auth(
                 pw.stop()
             except Exception:
                 pass
+        # Restore NODE_EXTRA_CA_CERTS to its previous value so subsequent
+        # auth calls (or test runs) are not silently affected.
+        if ca_bundle is not None:
+            if _prev_node_ca is None:
+                os.environ.pop("NODE_EXTRA_CA_CERTS", None)
+            else:
+                os.environ["NODE_EXTRA_CA_CERTS"] = _prev_node_ca
 
 
 _IDP_PROVIDERS = frozenset({"oidc", "saml", "oauth2"})
@@ -443,6 +451,7 @@ def start_headless_auth(
 
     pw = None
     browser = None
+    _prev_node_ca = os.environ.get("NODE_EXTRA_CA_CERTS")
     if ca_bundle is not None:
         os.environ["NODE_EXTRA_CA_CERTS"] = str(ca_bundle)
     try:
@@ -524,6 +533,13 @@ def start_headless_auth(
                 pw.stop()
             except Exception:
                 pass
+        # Restore NODE_EXTRA_CA_CERTS to its previous value so subsequent
+        # auth calls (or test runs) are not silently affected.
+        if ca_bundle is not None:
+            if _prev_node_ca is None:
+                os.environ.pop("NODE_EXTRA_CA_CERTS", None)
+            else:
+                os.environ["NODE_EXTRA_CA_CERTS"] = _prev_node_ca
 
 
 def _navigate_to_idp(page: Page, product_url: str) -> None:

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -90,6 +90,8 @@ class InteractiveAuthSession:
     _connect_url: str = field(default="", repr=False)
     _tmpdir: str = field(default="", repr=False)
     _cache_path: Path | None = field(default=None, repr=False)
+    _insecure: bool = field(default=False, repr=False)
+    _ca_bundle: Path | None = field(default=None, repr=False)
 
     def _cache_references_this_key(self) -> bool:
         """True when the on-disk cache still points at our ``api_key``.
@@ -129,7 +131,13 @@ class InteractiveAuthSession:
         """Delete the minted API key and remove the temp directory."""
         if self.api_key and self._connect_url and not self._cache_references_this_key():
             try:
-                _delete_api_key(self._connect_url, self.api_key, self.key_name)
+                _delete_api_key(
+                    self._connect_url,
+                    self.api_key,
+                    self.key_name,
+                    insecure=self._insecure,
+                    ca_bundle=self._ca_bundle,
+                )
             except Exception as exc:
                 print(f">>> Warning: Could not delete API key: {exc}")
 
@@ -212,6 +220,8 @@ def start_interactive_auth(
     connect_url: str | None = None,
     workbench_url: str | None = None,
     cache_path: Path | None = None,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
 ) -> InteractiveAuthSession:
     """Launch a headed browser, authenticate via OIDC, and optionally
     mint a Connect API key through the UI.
@@ -229,6 +239,11 @@ def start_interactive_auth(
 
     The browser is closed before this function returns.  pytest-playwright
     creates its own browser instance using the saved storage state.
+
+    When *insecure* is ``True``, Playwright ignores TLS certificate errors.
+    When *ca_bundle* is set, the path is exported as ``NODE_EXTRA_CA_CERTS``
+    before launching Chromium so it trusts a custom CA (Chromium-level trust
+    only; this does not update the OS certificate store).
     """
     if not connect_url and not workbench_url:
         raise ValueError(
@@ -254,10 +269,12 @@ def start_interactive_auth(
 
     pw = None
     browser = None
+    if ca_bundle is not None:
+        os.environ["NODE_EXTRA_CA_CERTS"] = str(ca_bundle)
     try:
         pw = sync_playwright().start()
         browser = _launch_chromium(pw, headless=False)
-        context = browser.new_context()
+        context = browser.new_context(ignore_https_errors=insecure)
         page = context.new_page()
 
         page.goto(f"{primary_url}{login_path}")
@@ -319,6 +336,8 @@ def start_interactive_auth(
             _connect_url=connect_url or "",
             _tmpdir=tmpdir,
             _cache_path=cache_path,
+            _insecure=insecure,
+            _ca_bundle=ca_bundle,
         )
 
         # Cache the session for reuse across runs.
@@ -355,6 +374,8 @@ def start_headless_auth(
     password: str = "",
     cache_path: Path | None = None,
     verbose: bool = False,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
 ) -> InteractiveAuthSession:
     """Launch a headless browser, automate OIDC login, and optionally
     mint a Connect API key through the UI.
@@ -367,6 +388,11 @@ def start_headless_auth(
     At least one of *connect_url* or *workbench_url* must be provided.
     The *idp* parameter selects which form automation strategy to use
     (e.g. ``"keycloak"``, ``"okta"``).
+
+    When *insecure* is ``True``, Playwright ignores TLS certificate errors.
+    When *ca_bundle* is set, the path is exported as ``NODE_EXTRA_CA_CERTS``
+    before launching Chromium so it trusts a custom CA (Chromium-level trust
+    only; this does not update the OS certificate store).
     """
     import vip.idp as _idp_mod
 
@@ -417,10 +443,12 @@ def start_headless_auth(
 
     pw = None
     browser = None
+    if ca_bundle is not None:
+        os.environ["NODE_EXTRA_CA_CERTS"] = str(ca_bundle)
     try:
         pw = sync_playwright().start()
         browser = _launch_chromium(pw, headless=True)
-        context = browser.new_context()
+        context = browser.new_context(ignore_https_errors=insecure)
         page = context.new_page()
 
         from vip.idp import _log_verbose, _sanitize_url
@@ -473,6 +501,8 @@ def start_headless_auth(
             _connect_url=connect_url or "",
             _tmpdir=tmpdir,
             _cache_path=cache_path,
+            _insecure=insecure,
+            _ca_bundle=ca_bundle,
         )
 
         if cache_path:
@@ -673,15 +703,30 @@ def _authenticate_workbench(page: Page, workbench_url: str) -> None:
     )
 
 
-def _delete_api_key(connect_url: str, api_key: str, key_name: str) -> None:
+def _delete_api_key(
+    connect_url: str,
+    api_key: str,
+    key_name: str,
+    *,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
+) -> None:
     """Delete the VIP API key using the key itself for authentication."""
     import httpx
+
+    if insecure:
+        verify: bool | str = False
+    elif ca_bundle is not None:
+        verify = str(ca_bundle)
+    else:
+        verify = True
 
     base = connect_url.rstrip("/")
     with httpx.Client(
         base_url=f"{base}/__api__",
         headers={"Authorization": f"Key {api_key}"},
         timeout=10.0,
+        verify=verify,
     ) as client:
         for keys_path in ("/v1/user/api_keys", "/keys"):
             resp = client.get(keys_path)

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -354,6 +354,16 @@ def _generate_temp_config(args: argparse.Namespace) -> str:
             lines.append(f'idp = "{idp}"')
         lines.append("")
 
+    insecure = getattr(args, "insecure", False)
+    ca_bundle = getattr(args, "ca_bundle", None)
+    if insecure or ca_bundle:
+        lines.append("[tls]")
+        if insecure:
+            lines.append("insecure = true")
+        if ca_bundle:
+            lines.append(f'ca_bundle = "{ca_bundle}"')
+        lines.append("")
+
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
         f.write("\n".join(lines) + "\n")
         return f.name
@@ -817,6 +827,32 @@ def main() -> None:
     url_group.add_argument("--connect-url", default=None, help="Connect server URL")
     url_group.add_argument("--workbench-url", default=None, help="Workbench server URL")
     url_group.add_argument("--package-manager-url", default=None, help="Package Manager server URL")
+
+    # TLS configuration
+    tls_group = verify_parser.add_argument_group("TLS configuration")
+    tls_group.add_argument(
+        "--insecure",
+        action="store_true",
+        default=False,
+        help=(
+            "Disable TLS certificate verification (equivalent to curl -k). "
+            "Use only in trusted environments; this silently ignores certificate errors. "
+            "For Playwright browser contexts, this sets ignore_https_errors=True. "
+            "Note: --ca-bundle is preferred when you have a custom CA certificate."
+        ),
+    )
+    tls_group.add_argument(
+        "--ca-bundle",
+        default=None,
+        metavar="PATH",
+        type=Path,
+        help=(
+            "Path to a custom CA certificate bundle (PEM) to trust. "
+            "Useful for self-signed or corporate CAs. "
+            "For Playwright, sets NODE_EXTRA_CA_CERTS before launching Chromium "
+            "(Chromium-level trust only; does not update the OS certificate store)."
+        ),
+    )
 
     # Config file
     verify_parser.add_argument(

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -356,12 +356,20 @@ def _generate_temp_config(args: argparse.Namespace) -> str:
 
     insecure = getattr(args, "insecure", False)
     ca_bundle = getattr(args, "ca_bundle", None)
+    if insecure and ca_bundle:
+        import warnings
+
+        warnings.warn(
+            "--insecure and --ca-bundle are both set; --insecure takes precedence "
+            "and the ca-bundle path will be ignored for TLS verification.",
+            stacklevel=2,
+        )
     if insecure or ca_bundle:
         lines.append("[tls]")
         if insecure:
             lines.append("insecure = true")
         if ca_bundle:
-            lines.append(f'ca_bundle = "{ca_bundle}"')
+            lines.append(f"ca_bundle = '{ca_bundle}'")
         lines.append("")
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -372,14 +372,15 @@ def _generate_temp_config(args: argparse.Namespace) -> str:
             "and the ca-bundle path will be ignored for TLS verification.",
             stacklevel=2,
         )
-    if insecure or ca_bundle:
+    effective_ca_bundle = None if insecure else ca_bundle
+    if insecure or effective_ca_bundle:
         lines.append("[tls]")
         if insecure:
             lines.append("insecure = true")
-        if ca_bundle:
+        if effective_ca_bundle:
             import json as _json
 
-            lines.append(f"ca_bundle = {_json.dumps(str(ca_bundle))}")
+            lines.append(f"ca_bundle = {_json.dumps(str(effective_ca_bundle))}")
         lines.append("")
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -193,7 +193,11 @@ def _print_skip_notes(config_path: str | None) -> None:
     """Print a note for each product that is not configured."""
     from vip.config import load_config
 
-    cfg = load_config(config_path)
+    try:
+        cfg = load_config(config_path)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
     products = [
         ("Connect", cfg.connect),
         ("Workbench", cfg.workbench),
@@ -221,7 +225,11 @@ def _check_credentials(
     """
     from vip.config import load_config
 
-    cfg = load_config(config_path)
+    try:
+        cfg = load_config(config_path)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
     if interactive_auth:
         return
 
@@ -369,7 +377,9 @@ def _generate_temp_config(args: argparse.Namespace) -> str:
         if insecure:
             lines.append("insecure = true")
         if ca_bundle:
-            lines.append(f"ca_bundle = '{ca_bundle}'")
+            import json as _json
+
+            lines.append(f"ca_bundle = {_json.dumps(str(ca_bundle))}")
         lines.append("")
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:

--- a/src/vip/clients/base.py
+++ b/src/vip/clients/base.py
@@ -80,6 +80,16 @@ class BaseClient:
         """Root URL of the product, without any API path prefix."""
         return self._base_url
 
+    @property
+    def verify(self) -> bool | str:
+        """The httpx ``verify`` value for this client's TLS configuration.
+
+        ``False`` means certificate verification is disabled (insecure mode).
+        A string is the path to a custom CA bundle.
+        ``True`` means the system trust store is used (default).
+        """
+        return self._verify
+
     def close(self) -> None:
         """Close the underlying httpx client."""
         self._client.close()

--- a/src/vip/clients/base.py
+++ b/src/vip/clients/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import TracebackType
 from typing import TypeVar
 
@@ -26,6 +27,13 @@ class BaseClient:
         property still returns the original URL without this prefix.
     timeout:
         Default request timeout in seconds.
+    insecure:
+        Disable TLS certificate verification (equivalent to ``curl -k``).
+        **Use only in trusted environments** — this silently ignores
+        certificate errors including MITM attacks.
+    ca_bundle:
+        Path to a custom CA certificate bundle (PEM) to trust in addition
+        to the system roots.  Useful for self-signed or corporate CAs.
     """
 
     def __init__(
@@ -34,11 +42,26 @@ class BaseClient:
         auth_header_value: str = "",
         api_prefix: str = "",
         timeout: float = 30.0,
+        insecure: bool = False,
+        ca_bundle: Path | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         headers: dict[str, str] = {}
         if auth_header_value:
             headers["Authorization"] = auth_header_value
+        # Compute the httpx ``verify`` argument from TLS config:
+        #   insecure=True  → False  (skip all certificate verification)
+        #   ca_bundle set  → str path  (use custom CA bundle)
+        #   default        → True  (use system trust store)
+        if insecure:
+            verify: bool | str = False
+        elif ca_bundle is not None:
+            verify = str(ca_bundle)
+        else:
+            verify = True
+        # Store for subclasses that need to create ad-hoc httpx clients with
+        # the same TLS configuration (e.g. temporary cookie-based clients).
+        self._verify = verify
         # HTTPTransport retries cover connection-level failures (e.g. refused
         # connections, broken pipes).  HTTP-level errors (502/503/504) are not
         # retried here — ConnectClient.wait_for_task already handles those at
@@ -49,6 +72,7 @@ class BaseClient:
             headers=headers,
             timeout=timeout,
             transport=transport,
+            verify=verify,
         )
 
     @property

--- a/src/vip/clients/connect.py
+++ b/src/vip/clients/connect.py
@@ -6,6 +6,7 @@ avoid tight coupling to a particular release of the Connect client library.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -29,14 +30,25 @@ def _normalized_port(scheme: str | None, port: int | None) -> int | None:
 class ConnectClient(BaseClient):
     """Minimal Connect API wrapper."""
 
-    def __init__(self, base_url: str, api_key: str, *, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        *,
+        timeout: float = 30.0,
+        insecure: bool = False,
+        ca_bundle: Path | None = None,
+    ) -> None:
         api_key = (api_key or "").strip()
         super().__init__(
             base_url,
             auth_header_value=f"Key {api_key}" if api_key else "",
             api_prefix="/__api__",
             timeout=timeout,
+            insecure=insecure,
+            ca_bundle=ca_bundle,
         )
+        # self._verify is set by BaseClient.__init__ and used by fetch_content.
 
     # -- Server info --------------------------------------------------------
 
@@ -294,6 +306,7 @@ class ConnectClient(BaseClient):
             headers={"Authorization": self._client.headers["Authorization"]},
             follow_redirects=False,
             timeout=timeout,
+            verify=self._verify,
         )
         for _ in range(max_redirects):
             if not resp.is_redirect:
@@ -319,6 +332,7 @@ class ConnectClient(BaseClient):
                 headers={"Authorization": self._client.headers["Authorization"]},
                 follow_redirects=False,
                 timeout=timeout,
+                verify=self._verify,
             )
         return resp
 

--- a/src/vip/clients/packagemanager.py
+++ b/src/vip/clients/packagemanager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from vip.clients.base import BaseClient
@@ -10,11 +11,21 @@ from vip.clients.base import BaseClient
 class PackageManagerClient(BaseClient):
     """Minimal Package Manager HTTP wrapper."""
 
-    def __init__(self, base_url: str, token: str = "", *, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        token: str = "",
+        *,
+        timeout: float = 30.0,
+        insecure: bool = False,
+        ca_bundle: Path | None = None,
+    ) -> None:
         super().__init__(
             base_url,
             auth_header_value=f"Bearer {token}" if token else "",
             timeout=timeout,
+            insecure=insecure,
+            ca_bundle=ca_bundle,
         )
 
     # -- Health / status ----------------------------------------------------

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -6,6 +6,7 @@ APIs than Connect, so many checks are done via the web UI with Playwright.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from vip.clients.base import BaseClient
@@ -14,11 +15,21 @@ from vip.clients.base import BaseClient
 class WorkbenchClient(BaseClient):
     """Minimal Workbench HTTP wrapper."""
 
-    def __init__(self, base_url: str, api_key: str = "", *, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str = "",
+        *,
+        timeout: float = 30.0,
+        insecure: bool = False,
+        ca_bundle: Path | None = None,
+    ) -> None:
         super().__init__(
             base_url,
             auth_header_value=f"Key {api_key}" if api_key else "",
             timeout=timeout,
+            insecure=insecure,
+            ca_bundle=ca_bundle,
         )
 
     # -- Health / info ------------------------------------------------------

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -336,6 +336,23 @@ class VIPConfig:
         return mapping[product]
 
 
+def _resolve_ca_bundle(raw: str | None) -> Path | None:
+    """Return a validated ``Path`` for the CA bundle, or ``None``.
+
+    Raises ``ValueError`` if the path is specified but does not point to an
+    existing file, so misconfigured deployments fail fast with a clear message
+    rather than producing an opaque SSL error on the first HTTP request.
+    """
+    if not raw:
+        return None
+    p = Path(raw)
+    if not p.is_file():
+        raise ValueError(
+            f"[tls] ca_bundle path does not exist or is not a file: {p}"
+        )
+    return p
+
+
 def load_config(path: str | Path | None = None) -> VIPConfig:
     """Load VIP configuration from a TOML file.
 
@@ -397,5 +414,5 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
         monitoring_enabled=monitoring_raw.get("enabled", False),
         security_policy_checks_enabled=security_raw.get("policy_checks_enabled", False),
         insecure=tls_raw.get("insecure", False),
-        ca_bundle=Path(tls_raw["ca_bundle"]) if tls_raw.get("ca_bundle") else None,
+        ca_bundle=_resolve_ca_bundle(tls_raw.get("ca_bundle")),
     )

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -302,6 +302,9 @@ class VIPConfig:
     monitoring_enabled: bool = False
     security_policy_checks_enabled: bool = False
 
+    insecure: bool = False
+    ca_bundle: Path | None = None
+
     def validate_for_mode(self, mode: Mode) -> None:
         """Raise ValueError if required fields are missing for *mode*.
 
@@ -364,6 +367,7 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
     security_raw = raw.get("security", {})
     runtimes_raw = raw.get("runtimes", {})
     performance_raw = raw.get("performance", {})
+    tls_raw = raw.get("tls", {})
 
     data_sources: list[DataSourceEntry] = []
     for name, ds in data_sources_raw.items():
@@ -392,4 +396,6 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
         email_enabled=email_raw.get("enabled", False),
         monitoring_enabled=monitoring_raw.get("enabled", False),
         security_policy_checks_enabled=security_raw.get("policy_checks_enabled", False),
+        insecure=tls_raw.get("insecure", False),
+        ca_bundle=Path(tls_raw["ca_bundle"]) if tls_raw.get("ca_bundle") else None,
     )

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -347,9 +347,7 @@ def _resolve_ca_bundle(raw: str | None) -> Path | None:
         return None
     p = Path(raw)
     if not p.is_file():
-        raise ValueError(
-            f"[tls] ca_bundle path does not exist or is not a file: {p}"
-        )
+        raise ValueError(f"[tls] ca_bundle path does not exist or is not a file: {p}")
     return p
 
 

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -189,7 +189,11 @@ def pytest_configure(config: pytest.Config) -> None:
 
             cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
             session = start_interactive_auth(
-                connect_url=connect_url, workbench_url=wb_url, cache_path=cache_path
+                connect_url=connect_url,
+                workbench_url=wb_url,
+                cache_path=cache_path,
+                insecure=vip_cfg.insecure,
+                ca_bundle=vip_cfg.ca_bundle,
             )
             config.stash[_auth_session_key] = session
             if session.api_key:
@@ -228,6 +232,8 @@ def pytest_configure(config: pytest.Config) -> None:
                     password=vip_cfg.auth.password,
                     cache_path=cache_path,
                     verbose=config.getoption("--vip-verbose", default=False),
+                    insecure=vip_cfg.insecure,
+                    ca_bundle=vip_cfg.ca_bundle,
                 )
             except AuthConfigError as exc:
                 raise pytest.UsageError(str(exc)) from None

--- a/src/vip/verify/credentials.py
+++ b/src/vip/verify/credentials.py
@@ -14,6 +14,7 @@ import json
 import secrets
 import string
 import subprocess
+from pathlib import Path
 
 import httpx
 
@@ -29,6 +30,8 @@ def ensure_keycloak_test_user(
     username: str,
     admin_secret_name: str,
     namespace: str = "posit-team",
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
 ) -> None:
     """Create or reset a test user in Keycloak and store credentials in a K8s Secret.
 
@@ -83,13 +86,17 @@ def ensure_keycloak_test_user(
     admin_username, admin_password = _get_secret_credentials(admin_secret_name, namespace)
 
     # Get admin access token
-    token = _get_keycloak_admin_token(keycloak_url, admin_username, admin_password)
+    token = _get_keycloak_admin_token(
+        keycloak_url, admin_username, admin_password, insecure=insecure, ca_bundle=ca_bundle
+    )
 
     # Generate a cryptographic random password
     password = _generate_password(32)
 
     # Create or reset the test user
-    _create_keycloak_user(keycloak_url, realm, token, username, password)
+    _create_keycloak_user(
+        keycloak_url, realm, token, username, password, insecure=insecure, ca_bundle=ca_bundle
+    )
 
     # Create the vip-test-credentials secret
     _create_credentials_secret(username, password, namespace)
@@ -465,7 +472,13 @@ def _get_secret_credentials(secret_name: str, namespace: str) -> tuple[str, str]
     return username, password
 
 
-def _get_keycloak_admin_token(keycloak_url: str, username: str, password: str) -> str:
+def _get_keycloak_admin_token(
+    keycloak_url: str,
+    username: str,
+    password: str,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
+) -> str:
     """Get an admin access token from Keycloak's master realm.
 
     Admin tokens are always obtained from the master realm, regardless of the target realm.
@@ -474,6 +487,8 @@ def _get_keycloak_admin_token(keycloak_url: str, username: str, password: str) -
         keycloak_url: Base URL of the Keycloak server
         username: Admin username
         password: Admin password
+        insecure: Disable TLS certificate verification
+        ca_bundle: Path to a custom CA certificate bundle
 
     Returns:
         Admin access token
@@ -482,6 +497,13 @@ def _get_keycloak_admin_token(keycloak_url: str, username: str, password: str) -
         httpx.HTTPError: If the token request fails
         ValueError: If the response is missing the access_token
     """
+    if insecure:
+        verify: bool | str = False
+    elif ca_bundle is not None:
+        verify = str(ca_bundle)
+    else:
+        verify = True
+
     token_url = f"{keycloak_url}/realms/master/protocol/openid-connect/token"
 
     data = {
@@ -491,7 +513,7 @@ def _get_keycloak_admin_token(keycloak_url: str, username: str, password: str) -
         "password": password,
     }
 
-    with httpx.Client(timeout=30.0) as client:
+    with httpx.Client(timeout=30.0, verify=verify) as client:
         resp = client.post(token_url, data=data)
         resp.raise_for_status()
 
@@ -535,7 +557,13 @@ def _find_keycloak_user_id(
 
 
 def _create_keycloak_user(
-    keycloak_url: str, realm: str, token: str, username: str, password: str
+    keycloak_url: str,
+    realm: str,
+    token: str,
+    username: str,
+    password: str,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
 ) -> None:
     """Create a user in Keycloak, or reset their password if they already exist.
 
@@ -548,11 +576,20 @@ def _create_keycloak_user(
         token: Admin access token
         username: Username for the user
         password: Password for the user
+        insecure: Disable TLS certificate verification
+        ca_bundle: Path to a custom CA certificate bundle
 
     Raises:
         httpx.HTTPError: If Keycloak API requests fail
     """
-    with httpx.Client(timeout=30.0) as client:
+    if insecure:
+        verify: bool | str = False
+    elif ca_bundle is not None:
+        verify = str(ca_bundle)
+    else:
+        verify = True
+
+    with httpx.Client(timeout=30.0, verify=verify) as client:
         users_url = f"{keycloak_url}/admin/realms/{realm}/users"
         headers = {"Authorization": f"Bearer {token}"}
 

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -131,6 +131,10 @@ def browser_context_args(
         browser_context_args["storage_state"] = str(session.storage_state_path)
     if vip_config.insecure:
         browser_context_args["ignore_https_errors"] = True
+    if vip_config.ca_bundle is not None:
+        import os
+
+        os.environ.setdefault("NODE_EXTRA_CA_CERTS", str(vip_config.ca_bundle))
     return browser_context_args
 
 

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -134,7 +134,16 @@ def browser_context_args(
     if vip_config.ca_bundle is not None:
         import os
 
-        os.environ.setdefault("NODE_EXTRA_CA_CERTS", str(vip_config.ca_bundle))
+        _prev = os.environ.get("NODE_EXTRA_CA_CERTS")
+        os.environ["NODE_EXTRA_CA_CERTS"] = str(vip_config.ca_bundle)
+
+        def _restore_node_ca() -> None:
+            if _prev is None:
+                os.environ.pop("NODE_EXTRA_CA_CERTS", None)
+            else:
+                os.environ["NODE_EXTRA_CA_CERTS"] = _prev
+
+        request.addfinalizer(_restore_node_ca)
     return browser_context_args
 
 

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -42,7 +42,12 @@ def vip_verbose(request: pytest.FixtureRequest) -> bool:
 def connect_client(vip_config: VIPConfig) -> ConnectClient | None:
     if not vip_config.connect.is_configured:
         return None
-    client = ConnectClient(vip_config.connect.url, api_key=vip_config.connect.api_key)
+    client = ConnectClient(
+        vip_config.connect.url,
+        api_key=vip_config.connect.api_key,
+        insecure=vip_config.insecure,
+        ca_bundle=vip_config.ca_bundle,
+    )
     yield client
     client.close()
 
@@ -56,7 +61,12 @@ def connect_url(vip_config: VIPConfig) -> str:
 def workbench_client(vip_config: VIPConfig) -> WorkbenchClient | None:
     if not vip_config.workbench.is_configured:
         return None
-    client = WorkbenchClient(vip_config.workbench.url, api_key=vip_config.workbench.api_key)
+    client = WorkbenchClient(
+        vip_config.workbench.url,
+        api_key=vip_config.workbench.api_key,
+        insecure=vip_config.insecure,
+        ca_bundle=vip_config.ca_bundle,
+    )
     yield client
     client.close()
 
@@ -71,7 +81,10 @@ def pm_client(vip_config: VIPConfig) -> PackageManagerClient | None:
     if not vip_config.package_manager.is_configured:
         return None
     client = PackageManagerClient(
-        vip_config.package_manager.url, token=vip_config.package_manager.token
+        vip_config.package_manager.url,
+        token=vip_config.package_manager.token,
+        insecure=vip_config.insecure,
+        ca_bundle=vip_config.ca_bundle,
     )
     yield client
     client.close()
@@ -105,8 +118,10 @@ def auth_mode(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="session")
-def browser_context_args(browser_context_args, request: pytest.FixtureRequest):
-    """Inject interactive auth storage state into all browser contexts.
+def browser_context_args(
+    browser_context_args, request: pytest.FixtureRequest, vip_config: VIPConfig
+):
+    """Inject interactive auth storage state and TLS config into all browser contexts.
 
     Overrides the pytest-playwright fixture of the same name.  The parameter
     name *must* match to receive the base fixture value.
@@ -114,6 +129,8 @@ def browser_context_args(browser_context_args, request: pytest.FixtureRequest):
     session = request.config.stash.get(_auth_session_key, None)
     if session is not None:
         browser_context_args["storage_state"] = str(session.storage_state_path)
+    if vip_config.insecure:
+        browser_context_args["ignore_https_errors"] = True
     return browser_context_args
 
 

--- a/src/vip_tests/connect/test_data_sources.py
+++ b/src/vip_tests/connect/test_data_sources.py
@@ -20,8 +20,14 @@ def data_sources_configured(data_sources):
 
 
 @when("I test connectivity to each data source", target_fixture="ds_results")
-def test_connectivity(data_sources):
-    return check_data_source_connectivity(data_sources)
+def test_connectivity(data_sources, vip_config):
+    if vip_config.insecure:
+        verify: bool | str = False
+    elif vip_config.ca_bundle is not None:
+        verify = str(vip_config.ca_bundle)
+    else:
+        verify = True
+    return check_data_source_connectivity(data_sources, verify=verify)
 
 
 @then("all data sources respond successfully")

--- a/src/vip_tests/helpers.py
+++ b/src/vip_tests/helpers.py
@@ -66,7 +66,7 @@ def _extract_host_port(connection_string: str, ds_type: str) -> tuple[str, int] 
     return host, port
 
 
-def check_data_source_connectivity(data_sources) -> list[dict]:
+def check_data_source_connectivity(data_sources, verify: bool | str = True) -> list[dict]:
     """Test connectivity to each configured data source.
 
     For HTTP/API sources, attempts a real HTTP GET and checks the response
@@ -94,7 +94,7 @@ def check_data_source_connectivity(data_sources) -> list[dict]:
         result = {"name": ds.name, "type": ds.type, "ok": False, "error": None}
         try:
             if ds.type in ("http", "api"):
-                resp = httpx.get(ds.connection_string, timeout=15)
+                resp = httpx.get(ds.connection_string, timeout=15, verify=verify)
                 result["ok"] = resp.status_code < 400
             else:
                 if not ds.connection_string:

--- a/src/vip_tests/helpers.py
+++ b/src/vip_tests/helpers.py
@@ -94,6 +94,10 @@ def check_data_source_connectivity(data_sources, verify: bool | str = True) -> l
         result = {"name": ds.name, "type": ds.type, "ok": False, "error": None}
         try:
             if ds.type in ("http", "api"):
+                # `verify` controls TLS certificate validation for HTTP sources.
+                # Non-HTTP types (DB, TCP) use socket.create_connection and do
+                # not perform TLS; the verify parameter is intentionally ignored
+                # for those types.
                 resp = httpx.get(ds.connection_string, timeout=15, verify=verify)
                 result["ok"] = resp.status_code < 400
             else:

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -50,10 +50,18 @@ def product_configured_https(product, vip_config):
 
 
 @when(parsers.parse("I make an HTTP request to {product}"), target_fixture="http_result")
-def make_http_request(product_url):
+def make_http_request(product_url, vip_config):
+    verify: bool | str
+    if vip_config.insecure:
+        verify = False
+    elif vip_config.ca_bundle is not None:
+        verify = str(vip_config.ca_bundle)
+    else:
+        verify = True
+
     http_url = product_url.replace("https://", "http://")
     try:
-        resp = httpx.get(http_url, follow_redirects=False, timeout=10)
+        resp = httpx.get(http_url, follow_redirects=False, timeout=10, verify=verify)
         return {
             "status": resp.status_code,
             "location": resp.headers.get("location", ""),
@@ -89,8 +97,17 @@ def inspect_headers(product, vip_config):
     pc = vip_config.product_config(product_key)
     if not pc.is_configured:
         pytest.skip(f"{product} is not configured")
+
+    verify: bool | str
+    if vip_config.insecure:
+        verify = False
+    elif vip_config.ca_bundle is not None:
+        verify = str(vip_config.ca_bundle)
+    else:
+        verify = True
+
     try:
-        resp = httpx.get(pc.url, follow_redirects=True, timeout=15)
+        resp = httpx.get(pc.url, follow_redirects=True, timeout=15, verify=verify)
     except httpx.ConnectError as exc:
         # httpx wraps ssl.SSLCertVerificationError in httpx.ConnectError.
         # A cert-verification failure is a trust-bundle issue on the test

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -17,6 +17,25 @@ scenarios("test_https.feature")
 
 
 # ---------------------------------------------------------------------------
+# TLS verify helper
+# ---------------------------------------------------------------------------
+
+
+def _verify_from_config(vip_config) -> bool | str:
+    """Return the httpx ``verify`` value derived from the VIP TLS config.
+
+    - ``insecure=True``   → ``False`` (disable TLS verification)
+    - ``ca_bundle`` set   → path string (use custom CA bundle)
+    - otherwise           → ``True`` (use system trust store)
+    """
+    if vip_config.insecure:
+        return False
+    if vip_config.ca_bundle is not None:
+        return str(vip_config.ca_bundle)
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Shared diagnostic text
 # ---------------------------------------------------------------------------
 
@@ -51,14 +70,7 @@ def product_configured_https(product, vip_config):
 
 @when(parsers.parse("I make an HTTP request to {product}"), target_fixture="http_result")
 def make_http_request(product_url, vip_config):
-    verify: bool | str
-    if vip_config.insecure:
-        verify = False
-    elif vip_config.ca_bundle is not None:
-        verify = str(vip_config.ca_bundle)
-    else:
-        verify = True
-
+    verify = _verify_from_config(vip_config)
     http_url = product_url.replace("https://", "http://")
     try:
         resp = httpx.get(http_url, follow_redirects=False, timeout=10, verify=verify)
@@ -98,14 +110,7 @@ def inspect_headers(product, vip_config):
     if not pc.is_configured:
         pytest.skip(f"{product} is not configured")
 
-    verify: bool | str
-    if vip_config.insecure:
-        verify = False
-    elif vip_config.ca_bundle is not None:
-        verify = str(vip_config.ca_bundle)
-    else:
-        verify = True
-
+    verify = _verify_from_config(vip_config)
     try:
         resp = httpx.get(pc.url, follow_redirects=True, timeout=15, verify=verify)
     except httpx.ConnectError as exc:

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -203,11 +203,13 @@ def _cleanup_sessions(page, workbench_client):
     try:
         cookies = {c["name"]: c["value"] for c in page.context.cookies()}
         # Use a temporary client so the session-scoped workbench_client's
-        # cookie jar is never mutated.
+        # cookie jar is never mutated.  Inherit TLS config from the session
+        # client so --insecure / --ca-bundle are honoured here too.
         with httpx.Client(
             base_url=workbench_client.base_url,
             cookies=cookies,
             timeout=30.0,
+            verify=workbench_client._verify,
         ) as tmp:
             resp = tmp.get("/api/sessions")
             sessions = resp.json() if resp.status_code == 200 else []

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -209,7 +209,7 @@ def _cleanup_sessions(page, workbench_client):
             base_url=workbench_client.base_url,
             cookies=cookies,
             timeout=30.0,
-            verify=workbench_client._verify,
+            verify=workbench_client.verify,
         ) as tmp:
             resp = tmp.get("/api/sessions")
             sessions = resp.json() if resp.status_code == 200 else []

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -115,6 +115,20 @@ enabled = false
 # load_test_duration = 30         # seconds (locust only)
 # load_test_spawn_rate = 10       # users/sec (locust only)
 
+[tls]
+# TLS configuration for self-signed or corporate CAs.
+#
+# Disable TLS certificate verification (equivalent to curl -k).
+# Use only in trusted environments; this silently ignores certificate errors.
+# Overridable on the command line with: vip verify --insecure
+# insecure = false
+#
+# Path to a custom CA certificate bundle (PEM).  Useful for self-signed or
+# corporate CAs.  For Playwright tests, sets NODE_EXTRA_CA_CERTS before
+# launching Chromium (Chromium-level trust only).
+# Overridable on the command line with: vip verify --ca-bundle /path/to/ca.pem
+# ca_bundle = "/etc/ssl/corp-ca.pem"
+
 [security]
 # Set enabled = true to run security-policy compliance tests.
 policy_checks_enabled = false


### PR DESCRIPTION
## Summary

- Adds `--insecure` and `--ca-bundle PATH` flags that flow end-to-end: CLI → `VIPConfig` `[tls]` section → all httpx clients (`BaseClient.verify`) → Playwright (`ignore_https_errors`, `NODE_EXTRA_CA_CERTS` with save/restore) → Keycloak credential provisioning.
- All ad-hoc httpx call sites in `auth.py`, `credentials.py`, `connect.py`, `helpers.py`, and `test_https.py` honor the new settings.
- Path quoting uses `json.dumps` for TOML safety; a `_resolve_ca_bundle` validator surfaces clean CLI errors when the file is missing; using both flags together emits a `UserWarning`.
- Eighteen new selftests cover the round-trip, env handling, fixture restore, and CLI temp-config generation.

Builds additively on the TLS diagnostics improvements from #198 — the diagnostic step in `test_ssl.py` is untouched.

Closes #224.

## Test plan

- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run pytest selftests/ -v` (338 passed)
- [x] Sanity: `vip verify --connect-url https://example.invalid --insecure --no-auth -- --collect-only` succeeds