### PR TITLE
feat(pm): add tests for authenticated repositories

### DIFF
--- a/src/vip/clients/packagemanager.py
+++ b/src/vip/clients/packagemanager.py
@@ -43,6 +43,14 @@ class PackageManagerClient(BaseClient):
         resp.raise_for_status()
         return resp.json()
 
+    def list_authenticated_repos(self) -> list[dict[str, Any]]:
+        """List repositories with the ``auth`` flag set on the server.
+
+        Authenticated repos require a valid token to download package content;
+        see https://docs.posit.co/rspm/admin/repositories.html#authenticated-repos.
+        """
+        return [r for r in self.list_repos() if r.get("auth") is True]
+
     def status(self) -> dict[str, Any]:
         """Return the parsed JSON body from the status endpoint."""
         resp = self._client.get("/__api__/status")

--- a/src/vip_tests/package_manager/test_authenticated_repos.feature
+++ b/src/vip_tests/package_manager/test_authenticated_repos.feature
@@ -1,0 +1,25 @@
+@package_manager @if_applicable
+Feature: Authenticated package repositories
+  As a Posit Team administrator
+  I want to verify that authenticated Package Manager repositories enforce tokens
+  So that protected content is only served to authorized clients
+
+  Scenario: At least one authenticated repository is configured
+    Given Package Manager is running
+    And a Package Manager token is configured
+    When I list authenticated repositories
+    Then at least one authenticated repository exists
+
+  Scenario: Authenticated repository denies access without a token
+    Given Package Manager is running
+    And a Package Manager token is configured
+    And an authenticated repository is configured
+    When I query the authenticated repository without a token
+    Then access is denied
+
+  Scenario: Authenticated repository allows access with a token
+    Given Package Manager is running
+    And a Package Manager token is configured
+    And an authenticated repository is configured
+    When I query the authenticated repository with the configured token
+    Then the repository responds successfully

--- a/src/vip_tests/package_manager/test_authenticated_repos.py
+++ b/src/vip_tests/package_manager/test_authenticated_repos.py
@@ -7,8 +7,6 @@ These scenarios are all skipped when no PM token is configured.
 
 from __future__ import annotations
 
-from copy import deepcopy
-
 import httpx
 import pytest
 from pytest_bdd import given, scenario, then, when
@@ -65,8 +63,8 @@ def authenticated_repo(pm_client):
     if not testable:
         types = sorted({r.get("type", "?") for r in auth_repos})
         pytest.skip(
-            f"No authenticated repositories with a testable client index path "
-            f"(found types: {types})"
+            f"No authenticated repositories have a name to query via "
+            f"/__api__/repos/{{name}}/packages (found types: {types})"
         )
     return testable[0]
 
@@ -81,7 +79,11 @@ def list_authenticated_repos(pm_client):
     target_fixture="unauth_response",
 )
 def query_without_token(pm_client, auth_repo):
-    resp = httpx.get(f"{pm_client.base_url}/__api__/repos/{auth_repo}/packages")
+    resp = httpx.get(
+        f"{pm_client.base_url}/__api__/repos/{auth_repo}/packages",
+        timeout=15,
+        verify=pm_client.verify,
+    )
     return resp
 
 

