### PR TITLE
fix(auth): surface workbench auth failures and scope cache per URL

### DIFF
--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -369,13 +369,16 @@ class TestInteractiveAuthSessionCleanup:
 class TestAuthenticateWorkbench:
     """_authenticate_workbench establishes the Workbench SSO session after
     Connect auth has already succeeded.  Network failures here must NOT
-    crash the pytest session — Connect tests should still run."""
+    crash the pytest session — Connect tests should still run.  The
+    helper returns ``None`` on success or a short failure reason that
+    callers stash on :class:`InteractiveAuthSession` so test-time skip
+    messages can quote the underlying cause."""
 
     def test_playwright_error_on_goto_is_non_fatal(self, capsys):
         """A PlaywrightError from page.goto() (e.g. ERR_CONNECTION_REFUSED,
         redirect-to-http) must be caught, logged as a warning, and return
-        cleanly.  Otherwise the whole pytest session dies with INTERNALERROR.
-        See issue #171."""
+        a failure reason.  Otherwise the whole pytest session dies with
+        INTERNALERROR.  See issue #171."""
         from playwright.sync_api import Error as PlaywrightError
 
         from vip.auth import _authenticate_workbench
@@ -385,11 +388,143 @@ class TestAuthenticateWorkbench:
             "net::ERR_CONNECTION_REFUSED at https://wb.example.com/pwb"
         )
 
-        _authenticate_workbench(page, "https://wb.example.com/pwb")
+        result = _authenticate_workbench(page, "https://wb.example.com/pwb")
 
         out = capsys.readouterr().out
         assert "Could not reach Workbench" in out
         assert "https://wb.example.com/pwb" in out
+        assert result is not None
+        assert "could not reach Workbench" in result
+        assert "https://wb.example.com/pwb" in result
+
+    def test_returns_none_when_landed_on_dashboard(self):
+        """SSO completed and the page is on the Workbench dashboard → success.
+        The helper must return ``None`` so the caller doesn't stash a
+        bogus error on the session."""
+        from unittest.mock import PropertyMock
+
+        from vip.auth import _authenticate_workbench
+
+        page = MagicMock()
+        page.goto.return_value = None
+        page.wait_for_load_state.return_value = None
+        type(page).url = PropertyMock(return_value="https://wb.example.com/")
+
+        result = _authenticate_workbench(page, "https://wb.example.com")
+
+        assert result is None
+
+    def test_returns_reason_when_timeout_keeps_us_on_login(self, monkeypatch):
+        """If the 2-minute redirect poll expires while we're still on
+        /auth-sign-in, the helper must return a string explaining why so
+        the workbench fixture can surface it instead of guessing."""
+        from unittest.mock import PropertyMock
+
+        from vip import auth as auth_mod
+
+        page = MagicMock()
+        page.goto.return_value = None
+        page.wait_for_load_state.return_value = None
+        type(page).url = PropertyMock(return_value="https://wb.example.com/auth-sign-in")
+
+        # Force the deadline loop to exit immediately so the test finishes fast.
+        times = iter([0.0, 1000.0])
+        monkeypatch.setattr(auth_mod.time, "monotonic", lambda: next(times))
+
+        result = auth_mod._authenticate_workbench(page, "https://wb.example.com")
+
+        assert result is not None
+        assert "did not complete" in result
+        assert "auth-sign-in" in result
+
+
+class TestLoadCachedAuth:
+    """_load_cached_auth must refuse to reuse a cache that was minted
+    against different product URLs.  The cache file lives one-per-
+    checkout-directory, so reusing it across sites would silently send
+    the wrong session cookies (and API key) to the new target."""
+
+    @staticmethod
+    def _write_cache(tmp_path, *, connect_url: str, workbench_url: str = ""):
+        import json
+        from pathlib import Path as _Path
+
+        cache = _Path(tmp_path) / ".vip-auth-cache.json"
+        cache.write_text('{"cookies": []}')
+        cache.with_suffix(".meta.json").write_text(
+            json.dumps(
+                {
+                    "api_key": "CACHED",
+                    "key_name": "_vip_interactive_1",
+                    "connect_url": connect_url,
+                    "workbench_url": workbench_url,
+                }
+            )
+        )
+        return cache
+
+    def test_reuses_cache_when_urls_match(self, tmp_path):
+        from vip.auth import _load_cached_auth
+
+        cache = self._write_cache(
+            tmp_path, connect_url="https://c.example.com", workbench_url="https://w.example.com"
+        )
+
+        session = _load_cached_auth(
+            cache,
+            requested_connect_url="https://c.example.com",
+            requested_workbench_url="https://w.example.com",
+        )
+
+        assert session is not None
+        assert session.api_key == "CACHED"
+
+    def test_rejects_cache_when_connect_url_differs(self, tmp_path, capsys):
+        from vip.auth import _load_cached_auth
+
+        cache = self._write_cache(tmp_path, connect_url="https://site-a.example.com")
+
+        session = _load_cached_auth(
+            cache,
+            requested_connect_url="https://site-b.example.com",
+            requested_workbench_url=None,
+        )
+
+        assert session is None
+        assert "Ignoring cached auth session" in capsys.readouterr().out
+
+    def test_rejects_cache_when_workbench_was_not_recorded(self, tmp_path):
+        """A cache minted with only Connect lacks Workbench cookies; a
+        later run that now also wants Workbench would skip every
+        Workbench test on stale state.  Treat as a miss."""
+        from vip.auth import _load_cached_auth
+
+        cache = self._write_cache(tmp_path, connect_url="https://c.example.com")
+
+        session = _load_cached_auth(
+            cache,
+            requested_connect_url="https://c.example.com",
+            requested_workbench_url="https://w.example.com",
+        )
+
+        assert session is None
+
+    def test_url_match_ignores_trailing_slash_and_case(self, tmp_path):
+        from vip.auth import _load_cached_auth
+
+        cache = self._write_cache(
+            tmp_path,
+            connect_url="https://Connect.Example.COM/",
+            workbench_url="https://wb.example.com",
+        )
+
+        session = _load_cached_auth(
+            cache,
+            requested_connect_url="https://connect.example.com",
+            requested_workbench_url="https://wb.example.com/",
+        )
+
+        assert session is not None
 
 
 class TestWaitForProductRedirect:

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -549,6 +549,26 @@ class TestLoadCachedAuth:
 
         assert session is None
 
