### PR TITLE
fix(issue-triage): promote pre-run cleanup to dedicated Step 1a

### DIFF
--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -58,18 +58,35 @@ number,title,body,labels,author,state`). Exit silently if any of:
   (`@ian-flores`, `@statik`, `@bdeitte`) OR the comment body does not
   match `@Copilot retry` (case-insensitive).
 
-If `re-triage` is in the labels, remove it (`gh issue edit <num>
---remove-label re-triage`) before continuing.
+## Step 1a — pre-run cleanup (MUST run before Step 2)
 
-Create the labels you may apply, idempotently, in case they do not yet
-exist:
+Before proceeding to Step 2, you MUST perform these two cleanup actions
+in order. Do not skip them. Do not defer them to the end of the run —
+partial-failure recovery depends on them happening at the start.
 
-```
-gh label create triaged-by-bot --color BFD4F2 --description "Bot has examined this issue" --force
-gh label create needs-human-triage --color D93F0B --description "Bot could not propose action; needs a maintainer" --force
-gh label create skip-triage --color CCCCCC --description "Do not run the triage agent on this issue" --force
-gh label create re-triage --color FBCA04 --description "Re-run the triage agent on this issue" --force
-```
+1. **Remove the `re-triage` label** if it is present on the issue.
+   Humans apply this label to request a re-run; the bot consumes it
+   here on every run. Check the labels from Step 1's `gh issue view`
+   output. If `re-triage` is among them, run:
+
+   ```
+   gh issue edit ${{ github.event.issue.number }} --remove-label re-triage
+   ```
+
+2. **Create the four triage labels idempotently** so subsequent
+   `--add-label` calls succeed. The `--force` flag makes these safe
+   to run on every invocation:
+
+   ```
+   gh label create triaged-by-bot --color BFD4F2 --description "Bot has examined this issue" --force
+   gh label create needs-human-triage --color D93F0B --description "Bot could not propose action; needs a maintainer" --force
+   gh label create skip-triage --color CCCCCC --description "Do not run the triage agent on this issue" --force
+   gh label create re-triage --color FBCA04 --description "Re-run the triage agent on this issue" --force
+   ```
+
+If either action fails, proceed to Step 2 anyway. Label cleanup is
+best-effort — record the failure in your reasoning but do not emit
+a Step 5 comment for it.
 
 ## Step 2 — classify
 


### PR DESCRIPTION
## Summary

Restructures the issue-triage workflow's Step 1 so the `re-triage`
removal and idempotent label-bootstrap commands live in their own
numbered, MUST-framed `Step 1a — pre-run cleanup` block instead of
sitting as loose paragraphs at the tail of the gate logic.

### Why

In #288's first re-run, the bot reached Step 4 (enhancement path) and
wrote the plan file successfully, but never executed the
`gh issue edit --remove-label re-triage` instruction that was buried in
Step 1's narrative. Same story for the `gh label create` bootstrap:
only the two labels the bot ended up *applying* (`triaged-by-bot`,
`needs-human-triage`) got created — `re-triage` and `skip-triage` had to
be created by hand for the re-triage flow to work at all.

The pattern is consistent: Copilot tends to skip "incidental" guidance
that isn't called out as imperative steps, especially when a later
section (Step 4 here) is framed as the deliverable. Promoting the
cleanup to its own numbered step with explicit `MUST` wording removes
the ambiguity.

### What changes

- New `Step 1a — pre-run cleanup` section with two numbered actions.
- Same shell commands as before, no behavior intent change.
- Added a best-effort failure clause so a transient label-API hiccup
  can't derail the run into Step 5.

### What does not change

- Step 1's gate conditions are untouched.
- The bash allowlist is untouched (`gh issue edit *` and `gh label
  create *` already permit the calls).
- Steps 2–6 are byte-identical.

## Test plan

- [ ] Verifiable only on the next live triage cycle. When an issue
      goes through a re-triage (or a fresh enhancement-path run lands),
      confirm the `re-triage` label is gone after the workflow run
      finishes, and that the four triage labels all exist.
- [ ] Tracked separately: CloudOps work to enable
      "Allow GitHub Actions to create and approve pull requests" so the
      enhancement path can actually open a PR end-to-end (currently
      falls back to opening a notification issue, as on #291).