### PR TITLE
fix(workbench): resume sessions via Launch modal button

### DIFF
--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -6,6 +6,7 @@ Patterns adapted from test_ide_launch.py.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -157,27 +158,70 @@ def user_resumes_session(page: Page, session_context: dict):
 
 
 @then("the session reaches Active state again")
-def session_becomes_active_again(page: Page, session_context: dict):
+def session_becomes_active_again(page: Page, workbench_url: str, session_context: dict):
     """Verify the session transitions back to Active state."""
     session_name = session_context["name"]
 
-    # Reload so the DOM reflects the current server state. Unlike the
-    # Active → Suspended check at line ~128, which observes the transition
-    # on the same homepage instance, the resume path requires a reload
-    # because go_back() returns a cached homepage where the "Suspended"
-    # badge has not been re-rendered. After the reload, Workbench's
-    # client-side state polling surfaces the Suspended → Active transition.
-    page.reload(timeout=TIMEOUT_PAGE_LOAD)
+    # Explicitly navigate back to /home. user_resumes_session attempts the
+    # same bounce, but Playwright's goto() races with the IDE iframe loading
+    # on /s/<id> and sometimes leaves the page on the session URL — where the
+    # sidebar shows a stale Suspended badge regardless of the actual server
+    # state. Doing the navigation here, in the observation step, guarantees
+    # we are looking at the real homepage.
+    home_url = workbench_url.rstrip("/") + "/home"
+    page.goto(home_url, timeout=TIMEOUT_PAGE_LOAD)
     expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 
+    # The Workbench homepage does not auto-poll session state, so a single
+    # locator wait cannot observe the Suspended → Active transition. Reload
+    # periodically inside the overall budget until the Active badge appears.
     session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
+    inner_timeout_ms = 5000
+    deadline = time.time() + (TIMEOUT_SESSION_START / 1000)
+    exc: AssertionError | None = None
+    while True:
+        try:
+            expect(session_active).to_be_visible(timeout=inner_timeout_ms)
+            return  # Active observed
+        except AssertionError as e:
+            exc = e
+            if time.time() >= deadline:
+                break
+            page.reload(timeout=TIMEOUT_PAGE_LOAD)
+            expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+
+    # Diagnostics before skip: capture what the homepage actually shows so
+    # we can tell whether the session is stuck on Suspended/Starting,
+    # whether the row is missing, or whether the selector format changed.
+    # Temporary — remove once the root cause of #238 is fully understood.
+    diag: list[str] = []
     try:
-        expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
-    except AssertionError as exc:
-        pytest.skip(
-            f"Session did not return to Active state after resume — "
-            f"suspend/resume may not be supported in this Workbench configuration ({exc})"
-        )
+        diag.append(f"page_url={page.url!r}")
+    except Exception as e:
+        diag.append(f"page_url_error={e!r}")
+    try:
+        row = page.locator(Homepage.session_row(session_name))
+        row_count = row.count()
+        diag.append(f"session_row_count={row_count}")
+        if row_count > 0:
+            badges = row.locator("[aria-label]").all()
+            labels = [b.get_attribute("aria-label") for b in badges[:20]]
+            diag.append(f"row_aria_labels={labels}")
+            diag.append(f"row_text={row.inner_text()[:500]!r}")
+    except Exception as e:
+        diag.append(f"row_inspect_error={e!r}")
+    try:
+        screenshot_dir = Path("report") / "diagnostics"
+        screenshot_dir.mkdir(parents=True, exist_ok=True)
+        screenshot_path = screenshot_dir / f"session_resume_skip_{int(time.time())}.png"
+        page.screenshot(path=str(screenshot_path), full_page=True)
+        diag.append(f"screenshot={screenshot_path}")
+    except Exception as e:
+        diag.append(f"screenshot_error={e!r}")
+    pytest.skip(
+        "Session did not return to Active state after resume — "
+        f"diagnostics: {' | '.join(diag)} | original: {exc}"
+    )
 
 
 @then("the session is cleaned up")

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -161,6 +161,11 @@ def session_becomes_active_again(page: Page, session_context: dict):
     """Verify the session transitions back to Active state."""
     session_name = session_context["name"]
 
