### PR TITLE
fix(config): redact secrets in config dataclass repr

### DIFF
--- a/selftests/test_config_repr.py
+++ b/selftests/test_config_repr.py
@@ -23,7 +23,8 @@ class TestConnectConfigRepr:
         assert "secret-key-abc123" not in r
         assert "'***'" in r
 
-    def test_api_key_is_empty_string_when_unset(self):
+    def test_api_key_is_empty_string_when_unset(self, monkeypatch):
+        monkeypatch.delenv("VIP_CONNECT_API_KEY", raising=False)
         cfg = ConnectConfig(url="https://connect.example.com", api_key="")
         r = repr(cfg)
         assert "'***'" not in r
@@ -43,7 +44,8 @@ class TestWorkbenchConfigRepr:
         assert "wb-secret-456" not in r
         assert "'***'" in r
 
-    def test_api_key_is_empty_string_when_unset(self):
+    def test_api_key_is_empty_string_when_unset(self, monkeypatch):
+        monkeypatch.delenv("VIP_WORKBENCH_API_KEY", raising=False)
         cfg = WorkbenchConfig(url="https://workbench.example.com", api_key="")
         r = repr(cfg)
         assert "'***'" not in r
@@ -63,7 +65,9 @@ class TestPackageManagerConfigRepr:
         assert "pm-token-789" not in r
         assert "'***'" in r
 
-    def test_token_is_empty_string_when_unset(self):
+    def test_token_is_empty_string_when_unset(self, monkeypatch):
+        monkeypatch.delenv("VIP_PACKAGE_MANAGER_TOKEN", raising=False)
+        monkeypatch.delenv("VIP_PM_TOKEN", raising=False)
         cfg = PackageManagerConfig(url="https://pm.example.com", token="")
         r = repr(cfg)
         assert "'***'" not in r
@@ -83,7 +87,8 @@ class TestAuthConfigRepr:
         assert "hunter2" not in r
         assert "'***'" in r
 
-    def test_password_is_empty_string_when_unset(self):
+    def test_password_is_empty_string_when_unset(self, monkeypatch):
+        monkeypatch.delenv("VIP_TEST_PASSWORD", raising=False)
         cfg = AuthConfig(username="admin", password="")
         r = repr(cfg)
         assert "'***'" not in r