--- a/src/vip_tests/package_manager/test_authenticated_repos.py
+++ b/src/vip_tests/package_manager/test_authenticated_repos.py
@@ -1,0 +1,115 @@
+"""Step definitions for Package Manager authenticated repository checks.
+
+Authenticated repos require a token to download package content
+(see https://docs.posit.co/rspm/admin/repositories.html#authenticated-repos).
+These scenarios are all skipped when no PM token is configured.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import httpx
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+
+@scenario("test_authenticated_repos.feature", "At least one authenticated repository is configured")
+def test_authenticated_repo_exists():
+    pass
+
+
+@scenario(
+    "test_authenticated_repos.feature",
+    "Authenticated repository denies access without a token",
+)
+def test_authenticated_repo_denies_without_token():
+    pass
+
+
+@scenario(
+    "test_authenticated_repos.feature",
+    "Authenticated repository allows access with a token",
+)
+def test_authenticated_repo_allows_with_token():
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Steps
+# ---------------------------------------------------------------------------
+
+
+@given("Package Manager is running")
+def pm_running(pm_client):
+    assert pm_client is not None, "Package Manager client not configured"
+    status = pm_client.health()
+    assert status < 400, f"Package Manager returned HTTP {status}"
+
+
+@given("a Package Manager token is configured")
+def pm_token_configured(vip_config):
+    if not vip_config.package_manager.token:
+        pytest.skip(
+            "No Package Manager token configured "
+            "(set [package_manager].token or VIP_PACKAGE_MANAGER_TOKEN)"
+        )
+
+
+@given("an authenticated repository is configured", target_fixture="auth_repo")
+def authenticated_repo(pm_client):
+    auth_repos = pm_client.list_authenticated_repos()
+    if not auth_repos:
+        pytest.skip("No authenticated repositories configured in Package Manager")
+    testable = [r.get("name") for r in auth_repos if r.get("name") is not None]
+    if not testable:
+        types = sorted({r.get("type", "?") for r in auth_repos})
+        pytest.skip(
+            f"No authenticated repositories with a testable client index path "
+            f"(found types: {types})"
+        )
+    return testable[0]
+
+
+@when("I list authenticated repositories", target_fixture="auth_repo_list")
+def list_authenticated_repos(pm_client):
+    return pm_client.list_authenticated_repos()
+
+
+@when(
+    "I query the authenticated repository without a token",
+    target_fixture="unauth_response",
+)
+def query_without_token(pm_client, auth_repo):
+    resp = httpx.get(f"{pm_client.base_url}/__api__/repos/{auth_repo}/packages")
+    return resp
+
+
+@when(
+    "I query the authenticated repository with the configured token",
+    target_fixture="auth_response",
+)
+def query_with_token(pm_client, vip_config, auth_repo):
+    resp = pm_client._client.get(f"{pm_client.base_url}/__api__/repos/{auth_repo}/packages")
+    return resp
+
+
+@then("at least one authenticated repository exists")
+def auth_repos_exist(auth_repo_list):
+    if not auth_repo_list:
+        pytest.skip("No authenticated repositories configured in Package Manager")
+    assert len(auth_repo_list) > 0
+
+
+@then("access is denied")
+def access_denied(unauth_response):
+    assert unauth_response.status_code in (401, 403, 404), (
+        f"Expected 401/403/404 from unauthenticated request, got {unauth_response.status_code}"
+    )
+
+
+@then("the repository responds successfully")
+def repo_responds(auth_response):
+    assert auth_response.status_code < 400, (
+        f"Authenticated request to repo failed with HTTP {auth_response.status_code}"
+    )

--- a/src/vip_tests/package_manager/test_private_repos.py
+++ b/src/vip_tests/package_manager/test_private_repos.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import httpx
 import pytest
 from pytest_bdd import given, scenario, then, when
 

--- a/src/vip_tests/package_manager/test_private_repos.py
+++ b/src/vip_tests/package_manager/test_private_repos.py
@@ -34,9 +34,8 @@ def query_private_repos(pm_client, private_repos):
     results = []
     for repo in private_repos:
         name = repo["name"]
-        resp = httpx.get(
-            f"{pm_client.base_url}/{name}/latest/", timeout=15, verify=pm_client.verify
-        )
+        query_url = f"{pm_client.base_url}/__api__/repos/{name}/packages"
+        resp = pm_client._client.get(query_url)
         results.append({"name": name, "status": resp.status_code})
     return results
 

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.32.1"
+version = "0.33.1"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },


### PR DESCRIPTION
## Summary
- Add `list_authenticated_repos()` on `PackageManagerClient` to filter `/__api__/repos` by `auth=true`.
- New BDD feature `src/vip_tests/package_manager/test_authenticated_repos.feature` with three scenarios: list authenticated repos, deny access without a token, allow access with the configured token.
- Step definitions exercise the admin packages endpoint (`/__api__/repos/{name}/packages`) — unauthenticated via raw `httpx`, authenticated via the configured `pm_client` which carries the Bearer token.
- All scenarios skip cleanly when no PM token is configured (per the issue) or when the deployment has no `auth=true` repos.
- Includes follow-up manual fixes on the branch refining the step definitions and accepted status codes (`401/403/404`) for the deny case.

Closes #269

## Test plan
- [ ] `uv run pytest selftests/ -q` passes (selftests don't require PPM)
- [ ] `uv run --with ruff==0.15.0 ruff check src/ src/vip_tests/ selftests/ examples/` is clean
- [ ] `uv run --with ruff==0.15.0 ruff format --check src/ src/vip_tests/ selftests/ examples/` is clean
- [ ] `uv run pytest src/vip_tests/package_manager/ --vip-config <toml> --collect-only` discovers the three new scenarios
- [ ] Against a PPM **with** an `auth=true` repo and a valid `VIP_PACKAGE_MANAGER_TOKEN`: deny scenario returns 401/403/404 and allow scenario returns <400
- [ ] Against a PPM **without** an `auth=true` repo: list scenario skips with the no-auth-repos message
- [ ] **Without** a PM token configured: all three scenarios skip with the no-token message

🤖 Generated with [Claude Code](https://claude.com/claude-code)