+    def test_url_match_distinguishes_single_vs_double_trailing_slash(self, tmp_path):
+        """``/app/`` and ``/app//`` are not guaranteed to route to the same
+        handler.  Only a single trailing slash is treated as cosmetic;
+        extra slashes are preserved so a misconfigured URL doesn't
+        silently cache-hit against the canonical one."""
+        from vip.auth import _load_cached_auth
+
+        cache = self._write_cache(
+            tmp_path,
+            connect_url="https://connect.example.com/app/",
+        )
+
+        session = _load_cached_auth(
+            cache,
+            requested_connect_url="https://connect.example.com/app//",
+            requested_workbench_url=None,
+        )
+
+        assert session is None
+
 
 class TestWaitForProductRedirect:
     """_wait_for_product_redirect handles the Workbench OIDC confirmation page.

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -211,6 +211,32 @@ class TestSaveAuthCache:
 
         assert cache.exists()
 
+    def test_writes_both_resolved_and_requested_connect_urls(self, tmp_path):
+        """Save the pre-resolve form too so a later cache load can
+        match against what the caller actually asked for, even when
+        ``_resolve_connect_api_base`` rewrote the dashboard URL to a
+        different API base."""
+        import json
+
+        from vip.auth import InteractiveAuthSession, _save_auth_cache
+
+        state = tmp_path / "state.json"
+        state.write_text('{"cookies": []}')
+        session = InteractiveAuthSession(
+            storage_state_path=state,
+            api_key="REAL",
+            key_name="_vip_interactive_1",
+            _connect_url="https://c.example.com",
+            _requested_connect_url="https://c.example.com/dashboard",
+        )
+        cache = tmp_path / ".vip-auth-cache.json"
+
+        _save_auth_cache(session, cache)
+
+        meta = json.loads(cache.with_suffix(".meta.json").read_text())
+        assert meta["connect_url"] == "https://c.example.com"
+        assert meta["requested_connect_url"] == "https://c.example.com/dashboard"
+
 
 class TestInteractiveAuthSessionCleanup:
     """Cleanup must not delete an API key that the on-disk cache still
@@ -437,6 +463,37 @@ class TestAuthenticateWorkbench:
         assert "did not complete" in result
         assert "auth-sign-in" in result
 