--- a/selftests/test_config_repr.py
+++ b/selftests/test_config_repr.py
@@ -1,0 +1,143 @@
+"""Tests that sensitive fields are redacted in repr() output for config dataclasses.
+
+Secret fields show '***' when populated and '' when empty — preserving the diagnostic
+signal that a field was set without leaking its value into test output or CI logs.
+"""
+
+from __future__ import annotations
+
+from vip.config import (
+    AuthConfig,
+    ConnectConfig,
+    DataSourceEntry,
+    PackageManagerConfig,
+    VIPConfig,
+    WorkbenchConfig,
+)
+
+
+class TestConnectConfigRepr:
+    def test_api_key_is_redacted_when_set(self):
+        cfg = ConnectConfig(url="https://connect.example.com", api_key="secret-key-abc123")
+        r = repr(cfg)
+        assert "secret-key-abc123" not in r
+        assert "'***'" in r
+
+    def test_api_key_is_empty_string_when_unset(self):
+        cfg = ConnectConfig(url="https://connect.example.com", api_key="")
+        r = repr(cfg)
+        assert "'***'" not in r
+        assert "api_key=''" in r
+
+    def test_non_secret_fields_appear_in_repr(self):
+        cfg = ConnectConfig(url="https://connect.example.com", api_key="secret")
+        r = repr(cfg)
+        assert "https://connect.example.com" in r
+        assert "ConnectConfig(" in r
+
+
+class TestWorkbenchConfigRepr:
+    def test_api_key_is_redacted_when_set(self):
+        cfg = WorkbenchConfig(url="https://workbench.example.com", api_key="wb-secret-456")
+        r = repr(cfg)
+        assert "wb-secret-456" not in r
+        assert "'***'" in r
+
+    def test_api_key_is_empty_string_when_unset(self):
+        cfg = WorkbenchConfig(url="https://workbench.example.com", api_key="")
+        r = repr(cfg)
+        assert "'***'" not in r
+        assert "api_key=''" in r
+
+    def test_non_secret_fields_appear_in_repr(self):
+        cfg = WorkbenchConfig(url="https://workbench.example.com", api_key="secret")
+        r = repr(cfg)
+        assert "https://workbench.example.com" in r
+        assert "WorkbenchConfig(" in r
+
+
+class TestPackageManagerConfigRepr:
+    def test_token_is_redacted_when_set(self):
+        cfg = PackageManagerConfig(url="https://pm.example.com", token="pm-token-789")
+        r = repr(cfg)
+        assert "pm-token-789" not in r
+        assert "'***'" in r
+
+    def test_token_is_empty_string_when_unset(self):
+        cfg = PackageManagerConfig(url="https://pm.example.com", token="")
+        r = repr(cfg)
+        assert "'***'" not in r
+        assert "token=''" in r
+
+    def test_non_secret_fields_appear_in_repr(self):
+        cfg = PackageManagerConfig(url="https://pm.example.com", token="secret")
+        r = repr(cfg)
+        assert "https://pm.example.com" in r
+        assert "PackageManagerConfig(" in r
+
+
+class TestAuthConfigRepr:
+    def test_password_is_redacted_when_set(self):
+        cfg = AuthConfig(username="admin", password="hunter2")
+        r = repr(cfg)
+        assert "hunter2" not in r
+        assert "'***'" in r
+
+    def test_password_is_empty_string_when_unset(self):
+        cfg = AuthConfig(username="admin", password="")
+        r = repr(cfg)
+        assert "'***'" not in r
+        assert "password=''" in r
+
+    def test_non_secret_fields_appear_in_repr(self):
+        cfg = AuthConfig(username="admin", password="secret")
+        r = repr(cfg)
+        assert "admin" in r
+        assert "AuthConfig(" in r
+
+
+class TestDataSourceEntryRepr:
+    def test_connection_string_is_redacted_when_set(self):
+        entry = DataSourceEntry(
+            name="mydb", type="postgres", connection_string="postgresql://user:pass@host/db"
+        )
+        r = repr(entry)
+        assert "postgresql://user:pass@host/db" not in r
+        assert "'***'" in r
+
+    def test_connection_string_is_empty_string_when_unset(self):
+        entry = DataSourceEntry(name="mydb", type="postgres", connection_string="")
+        r = repr(entry)
+        assert "'***'" not in r
+        assert "connection_string=''" in r
+
+    def test_non_secret_fields_appear_in_repr(self):
+        entry = DataSourceEntry(name="mydb", type="postgres", connection_string="secret")
+        r = repr(entry)
+        assert "mydb" in r
+        assert "DataSourceEntry(" in r
+
+
+class TestVIPConfigReprDoesNotLeakSecrets:
+    """Ensure repr(VIPConfig(...)) does not expose any plaintext secret.
+
+    pytest's assertion rewriting recurses into nested objects by calling their
+    __repr__, so this is the real-world scenario from the issue.
+    """
+
+    def test_vipconfig_repr_does_not_contain_secrets(self):
+        cfg = VIPConfig(
+            connect=ConnectConfig(url="https://connect.example.com", api_key="connect-secret"),
+            workbench=WorkbenchConfig(url="https://workbench.example.com", api_key="wb-secret"),
+            package_manager=PackageManagerConfig(url="https://pm.example.com", token="pm-secret"),
+            auth=AuthConfig(username="admin", password="auth-secret"),
+            data_sources=[
+                DataSourceEntry(name="db", type="postgres", connection_string="conn-secret")
+            ],
+        )
+        r = repr(cfg)
+        assert "connect-secret" not in r
+        assert "wb-secret" not in r
+        assert "pm-secret" not in r
+        assert "auth-secret" not in r
+        assert "conn-secret" not in r

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -102,6 +102,14 @@ class ConnectConfig(ProductConfig):
         if not self.api_key:
             self.api_key = os.environ.get("VIP_CONNECT_API_KEY", "")
 
