### PR TITLE
fix(install): detect stale chromium cache via pinned revision

### DIFF
--- a/selftests/install/test_playwright.py
+++ b/selftests/install/test_playwright.py
@@ -29,18 +29,52 @@ def test_default_cache_dir_respects_env(monkeypatch, tmp_path: Path):
     assert pw.default_cache_dir() == tmp_path / "custom"
 
 
-def test_chromium_installed_true_when_dir_present(tmp_path: Path):
+def test_chromium_installed_true_when_expected_revision_present(tmp_path: Path):
     (tmp_path / "chromium-1234").mkdir()
-    assert pw.chromium_installed(tmp_path) is True
+    assert pw.chromium_installed(tmp_path, revision="1234") is True
 
 
 def test_chromium_installed_false_when_no_chromium(tmp_path: Path):
     (tmp_path / "firefox-9999").mkdir()
-    assert pw.chromium_installed(tmp_path) is False
+    assert pw.chromium_installed(tmp_path, revision="1234") is False
 
 
 def test_chromium_installed_false_when_dir_missing(tmp_path: Path):
-    assert pw.chromium_installed(tmp_path / "does-not-exist") is False
+    assert pw.chromium_installed(tmp_path / "does-not-exist", revision="1234") is False
+
+
+def test_chromium_installed_false_when_only_stale_revision_present(tmp_path: Path):
+    """Reproduces the bug where a previous Playwright pin left chromium-1208
+    in the cache, but the current pin expects chromium-1217: the cache must
+    not be considered satisfied.
+    """
+    (tmp_path / "chromium-1208").mkdir()
+    assert pw.chromium_installed(tmp_path, revision="1217") is False
+
+
+def test_chromium_installed_uses_expected_revision_by_default(tmp_path: Path, monkeypatch):
+    """When no revision is passed, look it up from Playwright's browsers.json."""
+    monkeypatch.setattr(pw, "expected_chromium_revision", lambda: "4242")
+    (tmp_path / "chromium-4242").mkdir()
+    assert pw.chromium_installed(tmp_path) is True
+
+
+def test_chromium_installed_falls_back_when_revision_unknown(tmp_path: Path, monkeypatch):
+    """If the revision cannot be determined (e.g. Playwright not importable),
+    fall back to the old behavior of accepting any chromium-* directory so
+    users on broken installs aren't blocked from running `vip install`.
+    """
+    monkeypatch.setattr(pw, "expected_chromium_revision", lambda: None)
+    (tmp_path / "chromium-1234").mkdir()
+    assert pw.chromium_installed(tmp_path) is True
+
+
+def test_expected_chromium_revision_reads_browsers_json():
+    """The real Playwright in this venv has a browsers.json. Make sure we
+    return a non-empty revision string from it."""
+    rev = pw.expected_chromium_revision()
+    assert rev is not None
+    assert rev.isdigit()
 
 
 class _FakePopen:

--- a/selftests/install/test_playwright.py
+++ b/selftests/install/test_playwright.py
@@ -77,6 +77,27 @@ def test_expected_chromium_revision_reads_browsers_json():
     assert rev.isdigit()
 
 
+def test_expected_chromium_revision_returns_none_on_broken_import(monkeypatch):
+    """A corrupted Playwright install can fail at import time with errors
+    other than ImportError (e.g. SyntaxError, RuntimeError raised by code at
+    module load). The function must still return None so `vip install` can
+    fall back to the loose chromium-* check instead of crashing.
+    """
+    import builtins
+    import sys
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "playwright":
+            raise RuntimeError("playwright package is corrupted")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "playwright", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert pw.expected_chromium_revision() is None
+
+
 class _FakePopen:
     """Drop-in stand-in for subprocess.Popen for testing the streaming filter.
 

--- a/src/vip/install/playwright.py
+++ b/src/vip/install/playwright.py
@@ -50,9 +50,10 @@ def expected_chromium_revision() -> str | None:
     """
     try:
         import playwright