+    def test_timeout_reason_strips_oidc_query_parameters(self, monkeypatch):
+        """The returned URL is surfaced in CI logs via the workbench skip
+        message.  OIDC/SAML redirects can carry ``code=``, ``state=``,
+        and ``SAMLRequest=`` query parameters — sensitive auth artifacts
+        that must not leak.  Path is preserved so the failure is still
+        debuggable."""
+        from unittest.mock import PropertyMock
+
+        from vip import auth as auth_mod
+
+        page = MagicMock()
+        page.goto.return_value = None
+        page.wait_for_load_state.return_value = None
+        type(page).url = PropertyMock(
+            return_value=(
+                "https://idp.example.com/sso/callback?code=AUTH_CODE_SECRET&state=STATE_TOKEN"
+            )
+        )
+
+        times = iter([0.0, 1000.0])
+        monkeypatch.setattr(auth_mod.time, "monotonic", lambda: next(times))
+
+        result = auth_mod._authenticate_workbench(page, "https://wb.example.com")
+
+        assert result is not None
+        assert "AUTH_CODE_SECRET" not in result
+        assert "STATE_TOKEN" not in result
+        assert "code=" not in result
+        assert "state=" not in result
+        assert "/sso/callback" in result
+
 
 class TestLoadCachedAuth:
     """_load_cached_auth must refuse to reuse a cache that was minted
@@ -568,6 +625,44 @@ class TestLoadCachedAuth:
         )
 
         assert session is None
+
+    def test_match_uses_requested_url_when_resolved_differs(self, tmp_path):
+        """``_resolve_connect_api_base`` can rewrite the configured
+        sub-path dashboard URL to a different API base.  Cache match
+        must compare against what the caller asked for, not what
+        Connect resolved it to — otherwise every run cache-misses for
+        sub-path deployments."""
+        import json
+        from pathlib import Path as _Path
+
+        from vip.auth import _load_cached_auth
+
+        cache = _Path(tmp_path) / ".vip-auth-cache.json"
+        cache.write_text('{"cookies": []}')
+        cache.with_suffix(".meta.json").write_text(
+            json.dumps(
+                {
+                    "api_key": "CACHED",
+                    "key_name": "_vip_interactive_1",
+                    "connect_url": "https://connect.example.com",
+                    "requested_connect_url": "https://connect.example.com/dashboard",
+                    "workbench_url": "",
+                }
+            )
+        )
+
+        session = _load_cached_auth(
+            cache,
+            requested_connect_url="https://connect.example.com/dashboard",
+            requested_workbench_url=None,
+        )
+
+        assert session is not None
+        assert session.api_key == "CACHED"
+        # Resolved URL (used for API client + cleanup) is preserved.
+        assert session._connect_url == "https://connect.example.com"
+        # Requested URL (used for cache match) is also restored.
+        assert session._requested_connect_url == "https://connect.example.com/dashboard"
 
 
 class TestWaitForProductRedirect:

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -509,7 +509,10 @@ class TestLoadCachedAuth:
 
         assert session is None
 
-    def test_url_match_ignores_trailing_slash_and_case(self, tmp_path):
+    def test_url_match_normalizes_host_case_and_trailing_slash(self, tmp_path):
+        """Scheme and netloc are case-insensitive per RFC 3986 and a
+        single trailing slash on the path is not meaningful, so these
+        must still hit the cache."""
         from vip.auth import _load_cached_auth
 
         cache = self._write_cache(
@@ -525,6 +528,26 @@ class TestLoadCachedAuth:
         )
 
         assert session is not None
+
+    def test_url_match_preserves_path_case(self, tmp_path):
+        """URL paths are case-sensitive: ``/Dashboard`` and ``/dashboard``
+        can resolve to different Connect deployments when a sub-path
+        mount is used.  Lowercasing the path (the prior behaviour) would
+        send stale storage state and API key to the wrong target."""
+        from vip.auth import _load_cached_auth
+
+        cache = self._write_cache(
+            tmp_path,
+            connect_url="https://connect.example.com/Dashboard",
+        )
+
+        session = _load_cached_auth(
+            cache,
+            requested_connect_url="https://connect.example.com/dashboard",
+            requested_workbench_url=None,
+        )
+
+        assert session is None
 
 
 class TestWaitForProductRedirect:

--- a/selftests/test_workbench_skip.py
+++ b/selftests/test_workbench_skip.py
@@ -28,11 +28,15 @@ def test_names_interactive_flag_when_active():
     assert "--interactive-auth" in msg
 
 
-def test_falls_back_to_interactive_flag_when_mode_unknown():
+def test_names_both_flags_when_mode_unknown():
+    """When a caller forgets to thread the auth_mode fixture through,
+    the message must not pick one flag arbitrarily — that would point
+    users at the wrong flag.  Listing both is safe."""
     msg = _workbench_session_skip_message(
         auth_mode="none", workbench_auth_error=None, landed_url="https://wb/login"
     )
     assert "--interactive-auth" in msg
+    assert "--headless-auth" in msg
 
 
 def test_quotes_pre_test_auth_error_when_present():

--- a/selftests/test_workbench_skip.py
+++ b/selftests/test_workbench_skip.py
@@ -1,0 +1,52 @@
+"""Tests for the workbench login skip-message helper.
+
+When pre-test auth (--interactive-auth / --headless-auth) does not
+establish a Workbench session, browser tests skip.  The helper named
+here builds the user-facing skip text — naming the active mode's CLI
+flag and quoting the underlying failure captured by
+``_authenticate_workbench`` instead of guessing at the cause.
+"""
+
+from __future__ import annotations
+
+from vip_tests.workbench.conftest import _workbench_session_skip_message
+
+
+def test_names_headless_flag_when_active():
+    msg = _workbench_session_skip_message(
+        auth_mode="headless", workbench_auth_error=None, landed_url="https://wb/login"
+    )
+    assert "--headless-auth" in msg
+    assert "--interactive-auth" not in msg
+    assert "https://wb/login" in msg
+
+
+def test_names_interactive_flag_when_active():
+    msg = _workbench_session_skip_message(
+        auth_mode="interactive", workbench_auth_error=None, landed_url="https://wb/login"
+    )
+    assert "--interactive-auth" in msg
+
+
+def test_falls_back_to_interactive_flag_when_mode_unknown():
+    msg = _workbench_session_skip_message(
+        auth_mode="none", workbench_auth_error=None, landed_url="https://wb/login"
+    )
+    assert "--interactive-auth" in msg
+
+
+def test_quotes_pre_test_auth_error_when_present():
+    msg = _workbench_session_skip_message(
+        auth_mode="headless",
+        workbench_auth_error="Workbench authentication did not complete within 2 minutes",
+        landed_url="https://wb/auth-sign-in",
+    )
+    assert "Pre-test auth reported:" in msg
+    assert "Workbench authentication did not complete within 2 minutes" in msg
+
+
+def test_omits_pre_test_error_section_when_none():
+    msg = _workbench_session_skip_message(
+        auth_mode="headless", workbench_auth_error=None, landed_url="https://wb/login"
+    )
+    assert "Pre-test auth reported:" not in msg

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -86,8 +86,10 @@ class InteractiveAuthSession:
     storage_state_path: Path
     api_key: str | None = None
     key_name: str = ""
+    workbench_auth_error: str | None = None
 
     _connect_url: str = field(default="", repr=False)
+    _workbench_url: str = field(default="", repr=False)
     _tmpdir: str = field(default="", repr=False)
     _cache_path: Path | None = field(default=None, repr=False)
     _insecure: bool = field(default=False, repr=False)
@@ -145,8 +147,21 @@ class InteractiveAuthSession:
             shutil.rmtree(self._tmpdir, ignore_errors=True)
 
 
-def _load_cached_auth(cache_path: Path) -> InteractiveAuthSession | None:
-    """Load a cached auth session if the storage state file exists and is recent."""
+def _load_cached_auth(
+    cache_path: Path,
+    requested_connect_url: str | None = None,
+    requested_workbench_url: str | None = None,
+) -> InteractiveAuthSession | None:
+    """Load a cached auth session if the storage state file exists and is recent.
+
+    The cache lives at ``Path(config.rootpath) / .vip-auth-cache.json`` —
+    one slot per checkout directory, not per site.  If the caller is now
+    targeting a different Connect or Workbench URL than the one the cache
+    was minted against, reusing the saved storage state would silently
+    send the wrong session cookies (and the wrong API key) to the new
+    site.  We treat any URL mismatch as a cache miss so the next run
+    re-authenticates cleanly.
+    """
     if not cache_path.exists():
         return None
 
@@ -162,14 +177,27 @@ def _load_cached_auth(cache_path: Path) -> InteractiveAuthSession | None:
     api_key = None
     key_name = ""
     connect_url = ""
+    workbench_url = ""
     if meta_path.exists():
         try:
             meta = json.loads(meta_path.read_text())
             api_key = meta.get("api_key")
             key_name = meta.get("key_name", "")
             connect_url = meta.get("connect_url", "")
+            workbench_url = meta.get("workbench_url", "")
         except Exception:
             pass
+
+    if not _cached_urls_match(
+        connect_url, workbench_url, requested_connect_url, requested_workbench_url
+    ):
+        print(
+            ">>> Ignoring cached auth session: requested URLs differ from cached "
+            f"(cached connect={connect_url or '∅'}, workbench={workbench_url or '∅'}; "
+            f"requested connect={requested_connect_url or '∅'}, "
+            f"workbench={requested_workbench_url or '∅'})."
+        )
+        return None
 
     print(f">>> Reusing cached auth session from {cache_path}")
     return InteractiveAuthSession(
@@ -177,8 +205,33 @@ def _load_cached_auth(cache_path: Path) -> InteractiveAuthSession | None:
         api_key=api_key,
         key_name=key_name,
         _connect_url=connect_url,
+        _workbench_url=workbench_url,
         _tmpdir="",
         _cache_path=cache_path,
+    )
+
+
+def _normalize_url(url: str | None) -> str:
+    """Lowercase and strip trailing slashes so URL comparisons are stable."""
+    if not url:
+        return ""
+    return url.strip().rstrip("/").lower()
+
+
+def _cached_urls_match(
+    cached_connect: str,
+    cached_workbench: str,
+    requested_connect: str | None,
+    requested_workbench: str | None,
+) -> bool:
+    """True when the cache's recorded URLs match the requested ones.
+
+    A blank cached URL is only acceptable when the caller also did not
+    request that product — a cache minted with Connect-only cannot serve
+    a later run that now also wants Workbench (storage state would lack
+    Workbench cookies)."""
+    return _normalize_url(cached_connect) == _normalize_url(requested_connect) and (
+        _normalize_url(cached_workbench) == _normalize_url(requested_workbench)
     )
 
 
@@ -211,6 +264,7 @@ def _save_auth_cache(session: InteractiveAuthSession, cache_path: Path) -> None:
         "api_key": session.api_key,
         "key_name": session.key_name,
         "connect_url": session._connect_url,
+        "workbench_url": session._workbench_url,
     }
     meta_path.write_text(json.dumps(meta))
     os.chmod(meta_path, 0o600)
@@ -252,7 +306,7 @@ def start_interactive_auth(
 
     # Check for a valid cached session.
     if cache_path:
-        cached = _load_cached_auth(cache_path)
+        cached = _load_cached_auth(cache_path, connect_url, workbench_url)
         if cached is not None:
             return cached
 
@@ -330,8 +384,9 @@ def start_interactive_auth(
             )
 
         # Visit Workbench so the storage state includes its session cookies.
+        workbench_auth_error: str | None = None
         if workbench_url and connect_url:
-            _authenticate_workbench(page, workbench_url)
+            workbench_auth_error = _authenticate_workbench(page, workbench_url)
 
         context.storage_state(path=str(storage_state_path))
 
@@ -339,7 +394,9 @@ def start_interactive_auth(
             storage_state_path=storage_state_path,
             api_key=api_key,
             key_name=key_name,
+            workbench_auth_error=workbench_auth_error,
             _connect_url=connect_url or "",
+            _workbench_url=workbench_url or "",
             _tmpdir=tmpdir,
             _cache_path=cache_path,
             _insecure=insecure,
@@ -419,7 +476,7 @@ def start_headless_auth(
     # Check for a valid cached session before validating credentials/idp,
     # so a warm cache works even when env vars are not set.
     if cache_path:
-        cached = _load_cached_auth(cache_path)
+        cached = _load_cached_auth(cache_path, connect_url, workbench_url)
         if cached is not None:
             return cached
 
@@ -516,8 +573,9 @@ def start_headless_auth(
             )
 
         # Visit Workbench so the storage state includes its session cookies.
+        workbench_auth_error: str | None = None
         if workbench_url and connect_url:
-            _authenticate_workbench(page, workbench_url)
+            workbench_auth_error = _authenticate_workbench(page, workbench_url)
 
         context.storage_state(path=str(storage_state_path))
 
@@ -525,7 +583,9 @@ def start_headless_auth(
             storage_state_path=storage_state_path,
             api_key=api_key,
             key_name=key_name,
+            workbench_auth_error=workbench_auth_error,
             _connect_url=connect_url or "",
+            _workbench_url=workbench_url or "",
             _tmpdir=tmpdir,
             _cache_path=cache_path,
             _insecure=insecure,
@@ -689,7 +749,7 @@ def _on_login_page(url: str) -> bool:
     return any(kw in lower for kw in _LOGIN_KEYWORDS)
 
 
-def _authenticate_workbench(page: Page, workbench_url: str) -> None:
+def _authenticate_workbench(page: Page, workbench_url: str) -> str | None:
     """Navigate to Workbench to establish an SSO session.
 
     After the user authenticated to Connect via OIDC, the identity provider
