### PR TITLE
ci: harden checkouts with persist-credentials: false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         name: Ruff lint
@@ -29,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -45,35 +49,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - name: Enforce SHA-pinned actions
+      - name: Enforce SHA-pinned actions and credential hygiene
+        env:
+          ENFORCED_AUDITS: "unpinned-uses artipacked"
         run: |
           set +e
-          zizmor_output=$(uvx zizmor==1.24.1 --format=json .github/workflows/)
+          zizmor_output=$(uvx zizmor==1.24.1 --config .github/zizmor.yml --format=json .github/workflows/)
           zizmor_status=$?
           set -e
-
-          findings=$(printf '%s\n' "$zizmor_output" \
-            | jq '[.[] | select(.ident == "unpinned-uses")] | length')
 
           if [ "$zizmor_status" -ne 0 ] && [ -z "$zizmor_output" ]; then
             echo "::error::zizmor failed before producing JSON output."
             exit "$zizmor_status"
           fi
 
-          if [ "$findings" -gt 0 ]; then
-            echo "::error::Found $findings unpinned action reference(s). Pin to a 40-char commit SHA with a version comment, e.g. actions/checkout@<sha> # v6."
-            uvx zizmor==1.24.1 .github/workflows/ 2>&1 | grep -B1 -A6 'unpinned-uses' || true
-            exit 1
-          fi
+          fail=0
+          for audit in $ENFORCED_AUDITS; do
+            count=$(printf '%s\n' "$zizmor_output" \
+              | jq --arg a "$audit" '[.[] | select(.ident == $a)] | length')
+            if [ "$count" -gt 0 ]; then
+              echo "::error::Found $count '$audit' finding(s). See documentation: https://docs.zizmor.sh/audits/#$audit"
+              uvx zizmor==1.24.1 --config .github/zizmor.yml .github/workflows/ 2>&1 | grep -B1 -A6 "$audit" || true
+              fail=1
+            fi
+          done
+
+          [ "$fail" -eq 0 ] || exit 1
 
   audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -93,6 +107,8 @@ jobs:
         python-version: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -21,6 +21,8 @@ jobs:
         connect-version: ${{ github.event_name == 'schedule' && fromJSON('["2024.08.0", "release", "preview"]') || fromJSON('["2024.08.0", "release"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # Start Connect in Docker
       - name: Start Connect

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Install gh-aw extension
         uses: github/gh-aw/actions/setup-cli@ce1794953e0ec42adc41b6fca05e02ab49ee21c3 # v0.68.3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -21,6 +21,8 @@ jobs:
         pm-version: ${{ github.event_name == 'schedule' && fromJSON('["ubuntu2204-2024.08.0", "ubuntu2204"]') || fromJSON('["ubuntu2204-2024.08.0"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # Skip the entire job if the license secret is not configured
       - name: Check for RSPM_LICENSE

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/.github/workflows/rhel-smoke.yml
+++ b/.github/workflows/rhel-smoke.yml
@@ -35,6 +35,8 @@ jobs:
         version: [rhel9, rhel10]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -22,6 +22,8 @@ jobs:
         workbench-version: ${{ github.event_name == 'schedule' && fromJSON('["2026.01.1", "release"]') || fromJSON('["2026.01.1"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # Start Workbench in Docker
       - name: Start Workbench

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,10 +8,11 @@
 rules:
   artipacked:
     # `persist-credentials: false` is intentionally NOT set on these checkouts
-    # because the job needs the GitHub token to push back to the repo:
-    #   - release.yml      -- python-semantic-release pushes tags to main
-    #   - preview.yml      -- rossjrw/pr-preview-action pushes to gh-pages
-    #   - website-preview  -- rossjrw/pr-preview-action pushes to gh-pages
+    # because the job needs retained credentials to push back to the repo:
+    #   - release.yml          -- python-semantic-release pushes tags to main
+    #                            using an SSH deploy key configured via `ssh-key`
+    #   - preview.yml          -- rossjrw/pr-preview-action pushes to gh-pages
+    #   - website-preview.yml  -- rossjrw/pr-preview-action pushes to gh-pages
     ignore:
       - release.yml:18:9
       - preview.yml:25:9

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,20 @@
+---
+# zizmor configuration -- https://docs.zizmor.sh/configuration/
+#
+# `rules.<audit>.ignore` suppresses known-acceptable findings so genuine new
+# violations stand out in CI. Each ignore entry is `<filename>:<line>:<col>`
+# (column optional). If the line moves, update the entry.
+
+rules:
+  artipacked:
+    # `persist-credentials: false` is intentionally NOT set on these checkouts
+    # because the job needs the GitHub token to push back to the repo:
+    #   - release.yml      -- python-semantic-release pushes tags to main
+    #   - preview.yml      -- rossjrw/pr-preview-action pushes to gh-pages
+    #   - website-preview  -- rossjrw/pr-preview-action pushes to gh-pages
+    ignore:
+      - release.yml:18:9
+      - preview.yml:25:9
+      - preview.yml:45:9
+      - website-preview.yml:25:9
+      - website-preview.yml:89:9


### PR DESCRIPTION
## Summary

- Set `persist-credentials: false` on the 12 `actions/checkout` calls that don't need to push back, so the `GITHUB_TOKEN` isn't left in `.git/config` (clears all 17 `artipacked` findings from zizmor).
- Add `.github/zizmor.yml` with declarative ignores for the 5 checkouts that legitimately need credentials persisted: `release.yml` (semantic-release pushes tags), `preview.yml` and `website-preview.yml` (`pr-preview-action` pushes to gh-pages). Each ignore is commented with the reason so future readers see the intent.
- Extend the `actions-lint` CI gate to fail on the `artipacked` audit in addition to `unpinned-uses`. Adding more enforced audits later is a one-word change to the `ENFORCED_AUDITS` env var.

Verified locally: `zizmor --config .github/zizmor.yml .github/workflows/` returns 0 findings for both `unpinned-uses` and `artipacked`.

## Test plan

- [x] CI `actions-lint` job passes
- [x] Other CI jobs (`lint`, `typecheck`, `audit`, `selftest`) still pass with the new `persist-credentials: false` setting
- [x] Confirm release/preview workflows are unaffected (they retain credential persistence)