-    except ImportError:
+
+        browsers_json = Path(playwright.__file__).parent / "driver" / "package" / "browsers.json"
+    except Exception:
         return None
-    browsers_json = Path(playwright.__file__).parent / "driver" / "package" / "browsers.json"
     try:
         data = json.loads(browsers_json.read_text())
     except (OSError, ValueError):

--- a/src/vip/install/playwright.py
+++ b/src/vip/install/playwright.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -39,10 +40,46 @@ def default_cache_dir() -> Path:
     return home / ".cache" / "ms-playwright"
 
 
-def chromium_installed(cache_dir: Path) -> bool:
-    """Return True if any `chromium-*` directory exists under cache_dir."""
+def expected_chromium_revision() -> str | None:
+    """Return the Chromium build revision the current Playwright pin expects.
+
+    Reads ``playwright/driver/package/browsers.json`` shipped inside the
+    installed playwright package. Returns ``None`` if playwright cannot be
+    imported, the file is missing, or no chromium entry is found — callers
+    should treat that as "revision unknown" and fall back gracefully.
+    """
+    try:
+        import playwright
+    except ImportError:
+        return None
+    browsers_json = Path(playwright.__file__).parent / "driver" / "package" / "browsers.json"
+    try:
+        data = json.loads(browsers_json.read_text())
+    except (OSError, ValueError):
+        return None
+    for entry in data.get("browsers", []):
+        if entry.get("name") == "chromium":
+            revision = entry.get("revision")
+            return str(revision) if revision is not None else None
+    return None
+
+
+def chromium_installed(cache_dir: Path, *, revision: str | None = None) -> bool:
+    """Return True if the Chromium build Playwright currently expects is cached.
+
+    ``revision`` defaults to :func:`expected_chromium_revision`. When the
+    revision is known we check for the specific ``chromium-<revision>``
+    directory so a stale build from an older Playwright pin no longer hides
+    the need to reinstall. When the revision cannot be determined we fall
+    back to accepting any ``chromium-*`` directory so a broken Playwright
+    install does not stop ``vip install`` from making progress.
+    """
+    if revision is None:
+        revision = expected_chromium_revision()
     if not cache_dir.is_dir():
         return False
+    if revision is not None:
+        return (cache_dir / f"chromium-{revision}").is_dir()
     return any(p.name.startswith("chromium-") for p in cache_dir.iterdir() if p.is_dir())
 
 