+    def __repr__(self) -> str:
+        api_key_repr = "'***'" if self.api_key else "''"
+        return (
+            f"ConnectConfig(enabled={self.enabled!r}, url={self.url!r}, "
+            f"version={self.version!r}, api_key={api_key_repr}, "
+            f"deploy_timeout={self.deploy_timeout!r})"
+        )
+
     @classmethod
     def from_dict(cls, raw: dict) -> ConnectConfig:
         return cls(
@@ -150,6 +158,15 @@ class WorkbenchConfig(ProductConfig):
         if not self.api_key:
             self.api_key = os.environ.get("VIP_WORKBENCH_API_KEY", "")
 
+    def __repr__(self) -> str:
+        api_key_repr = "'***'" if self.api_key else "''"
+        return (
+            f"WorkbenchConfig(enabled={self.enabled!r}, url={self.url!r}, "
+            f"version={self.version!r}, api_key={api_key_repr}, "
+            f"session_profiles={self.session_profiles!r}, "
+            f"session_count={self.session_count!r}, extensions={self.extensions!r})"
+        )
+
     @classmethod
     def from_dict(cls, raw: dict) -> WorkbenchConfig:
         return cls(
@@ -176,6 +193,13 @@ class PackageManagerConfig(ProductConfig):
                 "VIP_PACKAGE_MANAGER_TOKEN", os.environ.get("VIP_PM_TOKEN", "")
             )
 
+    def __repr__(self) -> str:
+        token_repr = "'***'" if self.token else "''"
+        return (
+            f"PackageManagerConfig(enabled={self.enabled!r}, url={self.url!r}, "
+            f"version={self.version!r}, token={token_repr})"
+        )
+
     @classmethod
     def from_dict(cls, raw: dict) -> PackageManagerConfig:
         return cls(
@@ -200,6 +224,13 @@ class AuthConfig:
             self.username = os.environ.get("VIP_TEST_USERNAME", "")
         if not self.password:
             self.password = os.environ.get("VIP_TEST_PASSWORD", "")
+
+    def __repr__(self) -> str:
+        password_repr = "'***'" if self.password else "''"
+        return (
+            f"AuthConfig(provider={self.provider!r}, username={self.username!r}, "
+            f"password={password_repr}, idp={self.idp!r})"
+        )
 
     @classmethod
     def from_dict(cls, raw: dict) -> AuthConfig:
@@ -270,6 +301,13 @@ class DataSourceEntry:
     name: str = ""
     type: str = ""
     connection_string: str = ""
+
+    def __repr__(self) -> str:
+        conn_repr = "'***'" if self.connection_string else "''"
+        return (
+            f"DataSourceEntry(name={self.name!r}, type={self.type!r}, "
+            f"connection_string={conn_repr})"
+        )
 
 
 @dataclass

--- a/uv.lock
+++ b/uv.lock
@@ -2482,7 +2482,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.30.1"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-vip-fix-config-repr-secrets.md
+++ b/validation_docs/demo-vip-fix-config-repr-secrets.md
@@ -1,0 +1,55 @@
+# Fix: redact secrets in config dataclass repr
+
+*2026-05-11T16:34:02Z by Showboat 0.6.1*
+<!-- showboat-id: 3b7b91f5-89e4-40b5-aee4-d1bc4c7eb73d -->
+
+Config dataclasses (ConnectConfig, WorkbenchConfig, PackageManagerConfig, AuthConfig, DataSourceEntry) previously leaked secrets in their default repr, exposing API keys and passwords in CI logs and pytest assertion output. Issue #223: each class now has a custom __repr__ that prints sensitive fields as '***' when set and '' when empty. A new selftest file selftests/test_config_repr.py covers the change.
+
+```bash
+uv run python -c "
+from vip.config import ConnectConfig, AuthConfig
+c = ConnectConfig(url='https://connect.example.com', api_key='SECRET-12345')
+a = AuthConfig(username='admin', password='hunter2')
+print(repr(c))
+print(repr(a))
+"
+```
+
+```output
+ConnectConfig(enabled=True, url='https://connect.example.com', version=None, api_key='***', deploy_timeout=1200)
+AuthConfig(provider='password', username='admin', password='***', idp='')
+```
+
+```bash
+uv run pytest selftests/test_config_repr.py -v 2>&1 | grep -E 'PASSED|FAILED' | sed 's/ \[.*\]//' | sort
+```
+
+```output
+selftests/test_config_repr.py::TestAuthConfigRepr::test_non_secret_fields_appear_in_repr PASSED
+selftests/test_config_repr.py::TestAuthConfigRepr::test_password_is_empty_string_when_unset PASSED
+selftests/test_config_repr.py::TestAuthConfigRepr::test_password_is_redacted_when_set PASSED
+selftests/test_config_repr.py::TestConnectConfigRepr::test_api_key_is_empty_string_when_unset PASSED
+selftests/test_config_repr.py::TestConnectConfigRepr::test_api_key_is_redacted_when_set PASSED
+selftests/test_config_repr.py::TestConnectConfigRepr::test_non_secret_fields_appear_in_repr PASSED
+selftests/test_config_repr.py::TestDataSourceEntryRepr::test_connection_string_is_empty_string_when_unset PASSED
+selftests/test_config_repr.py::TestDataSourceEntryRepr::test_connection_string_is_redacted_when_set PASSED
+selftests/test_config_repr.py::TestDataSourceEntryRepr::test_non_secret_fields_appear_in_repr PASSED
+selftests/test_config_repr.py::TestPackageManagerConfigRepr::test_non_secret_fields_appear_in_repr PASSED
+selftests/test_config_repr.py::TestPackageManagerConfigRepr::test_token_is_empty_string_when_unset PASSED
+selftests/test_config_repr.py::TestPackageManagerConfigRepr::test_token_is_redacted_when_set PASSED
+selftests/test_config_repr.py::TestVIPConfigReprDoesNotLeakSecrets::test_vipconfig_repr_does_not_contain_secrets PASSED
+selftests/test_config_repr.py::TestWorkbenchConfigRepr::test_api_key_is_empty_string_when_unset PASSED
+selftests/test_config_repr.py::TestWorkbenchConfigRepr::test_api_key_is_redacted_when_set PASSED
+selftests/test_config_repr.py::TestWorkbenchConfigRepr::test_non_secret_fields_appear_in_repr PASSED
+```
+
+```bash
+uv run ruff check src/vip/config.py selftests/test_config_repr.py && uv run ruff format --check src/vip/config.py selftests/test_config_repr.py
+```
+
+```output
+All checks passed!
+2 files already formatted
+```
+
+The selftest suite covers 16 tests across all 5 config classes (ConnectConfig, WorkbenchConfig, PackageManagerConfig, AuthConfig, DataSourceEntry), with 3 tests per class validating redaction when set, empty-string display when unset, and non-secret field visibility. A 16th integration test (TestVIPConfigReprDoesNotLeakSecrets) constructs a full VIPConfig and asserts none of the 5 secret values appear in repr output.


### PR DESCRIPTION
## Summary

- Adds custom `__repr__` to 5 config dataclasses that previously leaked
  secrets via Python's default dataclass repr.
- Sensitive fields (`api_key`, `token`, `password`, `connection_string`)
  now display as `'***'` when populated and `''` when empty.
- Adds `selftests/test_config_repr.py` covering each class plus an
  end-to-end test that mirrors the leak scenario from the issue.

Fixes #223.

## Test plan

- [x] `uv run pytest selftests/test_config_repr.py -v` — 16/16 pass
- [x] `uv run pytest selftests/ -v` — 501 passed, 3 skipped, no regressions
- [x] `uv run ruff check src/ selftests/` clean
- [x] `uv run ruff format --check src/ selftests/` clean

## Observed output

Running the demo against a populated config:

```
ConnectConfig(enabled=True, url='https://connect.example.com', version=None, api_key='***', deploy_timeout=1200)
AuthConfig(provider='password', username='admin', password='***', idp='')
DataSourceEntry(name='mydb', type='postgres', connection_string='***')
```

## Demo

See `validation_docs/demo-vip-fix-config-repr-secrets.md`.