+    # Reload so the DOM reflects the current server state — go_back() can leave
+    # a cached page where the "Suspended" badge has not been re-rendered yet.
+    page.reload()
+    expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+
     session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
     try:
         expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -152,7 +152,16 @@ def user_resumes_session(page: Page, session_context: dict):
         # way to resume.  Click the session name text as a fallback.
         session_row.locator(f"text='{session_name}'").click()
 
-    # Navigate back to homepage to observe the Active state
+    # Wait for the navigation into the session URL to commit before going
+    # anywhere else. Clicking a suspended session navigates to /s/<id> which
+    # triggers the backend resume — but if we navigate away before that
+    # commits, Workbench aborts the start and the session stays Suspended.
+    page.wait_for_url("**/s/**", timeout=TIMEOUT_PAGE_LOAD)
+    page.wait_for_load_state("load", timeout=TIMEOUT_PAGE_LOAD)
+
+    # Navigate back to homepage to observe the Active state. NB: Workbench's
+    # /home may auto-redirect back to the recently-used session — that is OK
+    # for the next step, which observes the session badge in the sidebar.
     page.goto(page.url.split("/s/")[0] + "/home") if "/s/" in page.url else page.go_back()
     expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -140,15 +140,15 @@ def user_resumes_session(page: Page, session_context: dict):
 
     # Modern Workbench does not expose a one-click launch link on the row
     # for suspended sessions. Active sessions have `a[title='join <name>']`,
-    # but suspended ones only have the session-name link, which opens a
-    # session-details modal that contains a "Launch" button — that button
-    # is what triggers the backend resume. The previous implementation's
-    # `session_row.locator("a").first` was picking up a "Details" link
-    # instead, navigating to /s/<id>/workspaces/ (a management view) and
-    # never resuming the session.
-    name_link = page.locator(Homepage.session_link(session_name)).first
-    expect(name_link).to_be_visible(timeout=TIMEOUT_DIALOG)
-    name_link.click()
+    # but on suspended rows the name is rendered as plain text — clicking
+    # it opens a session-details modal that contains a "Launch" button.
+    # That Launch button is what triggers the backend resume. The previous
+    # implementation's `session_row.locator("a").first` was picking up a
+    # "Details" link instead, navigating to /s/<id>/workspaces/ (a
+    # management view) and never resuming the session.
+    name_text = session_row.locator(Homepage.session_text(session_name))
+    expect(name_text).to_be_visible(timeout=TIMEOUT_DIALOG)
+    name_text.click()
 
     modal = page.locator(Homepage.SESSION_DETAILS_DIALOG)
     expect(modal).to_be_visible(timeout=TIMEOUT_DIALOG)

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -163,7 +163,7 @@ def session_becomes_active_again(page: Page, session_context: dict):
 
     # Reload so the DOM reflects the current server state — go_back() can leave
     # a cached page where the "Suspended" badge has not been re-rendered yet.
-    page.reload()
+    page.reload(timeout=TIMEOUT_PAGE_LOAD)
     expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 
     session_active = page.locator(Homepage.session_row_status(session_name, "Active"))

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -162,7 +162,11 @@ def session_becomes_active_again(page: Page, session_context: dict):
     session_name = session_context["name"]
 
     # Reload so the DOM reflects the current server state — go_back() can leave
-    # a cached page where the "Suspended" badge has not been re-rendered yet.
+    # a cached page where the "Suspended" badge has not been re-rendered.
+    # After the reload, the Workbench homepage's client-side state polling
+    # surfaces the Suspended → Active transition (same pattern used at line
+    # ~128 above, where Playwright's locator polling observes the
+    # Active → Suspended transition without a reload).
     page.reload(timeout=TIMEOUT_PAGE_LOAD)
     expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -150,9 +150,13 @@ def user_resumes_session(page: Page, session_context: dict):
     expect(name_text).to_be_visible(timeout=TIMEOUT_DIALOG)
     name_text.click()
 
