### PR TITLE
ci: pin actions to SHAs and enforce with zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         name: Ruff lint
         with:
           version: "0.15.0"
           args: check src/ selftests/ examples/ docker/
 
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         name: Ruff format
         with:
           version: "0.15.0"
@@ -28,9 +28,9 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -40,13 +40,31 @@ jobs:
       - name: Run mypy
         run: uv run mypy src/vip/
 
+  actions-lint:
+    name: Actions Lint (zizmor)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Enforce SHA-pinned actions
+        run: |
+          findings=$(uvx zizmor==1.24.1 --format=json .github/workflows/ \
+            | jq '[.[] | select(.ident == "unpinned-uses")] | length')
+          if [ "$findings" -gt 0 ]; then
+            echo "::error::Found $findings unpinned action reference(s). Pin to a 40-char commit SHA with a version comment, e.g. actions/checkout@<sha> # v6."
+            uvx zizmor==1.24.1 .github/workflows/ 2>&1 | grep -B1 -A6 'unpinned-uses' || true
+            exit 1
+          fi
+
   audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -63,9 +81,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -83,7 +101,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: selftest-results-py${{ matrix.python-version }}
           path: selftest-results.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,19 @@ jobs:
 
       - name: Enforce SHA-pinned actions
         run: |
-          findings=$(uvx zizmor==1.24.1 --format=json .github/workflows/ \
+          set +e
+          zizmor_output=$(uvx zizmor==1.24.1 --format=json .github/workflows/)
+          zizmor_status=$?
+          set -e
+
+          findings=$(printf '%s\n' "$zizmor_output" \
             | jq '[.[] | select(.ident == "unpinned-uses")] | length')
+
+          if [ "$zizmor_status" -ne 0 ] && [ -z "$zizmor_output" ]; then
+            echo "::error::zizmor failed before producing JSON output."
+            exit "$zizmor_status"
+          fi
+
           if [ "$findings" -gt 0 ]; then
             echo "::error::Found $findings unpinned action reference(s). Pin to a 40-char commit SHA with a version comment, e.g. actions/checkout@<sha> # v6."
             uvx zizmor==1.24.1 .github/workflows/ 2>&1 | grep -B1 -A6 'unpinned-uses' || true

--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -20,12 +20,12 @@ jobs:
       matrix:
         connect-version: ${{ github.event_name == 'schedule' && fromJSON('["2024.08.0", "release", "preview"]') || fromJSON('["2024.08.0", "release"]') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Start Connect in Docker
       - name: Start Connect
         id: connect
-        uses: posit-dev/with-connect@main
+        uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
         with:
           version: ${{ matrix.connect-version }}
           license: ${{ secrets.CONNECT_LICENSE }}
@@ -77,7 +77,7 @@ jobs:
 
       # Rename the check run so the job title shows the resolved version
       - name: Update job title with resolved version
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const resolvedVersion = '${{ steps.version.outputs.resolved }}';
@@ -99,7 +99,7 @@ jobs:
             }
 
       # Set up Python and install VIP
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -146,7 +146,7 @@ jobs:
       # Upload test results for debugging failures
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: connect-smoke-results-${{ matrix.connect-version }}
           path: smoke-results.xml
@@ -201,7 +201,7 @@ jobs:
       # Stop Connect
       - name: Stop Connect
         if: always()
-        uses: posit-dev/with-connect@main
+        uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
         with:
           stop: ${{ steps.connect.outputs.CONTAINER_ID }}
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install gh-aw extension
-        uses: github/gh-aw/actions/setup-cli@v0.68.3
+        uses: github/gh-aw/actions/setup-cli@ce1794953e0ec42adc41b6fca05e02ab49ee21c3 # v0.68.3
         with:
           version: v0.48.1
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -49,7 +49,7 @@ jobs:
             type=sha
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/example-report.yml
+++ b/.github/workflows/example-report.yml
@@ -36,7 +36,7 @@ jobs:
       # Start Connect in Docker
       - name: Start Connect
         id: connect
-        uses: posit-dev/with-connect@main
+        uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
         with:
           version: release
           license: ${{ secrets.CONNECT_LICENSE }}
@@ -45,7 +45,7 @@ jobs:
       - name: Start Workbench
         if: steps.wb-license.outputs.available == 'true'
         id: workbench
-        uses: posit-dev/with-workbench@main
+        uses: posit-dev/with-workbench@da367f7337b28c6748f7dd43d08706788353be8d # main
         with:
           license-key: ${{ secrets.WORKBENCH_LICENSE }}
           version: release
@@ -197,7 +197,7 @@ jobs:
           echo "Resolved Package Manager version: ${VERSION}"
           echo "resolved=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -207,7 +207,7 @@ jobs:
       - name: Install Playwright browsers
         run: uv run vip install --skip-system
 
-      - uses: quarto-dev/quarto-actions/setup@v2
+      - uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2
         with:
           version: 1.9.37
 
@@ -283,7 +283,7 @@ jobs:
       # Stop Connect
       - name: Stop Connect
         if: always()
-        uses: posit-dev/with-connect@main
+        uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
         with:
           stop: ${{ steps.connect.outputs.CONTAINER_ID }}
 
@@ -295,12 +295,12 @@ jobs:
       # Stop Workbench
       - name: Stop Workbench
         if: always() && steps.wb-license.outputs.available == 'true'
-        uses: posit-dev/with-workbench@main
+        uses: posit-dev/with-workbench@da367f7337b28c6748f7dd43d08706788353be8d # main
         with:
           stop: ${{ steps.workbench.outputs.CONTAINER_ID }}
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: example-report
           path: report/_output/

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         pm-version: ${{ github.event_name == 'schedule' && fromJSON('["ubuntu2204-2024.08.0", "ubuntu2204"]') || fromJSON('["ubuntu2204-2024.08.0"]') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Skip the entire job if the license secret is not configured
       - name: Check for RSPM_LICENSE
@@ -117,7 +117,7 @@ jobs:
       # Rename the check run to show the resolved version
       - name: Update job title with resolved version
         if: steps.license.outputs.available == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const resolvedVersion = '${{ steps.version.outputs.resolved }}';
@@ -139,7 +139,7 @@ jobs:
             }
 
       # Set up Python and install VIP
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         if: steps.license.outputs.available == 'true'
         with:
           enable-cache: true
@@ -182,7 +182,7 @@ jobs:
       # Upload test results for debugging failures
       - name: Upload test results
         if: always() && steps.license.outputs.available == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pm-smoke-results-${{ matrix.pm-version }}
           path: smoke-results.xml

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,15 +22,15 @@ jobs:
     name: Deploy report preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download example report
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: example-report
           path: report/_output/
 
-      - uses: rossjrw/pr-preview-action@v1
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: report/_output/
           preview-branch: gh-pages
@@ -42,9 +42,9 @@ jobs:
     name: Clean up report preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: rossjrw/pr-preview-action@v1
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: report/_output/
           preview-branch: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,16 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
       - name: Build wheel and sdist
         run: uv build
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -34,9 +34,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
       group: release
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/rhel-smoke.yml
+++ b/.github/workflows/rhel-smoke.yml
@@ -34,12 +34,12 @@ jobs:
       matrix:
         version: [rhel9, rhel10]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ matrix.version }}-${{ hashFiles(format('docker/{0}/Dockerfile', matrix.version), 'pyproject.toml', 'uv.lock') }}
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-buildx-${{ matrix.version }}-
 
       - name: Build smoke image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: docker/${{ matrix.version }}/Dockerfile

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -22,9 +22,9 @@ jobs:
     name: Build & deploy website preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -40,7 +40,7 @@ jobs:
             uv run python scripts/generate-feature-matrix.py
           fi
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: npm
@@ -54,19 +54,19 @@ jobs:
           touch dist/.nojekyll
 
       - name: Download example report
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: example-report
           path: website/dist/example-report/
 
-      - uses: rossjrw/pr-preview-action@v1
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: website/dist/
           preview-branch: gh-pages
           umbrella-dir: pr-preview-site
           comment: false
 
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         env:
           WEBSITE_URL: https://posit-dev.github.io/vip/pr-preview-site/pr-${{ github.event.pull_request.number }}/
           REPORT_URL: https://posit-dev.github.io/vip/pr-preview/pr-${{ github.event.pull_request.number }}/
@@ -86,9 +86,9 @@ jobs:
     name: Clean up website preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: rossjrw/pr-preview-action@v1
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: website/dist/
           preview-branch: gh-pages
@@ -96,7 +96,7 @@ jobs:
           comment: false
           action: remove
 
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: preview-links
           delete: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -50,7 +50,7 @@ jobs:
             uv run python scripts/generate-feature-matrix.py
           fi
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -64,12 +64,12 @@ jobs:
           touch dist/.nojekyll
 
       - name: Download example report
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: example-report
           path: website/dist/example-report/
 
-      - uses: JamesIves/github-pages-deploy-action@v4.8.0
+      - uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: website/dist

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -21,12 +21,12 @@ jobs:
       matrix:
         workbench-version: ${{ github.event_name == 'schedule' && fromJSON('["2026.01.1", "release"]') || fromJSON('["2026.01.1"]') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Start Workbench in Docker
       - name: Start Workbench
         id: workbench
-        uses: posit-dev/with-workbench@main
+        uses: posit-dev/with-workbench@da367f7337b28c6748f7dd43d08706788353be8d # main
         with:
           license-key: ${{ secrets.WORKBENCH_LICENSE }}
           version: ${{ matrix.workbench-version }}
@@ -94,7 +94,7 @@ jobs:
 
       # Rename the check run so the job title shows the resolved version
       - name: Update job title with resolved version
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const resolvedVersion = '${{ steps.version.outputs.resolved }}';
@@ -116,7 +116,7 @@ jobs:
             }
 
       # Set up Python and install VIP
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -169,7 +169,7 @@ jobs:
       # Upload test results for debugging failures
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: workbench-smoke-results-${{ matrix.workbench-version }}
           path: smoke-results.xml
@@ -224,7 +224,7 @@ jobs:
       # Stop and remove the Workbench container
       - name: Stop Workbench
         if: always()
-        uses: posit-dev/with-workbench@main
+        uses: posit-dev/with-workbench@da367f7337b28c6748f7dd43d08706788353be8d # main
         with:
           stop: ${{ steps.workbench.outputs.CONTAINER_ID }}
 


### PR DESCRIPTION
## Summary

- Pin every github-actions reference across 14 workflow files to a 40-char commit SHA with a version comment, replacing tag refs (`@v6`, `@v8.1.0`) and mutable branch refs (`posit-dev/with-connect@main`, `pypa/gh-action-pypi-publish@release/v1`).
- Add an `actions-lint` job in `ci.yml` that runs `zizmor 1.24.1` via `uvx`, parses its JSON output, and fails the build on any `unpinned-uses` finding. Scoped to SHA pinning only — other zizmor findings (`excessive-permissions`, `github-env`) remain in the codebase and are not enforced here.
- `preview-screenshot-gallery.lock.yml` is auto-generated by gh-aw and was already pinned, so it is unchanged.
- Most pins were applied via `zizmor --fix=all`, which also added `persist-credentials: false` to checkout actions. Mutable-branch refs were resolved manually via `gh api`.

Dependabot is already configured for `github-actions` weekly with grouping, so SHAs will stay current.

## Test plan

- [ ] CI `actions-lint` job passes on this branch.
- [ ] Verified locally that the check returns 0 unpinned-uses findings on this tree.
- [ ] Verified locally that the check returns >0 findings (and exits non-zero) when an unpinned ref is reintroduced.
- [ ] `uv run ruff check` and `uv run ruff format --check` pass.