### PR TITLE
chore(deps): bump idna and starlette to fix CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "python-multipart>=0.0.26",  # CVE-2026-40347 fix; transitive via shiny
     "pip>=26.1",  # CVE-2026-3219 fix; transitive via pip-api
     "mako>=1.3.12",  # CVE-2026-44307 fix; transitive via pytest-bdd
+    "idna>=3.15",  # CVE-2026-45409 fix; transitive via httpx/requests/anyio
+    "starlette>=1.0.1",  # PYSEC-2026-161 fix; transitive via shiny
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1244,11 +1244,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -2527,6 +2527,7 @@ dependencies = [
     { name = "brand-yml" },
     { name = "htmltools" },
     { name = "httpx" },
+    { name = "idna" },
     { name = "mako" },
     { name = "pip" },
     { name = "playwright" },
@@ -2539,6 +2540,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "requests" },
     { name = "shiny", extra = ["theme"] },
+    { name = "starlette" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
@@ -2581,6 +2583,7 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'cluster'", specifier = ">=46.0.7" },
     { name = "htmltools" },
     { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "ipykernel", marker = "extra == 'report'" },
     { name = "jinja2", marker = "extra == 'report'", specifier = ">=3.1" },
     { name = "jupyter", marker = "extra == 'report'" },
@@ -2607,6 +2610,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0,<0.16" },
     { name = "shiny", extras = ["theme"], specifier = ">=1.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "tornado", marker = "extra == 'report'", specifier = ">=6.5.5" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
@@ -3613,15 +3617,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves the `Dependency Audit` CI failure that has been red on `main` since the CVE database picked up two new entries against currently-locked transitive deps.

- `idna 3.11` → `3.16` ([CVE-2026-45409](https://github.com/advisories/GHSA-jjg7-2v4v-x38h))
- `starlette 0.52.1` → `1.0.1` (PYSEC-2026-161)

Both are transitive. Pinned in `pyproject.toml` `[project.dependencies]` with a CVE-fix comment, following the existing convention used for `pygments`, `python-multipart`, `pip`, `mako`, etc.

## Test plan

- [x] `uv lock` resolves cleanly
- [x] `uv run pip-audit --skip-editable` → no known vulnerabilities
- [x] `uv run pytest selftests/ -q` → 548 passed, 3 skipped
- [x] `uv run --with ruff==0.15.0 ruff check src/ src/vip_tests/ selftests/ examples/` → clean
- [x] `uv run --with ruff==0.15.0 ruff format --check src/ src/vip_tests/ selftests/ examples/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)