-    modal = page.locator(Homepage.SESSION_DETAILS_DIALOG)
-    expect(modal).to_be_visible(timeout=TIMEOUT_DIALOG)
-    launch_btn = modal.locator("button:text-is('Launch')")
+    # Wait for the Launch button directly rather than the modal container.
+    # The modal's CSS class varies between Workbench UI versions (the page
+    # object's SESSION_DETAILS_DIALOG selector uses class*='modal-dialog'
+    # which does not match the newer data-slot based dialog markup), but
+    # the button text is stable. A visible Launch button proves the modal
+    # opened.
+    launch_btn = page.locator("button:text-is('Launch')")
     expect(launch_btn).to_be_visible(timeout=TIMEOUT_DIALOG)
     launch_btn.click()
 

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -161,12 +161,12 @@ def session_becomes_active_again(page: Page, session_context: dict):
     """Verify the session transitions back to Active state."""
     session_name = session_context["name"]
 
-    # Reload so the DOM reflects the current server state — go_back() can leave
-    # a cached page where the "Suspended" badge has not been re-rendered.
-    # After the reload, the Workbench homepage's client-side state polling
-    # surfaces the Suspended → Active transition (same pattern used at line
-    # ~128 above, where Playwright's locator polling observes the
-    # Active → Suspended transition without a reload).
+    # Reload so the DOM reflects the current server state. Unlike the
+    # Active → Suspended check at line ~128, which observes the transition
+    # on the same homepage instance, the resume path requires a reload
+    # because go_back() returns a cached homepage where the "Suspended"
+    # badge has not been re-rendered. After the reload, Workbench's
+    # client-side state polling surfaces the Suspended → Active transition.
     page.reload(timeout=TIMEOUT_PAGE_LOAD)
     expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -206,37 +206,9 @@ def session_becomes_active_again(page: Page, workbench_url: str, session_context
             page.reload(timeout=TIMEOUT_PAGE_LOAD)
             expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 
-    # Diagnostics before skip: capture what the homepage actually shows so
-    # we can tell whether the session is stuck on Suspended/Starting,
-    # whether the row is missing, or whether the selector format changed.
-    # Temporary — remove once the root cause of #238 is fully understood.
-    diag: list[str] = []
-    try:
-        diag.append(f"page_url={page.url!r}")
-    except Exception as e:
-        diag.append(f"page_url_error={e!r}")
-    try:
-        row = page.locator(Homepage.session_row(session_name))
-        row_count = row.count()
-        diag.append(f"session_row_count={row_count}")
-        if row_count > 0:
-            badges = row.locator("[aria-label]").all()
-            labels = [b.get_attribute("aria-label") for b in badges[:20]]
-            diag.append(f"row_aria_labels={labels}")
-            diag.append(f"row_text={row.inner_text()[:500]!r}")
-    except Exception as e:
-        diag.append(f"row_inspect_error={e!r}")
-    try:
-        screenshot_dir = Path("report") / "diagnostics"
-        screenshot_dir.mkdir(parents=True, exist_ok=True)
-        screenshot_path = screenshot_dir / f"session_resume_skip_{int(time.time())}.png"
-        page.screenshot(path=str(screenshot_path), full_page=True)
-        diag.append(f"screenshot={screenshot_path}")
-    except Exception as e:
-        diag.append(f"screenshot_error={e!r}")
     pytest.skip(
-        "Session did not return to Active state after resume — "
-        f"diagnostics: {' | '.join(diag)} | original: {exc}"
+        f"Session did not return to Active state after resume — "
+        f"suspend/resume may not be supported in this Workbench configuration ({exc})"
     )
 
 

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -132,30 +132,33 @@ def session_becomes_suspended(page: Page, session_context: dict):
 
 @when("the user resumes the session")
 def user_resumes_session(page: Page, session_context: dict):
-    """Click the suspended session link to resume it."""
+    """Open the session details modal and click Launch to resume the session."""
     session_name = session_context["name"]
 
     session_row = page.locator(Homepage.session_row(session_name))
     expect(session_row).to_be_visible(timeout=TIMEOUT_DIALOG)
 
-    # Suspended sessions may not have a clickable link.  Select the session
-    # checkbox and click the session name text to trigger a resume, or fall
-    # back to navigating into the session via any available link.
-    session_link = session_row.locator("a").first
-    if session_link.count() > 0:
-        session_link.click()
-    else:
-        # No link available — select and use the session row action
-        checkbox = page.locator(Homepage.session_checkbox(session_name))
-        checkbox.click()
-        # After selecting a suspended session, the homepage should offer a
-        # way to resume.  Click the session name text as a fallback.
-        session_row.locator(f"text='{session_name}'").click()
+    # Modern Workbench does not expose a one-click launch link on the row
+    # for suspended sessions. Active sessions have `a[title='join <name>']`,
+    # but suspended ones only have the session-name link, which opens a
+    # session-details modal that contains a "Launch" button — that button
+    # is what triggers the backend resume. The previous implementation's
+    # `session_row.locator("a").first` was picking up a "Details" link
+    # instead, navigating to /s/<id>/workspaces/ (a management view) and
+    # never resuming the session.
+    name_link = page.locator(Homepage.session_link(session_name)).first
+    expect(name_link).to_be_visible(timeout=TIMEOUT_DIALOG)
+    name_link.click()
+
+    modal = page.locator(Homepage.SESSION_DETAILS_DIALOG)
+    expect(modal).to_be_visible(timeout=TIMEOUT_DIALOG)
+    launch_btn = modal.locator("button:text-is('Launch')")
+    expect(launch_btn).to_be_visible(timeout=TIMEOUT_DIALOG)
+    launch_btn.click()
 
     # Wait for the navigation into the session URL to commit before going
-    # anywhere else. Clicking a suspended session navigates to /s/<id> which
-    # triggers the backend resume — but if we navigate away before that
-    # commits, Workbench aborts the start and the session stays Suspended.
+    # anywhere else. Navigating away from /s/<id> too quickly causes
+    # Workbench to abort the resume.
     page.wait_for_url("**/s/**", timeout=TIMEOUT_PAGE_LOAD)
     page.wait_for_load_state("load", timeout=TIMEOUT_PAGE_LOAD)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2482,7 +2482,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.30.1"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-vip-fix-suspend-resume-reload.md
+++ b/validation_docs/demo-vip-fix-suspend-resume-reload.md
@@ -1,9 +1,9 @@
 # Fix: reload page before polling for Active on resume
 
-*2026-05-11T21:20:04Z by Showboat 0.6.1*
-<!-- showboat-id: 0616d658-85a1-4ce6-bb72-404cc36655a4 -->
+*2026-05-12T18:02:59Z by Showboat 0.6.1*
+<!-- showboat-id: fef45b21-a767-4ac9-bc98-936b0adaf83c -->
 
-Issue #238: `test_session_suspend_resume` consistently timed out at 90 seconds waiting for the Active badge to reappear after resume. Root cause: `page.go_back()` in the resume step leaves a stale homepage DOM where the badge still reads "Suspended", so DOM polling never sees the transition to Active. The fix adds `page.reload()` plus a homepage-logo wait at the start of the `session_becomes_active_again` step in `src/vip_tests/workbench/test_sessions.py`. End-to-end verification requires a real Workbench deployment, so this demo proves the change is well-formed: the test still collects, lint passes, and the diff is small and reviewable.
+Issue #238: `test_session_suspend_resume` consistently timed out at 90 seconds waiting for the Active badge to reappear after resume. Root cause: `page.go_back()` in the resume step leaves a stale homepage DOM where the badge still reads "Suspended", so DOM polling never sees the transition to Active. The fix adds `page.reload(timeout=TIMEOUT_PAGE_LOAD)` plus a homepage-logo wait at the start of the `session_becomes_active_again` step in `src/vip_tests/workbench/test_sessions.py`. End-to-end verification requires a real Workbench deployment, so this demo proves the change is well-formed: the test still collects, lint passes, and the diff is small and reviewable.
 
 ```bash
 uv run pytest src/vip_tests/ --collect-only --quiet 2>&1 | tail -1 | sed 's/ in [0-9.]*s//'
@@ -14,13 +14,19 @@ uv run pytest src/vip_tests/ --collect-only --quiet 2>&1 | tail -1 | sed 's/ in 
 ```
 
 ```bash
-uv run ruff check src/vip_tests/workbench/test_sessions.py && uv run ruff format --check src/vip_tests/workbench/test_sessions.py && echo 'ruff: all checks passed'
+uv run ruff check src/vip_tests/workbench/test_sessions.py
 ```
 
 ```output
 All checks passed!
+```
+
+```bash
+uv run ruff format --check src/vip_tests/workbench/test_sessions.py
+```
+
+```output
 1 file already formatted
-ruff: all checks passed
 ```
 
 ```bash
@@ -28,8 +34,8 @@ git diff --stat origin/main -- src/vip_tests/workbench/test_sessions.py
 ```
 
 ```output
- src/vip_tests/workbench/test_sessions.py | 5 +++++
- 1 file changed, 5 insertions(+)
+ src/vip_tests/workbench/test_sessions.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 ```
 
 ```bash
@@ -38,16 +44,20 @@ git diff origin/main -- src/vip_tests/workbench/test_sessions.py
 
 ```output
 diff --git a/src/vip_tests/workbench/test_sessions.py b/src/vip_tests/workbench/test_sessions.py
-index d8d067b..3675164 100644
+index d8d067b..5f047d9 100644
 --- a/src/vip_tests/workbench/test_sessions.py
 +++ b/src/vip_tests/workbench/test_sessions.py
-@@ -161,6 +161,11 @@ def session_becomes_active_again(page: Page, session_context: dict):
+@@ -161,6 +161,15 @@ def session_becomes_active_again(page: Page, session_context: dict):
      """Verify the session transitions back to Active state."""
      session_name = session_context["name"]
  
 +    # Reload so the DOM reflects the current server state — go_back() can leave
-+    # a cached page where the "Suspended" badge has not been re-rendered yet.
-+    page.reload()
++    # a cached page where the "Suspended" badge has not been re-rendered.
++    # After the reload, the Workbench homepage's client-side state polling
++    # surfaces the Suspended → Active transition (same pattern used at line
++    # ~128 above, where Playwright's locator polling observes the
++    # Active → Suspended transition without a reload).
++    page.reload(timeout=TIMEOUT_PAGE_LOAD)
 +    expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 +
      session_active = page.locator(Homepage.session_row_status(session_name, "Active"))

--- a/validation_docs/demo-vip-fix-suspend-resume-reload.md
+++ b/validation_docs/demo-vip-fix-suspend-resume-reload.md
@@ -1,12 +1,12 @@
-# Fix: reload page before polling for Active on resume
+# Fix: resume Workbench session via Launch modal button
 
-*2026-05-12T18:02:59Z by Showboat 0.6.1*
-<!-- showboat-id: fef45b21-a767-4ac9-bc98-936b0adaf83c -->
+*2026-05-13T15:19:34Z by Showboat 0.6.1*
+<!-- showboat-id: 2f460187-9714-4a49-bfbd-86de3751e905 -->
 
-Issue #238: `test_session_suspend_resume` consistently timed out at 90 seconds waiting for the Active badge to reappear after resume. Root cause: `page.go_back()` in the resume step leaves a stale homepage DOM where the badge still reads "Suspended", so DOM polling never sees the transition to Active. The fix adds `page.reload(timeout=TIMEOUT_PAGE_LOAD)` plus a homepage-logo wait at the start of the `session_becomes_active_again` step in `src/vip_tests/workbench/test_sessions.py`. End-to-end verification requires a real Workbench deployment, so this demo proves the change is well-formed: the test still collects, lint passes, and the diff is small and reviewable.
+Issue #238: test_session_suspend_resume was failing because user_resumes_session clicked a 'Details' anchor link on the suspended session row instead of triggering the backend resume. Modern Workbench renders the session name as plain text on suspended rows; clicking it opens a session-details modal containing a 'Launch' button — that button is what initiates the resume. The fix clicks the session name text to open the modal, waits for and clicks the Launch button, then waits for the session URL before returning to /home. In the observation step, session_becomes_active_again now also does an explicit goto /home and retries with page.reload() inside the session-start budget because the Workbench homepage does not auto-poll session state. Validated end-to-end against dev.ganso.lab.staging.posit.team: test_session_suspend_resume[chromium] PASSED.
 
 ```bash
-uv run pytest src/vip_tests/ --collect-only --quiet 2>&1 | tail -1 | sed 's/ in [0-9.]*s//'
+NO_COLOR=1 uv run pytest src/vip_tests/ --collect-only --quiet 2>&1 | tail -1 | sed 's/ in [0-9.]*s//'
 ```
 
 ```output
@@ -34,35 +34,8 @@ git diff --stat origin/main -- src/vip_tests/workbench/test_sessions.py
 ```
 
 ```output
- src/vip_tests/workbench/test_sessions.py | 9 +++++++++
- 1 file changed, 9 insertions(+)
+ src/vip_tests/workbench/test_sessions.py | 89 +++++++++++++++++++++++---------
+ 1 file changed, 65 insertions(+), 24 deletions(-)
 ```
 
-```bash
-git diff origin/main -- src/vip_tests/workbench/test_sessions.py
-```
-
-```output
-diff --git a/src/vip_tests/workbench/test_sessions.py b/src/vip_tests/workbench/test_sessions.py
-index d8d067b..5f047d9 100644
---- a/src/vip_tests/workbench/test_sessions.py
-+++ b/src/vip_tests/workbench/test_sessions.py
-@@ -161,6 +161,15 @@ def session_becomes_active_again(page: Page, session_context: dict):
-     """Verify the session transitions back to Active state."""
-     session_name = session_context["name"]
- 
-+    # Reload so the DOM reflects the current server state — go_back() can leave
-+    # a cached page where the "Suspended" badge has not been re-rendered.
-+    # After the reload, the Workbench homepage's client-side state polling
-+    # surfaces the Suspended → Active transition (same pattern used at line
-+    # ~128 above, where Playwright's locator polling observes the
-+    # Active → Suspended transition without a reload).
-+    page.reload(timeout=TIMEOUT_PAGE_LOAD)
-+    expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
-+
-     session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
-     try:
-         expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
-```
-
-End-to-end verification — confirming the session badge transitions correctly after resume — requires a real Workbench deployment and is tracked for validation against the staging cluster.
+End-to-end validation against dev.ganso.lab.staging.posit.team on 2026-05-13: test_session_suspend_resume[chromium] PASSED with the session-name text click + Launch modal + reload-retry flow.

--- a/validation_docs/demo-vip-fix-suspend-resume-reload.md
+++ b/validation_docs/demo-vip-fix-suspend-resume-reload.md
@@ -1,0 +1,58 @@
+# Fix: reload page before polling for Active on resume
+
+*2026-05-11T21:20:04Z by Showboat 0.6.1*
+<!-- showboat-id: 0616d658-85a1-4ce6-bb72-404cc36655a4 -->
+
+Issue #238: `test_session_suspend_resume` consistently timed out at 90 seconds waiting for the Active badge to reappear after resume. Root cause: `page.go_back()` in the resume step leaves a stale homepage DOM where the badge still reads "Suspended", so DOM polling never sees the transition to Active. The fix adds `page.reload()` plus a homepage-logo wait at the start of the `session_becomes_active_again` step in `src/vip_tests/workbench/test_sessions.py`. End-to-end verification requires a real Workbench deployment, so this demo proves the change is well-formed: the test still collects, lint passes, and the diff is small and reviewable.
+
+```bash
+uv run pytest src/vip_tests/ --collect-only --quiet 2>&1 | tail -1 | sed 's/ in [0-9.]*s//'
+```
+
+```output
+7/103 tests collected (96 deselected)
+```
+
+```bash
+uv run ruff check src/vip_tests/workbench/test_sessions.py && uv run ruff format --check src/vip_tests/workbench/test_sessions.py && echo 'ruff: all checks passed'
+```
+
+```output
+All checks passed!
+1 file already formatted
+ruff: all checks passed
+```
+
+```bash
+git diff --stat origin/main -- src/vip_tests/workbench/test_sessions.py
+```
+
+```output
+ src/vip_tests/workbench/test_sessions.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+```
+
+```bash
+git diff origin/main -- src/vip_tests/workbench/test_sessions.py
+```
+
+```output
+diff --git a/src/vip_tests/workbench/test_sessions.py b/src/vip_tests/workbench/test_sessions.py
+index d8d067b..3675164 100644
+--- a/src/vip_tests/workbench/test_sessions.py
++++ b/src/vip_tests/workbench/test_sessions.py
+@@ -161,6 +161,11 @@ def session_becomes_active_again(page: Page, session_context: dict):
+     """Verify the session transitions back to Active state."""
+     session_name = session_context["name"]
+ 
++    # Reload so the DOM reflects the current server state — go_back() can leave
++    # a cached page where the "Suspended" badge has not been re-rendered yet.
++    page.reload()
++    expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
++
+     session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
+     try:
+         expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
+```
+
+End-to-end verification — confirming the session badge transitions correctly after resume — requires a real Workbench deployment and is tracked for validation against the staging cluster.


### PR DESCRIPTION
## Summary

`test_session_suspend_resume` was timing out at 90s waiting for the
"Active" badge to reappear after resume. End-to-end debugging against
`dev.ganso.lab.staging.posit.team` surfaced a layered set of root causes
— the original "minimal `page.reload()` fix" assumption from the issue
was wrong.

The real bug was in `user_resumes_session`: it grabbed the first `<a>`
in a suspended session row and clicked it, expecting that to trigger
resume. In modern Workbench the first `<a>` on a suspended row is a
"Details" link that navigates to `/s/<id>/workspaces/` — a session
management view — and never triggers resume at all.

Modern Workbench's actual suspended-session resume flow:

1. Click the session-name text (not a link).
2. A session-details modal opens.
3. Click the **Launch** button inside the modal.

This PR reworks `user_resumes_session` to do exactly that:

- Clicks the session-name text via `Homepage.session_text(name)`
  (scoped to the row).
- Waits for the **Launch** button directly (the modal's CSS class
  varies between Workbench UI versions; the button text is stable).
- Clicks Launch, then `wait_for_url("**/s/**") + wait_for_load_state("load")`
  so Workbench has time to commit to starting the session before any
  navigation away (otherwise the resume is aborted).

Additionally, `session_becomes_active_again` now:

- Explicitly navigates back to `/home` (Workbench's `/home` can
  auto-redirect to recently-used sessions; the previous step's bounce
  can race).
- Replaces the original single locator wait with a **reload-retry
  loop**: the Workbench homepage does not auto-poll session state, so
  one DOM snapshot never observes the Suspended → Active transition.
  The loop reloads every ~5s within the overall `TIMEOUT_SESSION_START`
  budget until the Active badge appears.

Fixes #238.

## Scope notes

- The `pytest.skip` fallback inside `session_becomes_active_again` is
  intentionally left in place. The roborev review (job 1328) flagged
  that this can mask real regressions; converting it to a hard failure
  is a separate behavioral change worth its own PR.
- API-based polling against `workbench_client` was considered but
  rejected — the DOM-based flow now actually works, and the test still
  exercises the user-facing UI as intended.

## Test plan

- [x] `uv run pytest src/vip_tests/workbench/test_sessions.py --collect-only` — test still collects
- [x] `uv run pytest selftests/ -q` — 485 passed, 3 skipped, no regressions
- [x] `uv run ruff check ...` clean
- [x] `uv run ruff format --check ...` clean
- [x] **End-to-end validated against `dev.ganso.lab.staging.posit.team`** — `test_session_suspend_resume[chromium] PASSED`

## Demo

See `validation_docs/demo-vip-fix-suspend-resume-reload.md` (regenerated to reflect the final diff).