@@ -707,6 +767,11 @@ def _authenticate_workbench(page: Page, workbench_url: str) -> None:
     If SSO does not resolve automatically (e.g. the auth-sign-in page
     requires a click), we attempt to click through.  The headed browser is
     still visible so the user can also intervene manually.
+
+    Returns ``None`` on success, or a short string describing why
+    Workbench authentication did not complete.  Callers stash this on
+    :class:`InteractiveAuthSession` so test-time skip messages can quote
+    the underlying cause instead of guessing.
     """
     wb_base = workbench_url.rstrip("/").lower()
     print(f"\n>>> Authenticating to Workbench at {workbench_url} ...")
@@ -715,18 +780,19 @@ def _authenticate_workbench(page: Page, workbench_url: str) -> None:
         page.goto(workbench_url)
         page.wait_for_load_state("networkidle")
     except PlaywrightError as exc:
+        reason = f"could not reach Workbench at {workbench_url}: {exc}"
         print(
             f">>> Warning: Could not reach Workbench at {workbench_url}: {exc}\n"
             ">>> Verify the URL is correct and accessible. "
             "Workbench tests may be skipped.\n"
         )
-        return
+        return reason
 
     # Quick check — already on the Workbench dashboard?
     url = page.url
     if url.lower().startswith(wb_base) and not _on_login_page(url):
         print(">>> Workbench authenticated via SSO.\n")
-        return
+        return None
 
     # We're likely on /auth-sign-in.  Try clicking a sign-in button to
     # trigger the OIDC redirect (some Workbench configs don't auto-redirect).
@@ -748,18 +814,19 @@ def _authenticate_workbench(page: Page, workbench_url: str) -> None:
     print(">>> If prompted, please complete authentication in the browser.\n")
 
     deadline = time.monotonic() + 120  # 2-minute timeout
+    last_url = url
     while time.monotonic() < deadline:
         try:
             page.wait_for_load_state("networkidle", timeout=5_000)
         except Exception:
             pass
         try:
-            url = page.url
+            last_url = page.url
         except Exception:
             break
-        if url.lower().startswith(wb_base) and not _on_login_page(url):
+        if last_url.lower().startswith(wb_base) and not _on_login_page(last_url):
             print(">>> Workbench authenticated.\n")
-            return
+            return None
         try:
             page.wait_for_timeout(500)
         except Exception:
@@ -768,6 +835,12 @@ def _authenticate_workbench(page: Page, workbench_url: str) -> None:
     print(
         ">>> Warning: Workbench authentication did not complete within 2 minutes.\n"
         ">>> Workbench browser tests may skip.\n"
+    )
+    return (
+        "Workbench authentication did not complete within 2 minutes "
+        f"(last URL: {last_url}). "
+        "OIDC session may not be shared between Connect and Workbench, "
+        "or the auth-sign-in page required interaction."
     )
 
 

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -232,7 +232,12 @@ def _normalize_url(url: str | None) -> str:
     parts = urlsplit(url.strip())
     scheme = parts.scheme.lower()
     netloc = parts.netloc.lower()
-    path = parts.path.rstrip("/")
+    # Strip at most one trailing slash so ``/app`` and ``/app/`` match,
+    # but ``/app/`` and ``/app//`` remain distinct (some deployments
+    # route them to different handlers).  ``removesuffix`` also turns a
+    # bare ``/`` into ``""`` so a configured-without-trailing-slash URL
+    # matches the same host with ``/`` appended.
+    path = parts.path.removesuffix("/")
     return urlunsplit((scheme, netloc, path, "", ""))
 
 

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -89,6 +89,14 @@ class InteractiveAuthSession:
     workbench_auth_error: str | None = None
 
     _connect_url: str = field(default="", repr=False)
+    # The Connect URL as originally supplied by the caller, before
+    # ``_resolve_connect_api_base`` may have rewritten it to a separate
+    # dashboard/API base.  ``_connect_url`` continues to hold the
+    # resolved value so API key cleanup hits the right endpoint, while
+    # cache-key matching uses this requested form so a stable
+    # configuration cache-hits cleanly even when the dashboard sits at
+    # a sub-path that resolves to a different API base.
+    _requested_connect_url: str = field(default="", repr=False)
     _workbench_url: str = field(default="", repr=False)
     _tmpdir: str = field(default="", repr=False)
     _cache_path: Path | None = field(default=None, repr=False)
@@ -176,24 +184,39 @@ def _load_cached_auth(
     meta_path = cache_path.with_suffix(".meta.json")
     api_key = None
     key_name = ""
-    connect_url = ""
-    workbench_url = ""
+    resolved_connect_url = ""
+    cached_request_connect_url = ""
+    cached_request_workbench_url = ""
     if meta_path.exists():
         try:
             meta = json.loads(meta_path.read_text())
             api_key = meta.get("api_key")
             key_name = meta.get("key_name", "")
-            connect_url = meta.get("connect_url", "")
-            workbench_url = meta.get("workbench_url", "")
+            resolved_connect_url = meta.get("connect_url", "")
+            # Older caches (pre-fix) only stored the resolved URL.  Fall
+            # back to it so a stale cache still matches when the
+            # resolved and requested forms are identical (no sub-path
+            # rewrite happened).
+            cached_request_connect_url = (
+                meta.get("requested_connect_url", "") or resolved_connect_url
+            )
+            cached_request_workbench_url = meta.get("workbench_url", "")
         except Exception:
             pass
 
+    # Match against the *requested* Connect URL so that
+    # ``_resolve_connect_api_base`` rewriting the dashboard URL to a
+    # different API base doesn't force a cache miss on every run.
     if not _cached_urls_match(
-        connect_url, workbench_url, requested_connect_url, requested_workbench_url
+        cached_request_connect_url,
+        cached_request_workbench_url,
+        requested_connect_url,
+        requested_workbench_url,
     ):
         print(
             ">>> Ignoring cached auth session: requested URLs differ from cached "
-            f"(cached connect={connect_url or '∅'}, workbench={workbench_url or '∅'}; "
+            f"(cached connect={cached_request_connect_url or '∅'}, "
+            f"workbench={cached_request_workbench_url or '∅'}; "
             f"requested connect={requested_connect_url or '∅'}, "
             f"workbench={requested_workbench_url or '∅'})."
         )
@@ -204,8 +227,9 @@ def _load_cached_auth(
         storage_state_path=cache_path,
         api_key=api_key,
         key_name=key_name,
-        _connect_url=connect_url,
-        _workbench_url=workbench_url,
+        _connect_url=resolved_connect_url,
+        _requested_connect_url=cached_request_connect_url,
+        _workbench_url=cached_request_workbench_url,
         _tmpdir="",
         _cache_path=cache_path,
     )
@@ -281,12 +305,18 @@ def _save_auth_cache(session: InteractiveAuthSession, cache_path: Path) -> None:
     _shutil.copy2(session.storage_state_path, cache_path)
     os.chmod(cache_path, 0o600)
 
-    # Write companion metadata.
+    # Write companion metadata.  ``connect_url`` keeps the resolved
+    # form (used for API key cleanup); ``requested_connect_url`` keeps
+    # the pre-resolve form for cache-key matching.  Older releases only
+    # wrote ``connect_url`` — :func:`_load_cached_auth` handles that
+    # case by falling back to it when ``requested_connect_url`` is
+    # missing.
     meta_path = cache_path.with_suffix(".meta.json")
     meta = {
         "api_key": session.api_key,
         "key_name": session.key_name,
         "connect_url": session._connect_url,
+        "requested_connect_url": session._requested_connect_url or session._connect_url,
         "workbench_url": session._workbench_url,
     }
     meta_path.write_text(json.dumps(meta))
@@ -396,8 +426,11 @@ def start_interactive_auth(
                 "Please rerun and complete authentication in the browser window."
             )
 
-        # Mint Connect API key only if Connect is configured.
+        # Mint Connect API key only if Connect is configured.  Keep the
+        # caller's original URL for cache-key matching; the rewritten
+        # form is what we actually mint and clean up against.
         api_key = None
+        requested_connect_url = connect_url or ""
         if connect_url:
             connect_url = _resolve_connect_api_base(
                 connect_url, insecure=insecure, ca_bundle=ca_bundle
@@ -419,6 +452,7 @@ def start_interactive_auth(
             key_name=key_name,
             workbench_auth_error=workbench_auth_error,
             _connect_url=connect_url or "",
+            _requested_connect_url=requested_connect_url,
             _workbench_url=workbench_url or "",
             _tmpdir=tmpdir,
             _cache_path=cache_path,
@@ -585,8 +619,11 @@ def start_headless_auth(
             ) from exc
         print(">>> Authentication complete.")
 
-        # Mint Connect API key only if Connect is configured.
+        # Mint Connect API key only if Connect is configured.  Keep the
+        # caller's original URL for cache-key matching; the rewritten
+        # form is what we actually mint and clean up against.
         api_key = None
+        requested_connect_url = connect_url or ""
         if connect_url:
             connect_url = _resolve_connect_api_base(
                 connect_url, insecure=insecure, ca_bundle=ca_bundle
@@ -608,6 +645,7 @@ def start_headless_auth(
             key_name=key_name,
             workbench_auth_error=workbench_auth_error,
             _connect_url=connect_url or "",
+            _requested_connect_url=requested_connect_url,
             _workbench_url=workbench_url or "",
             _tmpdir=tmpdir,
             _cache_path=cache_path,
@@ -861,10 +899,30 @@ def _authenticate_workbench(page: Page, workbench_url: str) -> str | None:
     )
     return (
         "Workbench authentication did not complete within 2 minutes "
-        f"(last URL: {last_url}). "
+        f"(last URL: {_strip_url_query(last_url)}). "
         "OIDC session may not be shared between Connect and Workbench, "
         "or the auth-sign-in page required interaction."
     )
+
+
+def _strip_url_query(url: str) -> str:
+    """Drop query string and fragment from *url* for safe logging.
+
+    The timeout reason from :func:`_authenticate_workbench` is surfaced
+    in the workbench skip message and therefore lands in CI logs and
+    test reports.  If the redirect chain stalled mid-OIDC/SAML, the URL
+    may carry sensitive parameters like ``code=``, ``state=``, or
+    ``SAMLRequest=`` — we keep scheme/host/path for debugging but drop
+    the rest.  Returns the input unchanged when it can't be parsed."""
+    if not url:
+        return url
+    try:
+        from urllib.parse import urlsplit, urlunsplit
+
+        parts = urlsplit(url)
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    except Exception:
+        return url
 
 
 def _httpx_verify(insecure: bool, ca_bundle: Path | None) -> bool | str:

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -212,10 +212,28 @@ def _load_cached_auth(
 
 
 def _normalize_url(url: str | None) -> str:
-    """Lowercase and strip trailing slashes so URL comparisons are stable."""
+    """Normalize a product URL for cache-key comparison.
+
+    Per RFC 3986 the scheme and host are case-insensitive but the path
+    is case-sensitive — Connect can be served at ``/Dashboard`` and
+    ``/dashboard`` as distinct routes when a sub-path mount is used.
+    Lowercasing the whole string (the prior behaviour) collapsed those
+    into the same cache slot and could reuse storage state minted
+    against a different deployment path.
+
+    We lowercase only the scheme and netloc, preserve path case, strip
+    a single trailing ``/`` from the path, and drop query/fragment
+    (auth cache keying off ``?foo=bar`` would be surprising)."""
     if not url:
         return ""
-    return url.strip().rstrip("/").lower()
+
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(url.strip())
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc.lower()
+    path = parts.path.rstrip("/")
+    return urlunsplit((scheme, netloc, path, "", ""))
 
 
 def _cached_urls_match(

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -291,7 +291,9 @@ def _restore_worker_auth(config: pytest.Config, vip_cfg: VIPConfig) -> None:
         storage_state_path=Path(storage_state) if storage_state else Path("/dev/null"),
         api_key=api_key,
         key_name=wi.get("vip_key_name", ""),
+        workbench_auth_error=wi.get("vip_workbench_auth_error") or None,
         _connect_url=connect_url,
+        _workbench_url=wi.get("vip_workbench_url", "") or "",
         _tmpdir="",  # Workers don't own the temp dir; controller cleans up.
     )
     config.stash[_auth_session_key] = session
@@ -309,6 +311,8 @@ def pytest_configure_node(node) -> None:
         node.workerinput["vip_storage_state"] = str(auth.storage_state_path)
         node.workerinput["vip_key_name"] = auth.key_name
         node.workerinput["vip_connect_url"] = auth._connect_url
+        node.workerinput["vip_workbench_url"] = auth._workbench_url
+        node.workerinput["vip_workbench_auth_error"] = auth.workbench_auth_error or ""
         node.workerinput["vip_auth_mode"] = node.config.stash.get(_auth_mode_key, "")
 
 

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -124,6 +124,21 @@ def auth_mode(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="session")
+def workbench_auth_error(request: pytest.FixtureRequest) -> str | None:
+    """Reason Workbench auth did not complete during pre-test sign-in, if any.
+
+    Returns ``None`` when Workbench was authenticated successfully or
+    when no pre-test auth ran.  Tests that depend on Workbench storage
+    state can read this to produce an informative skip message instead
+    of a generic "session not shared" guess.
+    """
+    session = request.config.stash.get(_auth_session_key, None)
+    if session is None:
+        return None
+    return session.workbench_auth_error
+
+
+@pytest.fixture(scope="session")
 def browser_context_args(
     browser_context_args, request: pytest.FixtureRequest, vip_config: VIPConfig
 ):

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -54,6 +54,32 @@ def _on_login_page(url: str) -> bool:
     return any(kw in lower for kw in _LOGIN_KEYWORDS)
 
 
+def _workbench_session_skip_message(
+    *,
+    auth_mode: str,
+    workbench_auth_error: str | None,
+    landed_url: str,
+) -> str:
+    """Build the skip text shown when storage state did not log Workbench in.
+
+    Names the active auth mode's CLI flag, quotes any error captured by
+    ``_authenticate_workbench`` during pre-test sign-in, and lists the
+    next steps a user can take.  Prior versions said "Interactive auth
+    storage state did not authenticate Workbench" regardless of which
+    mode was active and without surfacing the underlying cause.
+    """
+    flag = "--headless-auth" if auth_mode == "headless" else "--interactive-auth"
+    lines = [f"Workbench session not established by {flag} (landed on login page: {landed_url})."]
+    if workbench_auth_error:
+        lines.append(f"Pre-test auth reported: {workbench_auth_error}")
+    lines.append(
+        "Next steps: rerun with --vip-verbose to see the auth flow, "
+        "confirm the OIDC provider issues a session valid for Workbench's domain, "
+        "and check that the Workbench auth-sign-in page does not require interaction."
+    )
+    return " ".join(lines)
+
+
 def assert_homepage_loaded(page: Page) -> None:
     """Assert that the Workbench homepage has fully loaded.
 
@@ -77,6 +103,8 @@ def workbench_login(
     auth_provider: str = "password",
     interactive_auth: bool = False,
     *,
+    auth_mode: str = "none",
+    workbench_auth_error: str | None = None,
     max_retries: int = 3,
     retry_delay: float = 2.0,
 ) -> None:
@@ -96,6 +124,11 @@ def workbench_login(
         auth_provider: Auth type (e.g., "password", "oidc", "saml")
         interactive_auth: True when an auth session is pre-loaded (either
             --interactive-auth or --headless-auth)
+        auth_mode: Active auth mode ("interactive", "headless", or "none"),
+            used to name the responsible CLI flag in skip messages
+        workbench_auth_error: Reason the pre-test auth flow could not
+            establish a Workbench session, if known.  Quoted in the skip
+            message so users see the real cause instead of a guess.
         max_retries: Max login attempts on transient errors (default 3)
         retry_delay: Seconds to wait between retries (default 2.0)
 
@@ -123,10 +156,12 @@ def workbench_login(
     # Check if we landed on a login/IdP page
     if _on_login_page(page.url):
         if auth_provider != "password":
-            # Interactive auth storage state didn't authenticate Workbench
             pytest.skip(
-                "Interactive auth storage state did not authenticate Workbench. "
-                "The OIDC session may not be shared between Connect and Workbench."
+                _workbench_session_skip_message(
+                    auth_mode=auth_mode,
+                    workbench_auth_error=workbench_auth_error,
+                    landed_url=page.url,
+                )
             )
         # Password auth - proceed with form login below
     else:
@@ -240,6 +275,8 @@ def wb_login(
     test_password: str,
     auth_provider: str,
     interactive_auth: bool,
+    auth_mode: str,
+    workbench_auth_error: str | None,
 ):
     """Log in to Workbench and verify homepage loads.
 
@@ -250,7 +287,14 @@ def wb_login(
     Returns the page for further interactions.
     """
     workbench_login(
-        page, workbench_url, test_username, test_password, auth_provider, interactive_auth
+        page,
+        workbench_url,
+        test_username,
+        test_password,
+        auth_provider,
+        interactive_auth,
+        auth_mode=auth_mode,
+        workbench_auth_error=workbench_auth_error,
     )
 
     assert_homepage_loaded(page)

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -67,8 +67,17 @@ def _workbench_session_skip_message(
     next steps a user can take.  Prior versions said "Interactive auth
     storage state did not authenticate Workbench" regardless of which
     mode was active and without surfacing the underlying cause.
+
+    When *auth_mode* is unknown (a caller forgot to thread the fixture
+    through), the message names both ``--interactive-auth`` and
+    ``--headless-auth`` so the reader isn't pointed at the wrong flag.
     """
-    flag = "--headless-auth" if auth_mode == "headless" else "--interactive-auth"
+    if auth_mode == "headless":
+        flag = "--headless-auth"
+    elif auth_mode == "interactive":
+        flag = "--interactive-auth"
+    else:
+        flag = "--interactive-auth / --headless-auth"
     lines = [f"Workbench session not established by {flag} (landed on login page: {landed_url})."]
     if workbench_auth_error:
         lines.append(f"Pre-test auth reported: {workbench_auth_error}")

--- a/src/vip_tests/workbench/test_data_sources.py
+++ b/src/vip_tests/workbench/test_data_sources.py
@@ -138,11 +138,20 @@ def verify_connectivity(
     test_password: str,
     auth_provider: str,
     interactive_auth: bool,
+    auth_mode: str,
+    workbench_auth_error: str | None,
     data_sources,
 ):
     """Start an RStudio session and verify HTTP data source connectivity from within it."""
     workbench_login(
-        page, workbench_url, test_username, test_password, auth_provider, interactive_auth
+        page,
+        workbench_url,
+        test_username,
+        test_password,
+        auth_provider,
+        interactive_auth,
+        auth_mode=auth_mode,
+        workbench_auth_error=workbench_auth_error,
     )
     assert_homepage_loaded(page)
 

--- a/src/vip_tests/workbench/test_ide_extensions.py
+++ b/src/vip_tests/workbench/test_ide_extensions.py
@@ -99,10 +99,19 @@ def user_logged_in(
     test_password: str,
     auth_provider: str,
     interactive_auth: bool,
+    auth_mode: str,
+    workbench_auth_error: str | None,
 ):
     """Log in to Workbench and verify homepage loads."""
     workbench_login(
-        page, workbench_url, test_username, test_password, auth_provider, interactive_auth
+        page,
+        workbench_url,
+        test_username,
+        test_password,
+        auth_provider,
+        interactive_auth,
+        auth_mode=auth_mode,
+        workbench_auth_error=workbench_auth_error,
     )
     assert_homepage_loaded(page)
 

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -105,10 +105,19 @@ def user_logged_in(
     test_password: str,
     auth_provider: str,
     interactive_auth: bool,
+    auth_mode: str,
+    workbench_auth_error: str | None,
 ):
     """Log in to Workbench and verify homepage loads."""
     workbench_login(
-        page, workbench_url, test_username, test_password, auth_provider, interactive_auth
+        page,
+        workbench_url,
+        test_username,
+        test_password,
+        auth_provider,
+        interactive_auth,
+        auth_mode=auth_mode,
+        workbench_auth_error=workbench_auth_error,
     )
 
     assert_homepage_loaded(page)

--- a/src/vip_tests/workbench/test_packages.py
+++ b/src/vip_tests/workbench/test_packages.py
@@ -48,10 +48,19 @@ def user_logged_in(
     test_password: str,
     auth_provider: str,
     interactive_auth: bool,
+    auth_mode: str,
+    workbench_auth_error: str | None,
 ):
     """Log in to Workbench and verify homepage loads."""
     workbench_login(
-        page, workbench_url, test_username, test_password, auth_provider, interactive_auth
+        page,
+        workbench_url,
+        test_username,
+        test_password,
+        auth_provider,
+        interactive_auth,
+        auth_mode=auth_mode,
+        workbench_auth_error=workbench_auth_error,
     )
     assert_homepage_loaded(page)
 

--- a/src/vip_tests/workbench/test_session_capacity.py
+++ b/src/vip_tests/workbench/test_session_capacity.py
@@ -168,6 +168,8 @@ def workbench_logged_in(
     test_password: str,
     auth_provider: str,
     interactive_auth: bool,
+    auth_mode: str,
+    workbench_auth_error: str | None,
 ):
     workbench_login(
         page,
@@ -176,6 +178,8 @@ def workbench_logged_in(
         test_password,
         auth_provider,
         interactive_auth,
+        auth_mode=auth_mode,
+        workbench_auth_error=workbench_auth_error,
     )
     assert_homepage_loaded(page)
 

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -58,10 +58,19 @@ def user_logged_in(
     test_password: str,
     auth_provider: str,
     interactive_auth: bool,
+    auth_mode: str,
+    workbench_auth_error: str | None,
 ):
     """Log in to Workbench and verify homepage loads."""
     workbench_login(
-        page, workbench_url, test_username, test_password, auth_provider, interactive_auth
+        page,
+        workbench_url,
+        test_username,
+        test_password,
+        auth_provider,
+        interactive_auth,
+        auth_mode=auth_mode,
+        workbench_auth_error=workbench_auth_error,
     )
 
     assert_homepage_loaded(page)


### PR DESCRIPTION
## Summary

As I was trying two internal testing sites with okta, I came across some issues with auth that I've fixed up here.

- **Workbench skip messages now name the cause.** When `--interactive-auth` / `--headless-auth` could not establish a Workbench session, browser tests skipped with a hard-coded "Interactive auth storage state did not authenticate Workbench" line regardless of which mode was active. `_authenticate_workbench` now returns the failure reason (PlaywrightError, 2-minute timeout, or last URL on the login page) and the workbench login fixture quotes it in the skip text along with the active mode's CLI flag and a short list of next steps.
- **Auth cache invalidates on URL mismatch.** `.vip-auth-cache.json` is one slot per checkout directory, so a second run targeting a different connect-url or workbench-url silently reused the first run's storage state and API key. The cache now records both URLs and refuses to load when either differs from the request. URL normalization lowercases only scheme + netloc (paths are case-sensitive per RFC 3986) and strips at most one trailing slash so `/app/` and `/app//` remain distinct.
- **`workbench_auth_error` propagates across xdist workers** via `pytest_configure_node` / `_restore_worker_auth` so the new skip message is consistent under `-n auto`.

## Test plan

- [x] `just check` (ruff lint + format)
- [x] `uv run pytest selftests/ -q` (559 passing, 3 expected skips)
- [x] Reproduce the original skip on a real OIDC deployment with mismatched Connect/Workbench sessions and verify the new skip message names the right flag and quotes the captured reason
- [x] Verify cache invalidation: run `vip verify` against site A, then site B from the same directory within 4 hours, and confirm site B re-authenticates instead of reusing site A's state