--- a/validation_docs/demo-chromium-revision-check.md
+++ b/validation_docs/demo-chromium-revision-check.md
@@ -1,0 +1,95 @@
+# Fix: chromium_installed must respect Playwright's pinned revision
+
+*2026-05-15T15:50:00Z by Showboat 0.6.1*
+<!-- showboat-id: 80bfac09-f421-493d-863d-1838b1de05d6 -->
+
+Before this change, `chromium_installed()` returned True for any `chromium-*` directory under the Playwright cache. When the pinned Playwright version bumped (e.g. from chromium-1208 to chromium-1217), `vip install` saw the old directory and reported "nothing to install" — even though Playwright itself would fail at launch with a 'please run playwright install' message.
+
+The fix reads the current build revision from `playwright/driver/package/browsers.json` and checks for that specific `chromium-<revision>` directory. If Playwright isn't importable or the file is missing, we fall back to the old loose check so a broken Playwright install doesn't block `vip install` from running.
+
+## Repro: stale cache hides the missing build
+
+The current playwright pin is 1.59.0, which expects `chromium-1217`. We point the cache at a fresh tmpdir, drop in a stale `chromium-1208` directory, and confirm `vip install --dry-run` now correctly plans to install chromium instead of saying 'nothing to install'.
+
+```bash
+set -eu
+DEMO_CACHE="/tmp/vip-demo-stale-cache"
+rm -rf "$DEMO_CACHE"
+mkdir -p "$DEMO_CACHE/chromium-1208"
+PLAYWRIGHT_BROWSERS_PATH="$DEMO_CACHE" uv run vip install --dry-run
+rm -rf "$DEMO_CACHE"
+```
+
+```output
+vip install plan (macos ):
+  playwright: install chromium into /tmp/vip-demo-stale-cache
+```
+
+## Repro: a matching cache is still recognized
+
+Now the same tmpdir but with the *current* expected revision (`chromium-1217`) pre-populated. `vip install` correctly says there's nothing to do.
+
+```bash
+set -eu
+DEMO_CACHE="/tmp/vip-demo-current-cache"
+rm -rf "$DEMO_CACHE"
+mkdir -p "$DEMO_CACHE/chromium-1217"
+PLAYWRIGHT_BROWSERS_PATH="$DEMO_CACHE" uv run vip install --dry-run
+rm -rf "$DEMO_CACHE"
+```
+
+```output
+vip install: nothing to install.
+```
+
+## Fallback: no Playwright available
+
+If `expected_chromium_revision()` cannot determine the pinned revision (e.g. broken Playwright install), `chromium_installed()` falls back to the old behavior of accepting any `chromium-*` directory so users aren't blocked from running `vip install` while debugging.
+
+```bash
+uv run python -c "
+from pathlib import Path
+import tempfile
+from vip.install import playwright as pw
+
+with tempfile.TemporaryDirectory() as d:
+    cache = Path(d)
+    (cache / \"chromium-1208\").mkdir()
+    # Explicit revision=None and monkey-patched lookup returning None
+    pw.expected_chromium_revision = lambda: None
+    print(\"fallback accepts any chromium-* dir:\", pw.chromium_installed(cache))
+"
+```
+
+```output
+fallback accepts any chromium-* dir: True
+```
+
+## Tests
+
+New test cases in `selftests/install/test_playwright.py` cover:
+- the bug repro (stale revision in cache, current revision missing → False)
+- positive case with explicit revision
+- default revision lookup via `expected_chromium_revision()`
+- fallback when the revision cannot be determined
+- the live read of `browsers.json` from the installed playwright package
+
+Run the full selftest suite and strip the elapsed-time suffix so re-runs verify cleanly:
+
+```bash
+uv run pytest selftests/install/test_playwright.py -q 2>&1 | tail -1 | sed 's/ in [0-9.]*s//'
+```
+
+```output
+16 passed
+```
+
+```bash
+uv run ruff check src/ selftests/ examples/ docker/ 2>&1
+uv run ruff format --check src/ selftests/ examples/ docker/ 2>&1
+```
+
+```output
+All checks passed!
+128 files already formatted
+```


### PR DESCRIPTION
## Summary

I was noticing that tests couldn't be run even after I ran "vip install", as it complain about my Playwright version.  This fixes things so an old  Playwright install is detected and an upgrade happens

- `chromium_installed()` previously matched any `chromium-*` directory, so a stale build from an older Playwright pin made `vip install` say "nothing to install" — and Playwright then failed at launch with its own "please run playwright install" message, undermining the whole point of `vip install`.
- Now we read the expected revision from `playwright/driver/package/browsers.json` shipped inside the installed Playwright package and look for the specific `chromium-<revision>` directory.
- Falls back to the old loose match when the revision cannot be determined so a broken Playwright install does not block `vip install`.
- New selftests cover the bug repro, the matching-revision case, the default lookup, the fallback, and a live read of `browsers.json`.

## Test plan

- [x] `uv run pytest selftests/install/test_playwright.py -v` (new and existing playwright selftests)
- [x] `uv run pytest selftests/ -q` (full selftest suite: 505 passed, 3 skipped)
- [x] `just check` (ruff lint + format)
- [x] `uv run vip install --dry-run` against real cache with stale `chromium-1208` correctly plans to install chromium
- [x] `showboat verify` on `validation_docs/demo-chromium-revision-check.md`