### PR TITLE
chore(deps): bump urllib3 to fix CVE-2026-44431 and CVE-2026-44432

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2482,7 +2482,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.29.0"
+version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },
@@ -3749,11 +3749,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pip-audit` flagged urllib3 2.6.3 with two CVEs caught by Dependency Audit on PR #161:

| CVE | Fix |
|---|---|
| CVE-2026-44431 | 2.7.0 |
| CVE-2026-44432 | 2.7.0 |

Bumps urllib3 to 2.7.0 in `uv.lock`. Off main, independent of PR #161 so it can land first and clear the audit failure on PR #161 via a rebase or merge.

## Test plan

- [x] `uvx pip-audit --skip-editable` — no known vulnerabilities found
- [x] `uv run pytest selftests/` — 478 passed, 3 skipped
- [x] `just check` — lint and format clean
