### PR TITLE
ci: narrow agentic workflow permissions to match the App's grants

### DIFF
--- a/.github/workflows/implement-plan.lock.yml
+++ b/.github/workflows/implement-plan.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bfe6e1f66aceb76078b1e8f021529d24e8122ac2724edd50205ec58018dd4cea","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ff0a407e24eb860aa120883c0a7382498d58b28e2a20156b60b8abf506b9472e","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -207,23 +207,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           <system>
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,12 +252,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           </system>
           {{#runtime-import .github/workflows/implement-plan.md}}
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -340,7 +340,10 @@ jobs:
   agent:
     needs: activation
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -437,18 +440,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
-          permission-actions: read
-          permission-checks: read
           permission-contents: read
-          permission-deployments: read
-          permission-discussions: read
           permission-issues: read
-          permission-packages: read
-          permission-pages: read
           permission-pull-requests: read
-          permission-security-events: read
-          permission-statuses: read
-          permission-vulnerability-alerts: read
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -482,9 +476,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4ad05deed1b72574_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4fae8978cf95b3dc_EOF'
           {"add_comment":{"max":2},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4ad05deed1b72574_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4fae8978cf95b3dc_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -720,7 +714,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f91016075891f16d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8a3a3fa4f99bbe8f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -748,7 +742,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f91016075891f16d_EOF
+          GH_AW_MCP_CONFIG_8a3a3fa4f99bbe8f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1038,7 +1032,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1074,7 +1067,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1450,7 +1442,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1520,7 +1511,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Extract base branch from agent output

--- a/.github/workflows/implement-plan.md
+++ b/.github/workflows/implement-plan.md
@@ -5,7 +5,10 @@ on:
     branches: [main]
     paths:
       - "thoughts/shared/plans/**.md"
-permissions: read-all
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 tools:
   github:
     toolsets: [default]
@@ -34,6 +37,7 @@ safe-outputs:
     private-key: ${{ secrets.POSIT_VIP_TRIAGE_PEM }}
   add-comment:
     max: 2
+    discussions: false
   create-pull-request:
     branch-prefix: "bot-"
     draft: false

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e3a836bf5d2b3545deb02f74f88a86b174384399b76a4d84bc35c6f113da5be5","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b759d948481d7c74aa664aa8dfb437bf0584312f6b1dea358a1fdfa33bad773b","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -207,23 +207,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           <system>
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request, add_labels(max:3), missing_tool, missing_data, noop
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,15 +252,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -345,7 +345,10 @@ jobs:
   agent:
     needs: activation
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -442,18 +445,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
-          permission-actions: read
-          permission-checks: read
           permission-contents: read
-          permission-deployments: read
-          permission-discussions: read
           permission-issues: read
-          permission-packages: read
-          permission-pages: read
           permission-pull-requests: read
-          permission-security-events: read
-          permission-statuses: read
-          permission-vulnerability-alerts: read
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -487,9 +481,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0259cadbc41b64b0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0efee8098bd6d8d2_EOF'
           {"add_comment":{"max":1},"add_labels":{"allowed":["triaged-by-bot","needs-human-triage"],"max":3},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0259cadbc41b64b0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0efee8098bd6d8d2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -745,7 +739,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_d25bf35591415f26_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_379c3c452c0729ea_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -773,7 +767,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d25bf35591415f26_EOF
+          GH_AW_MCP_CONFIG_379c3c452c0729ea_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1065,7 +1059,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1101,7 +1094,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1478,7 +1470,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1548,7 +1539,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Extract base branch from agent output

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -4,7 +4,10 @@ on:
     types: [opened, reopened, labeled]
   issue_comment:
     types: [created]
-permissions: read-all
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 tools:
   github:
     toolsets: [default]
@@ -35,6 +38,7 @@ safe-outputs:
     private-key: ${{ secrets.POSIT_VIP_TRIAGE_PEM }}
   add-comment:
     max: 1
+    discussions: false
   add-labels:
     max: 3
     allowed: ["triaged-by-bot", "needs-human-triage"]

--- a/.github/workflows/preview-screenshot-gallery.lock.yml
+++ b/.github/workflows/preview-screenshot-gallery.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e0d2d8a1939b19458b21ece954547d5a000e600ceb0b539567227efda1744e2b","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f049c2ec70f505fa1dfffdefa25381f8fb3c75f237c1f9ea2ce28fd9680d2e8f","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -193,23 +193,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           <system>
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/playwright_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           <safe-output-tools>
           Tools: add_comment, upload_asset(max:100), missing_tool, missing_data, noop
           
           upload_asset: provide a file path; returns a URL; assets are published after the workflow completes (safeoutputs).
           </safe-output-tools>
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -238,12 +238,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           </system>
           {{#runtime-import .github/workflows/preview-screenshot-gallery.md}}
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -323,7 +323,10 @@ jobs:
   agent:
     needs: activation
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     concurrency:
       group: "gh-aw-copilot-${{ github.workflow }}"
     env:
@@ -426,18 +429,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
-          permission-actions: read
-          permission-checks: read
           permission-contents: read
-          permission-deployments: read
-          permission-discussions: read
           permission-issues: read
-          permission-packages: read
-          permission-pages: read
           permission-pull-requests: read
-          permission-security-events: read
-          permission-statuses: read
-          permission-vulnerability-alerts: read
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -471,9 +465,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_bbe494a0b3fc3974_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7d23069ddca2d315_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/preview-screenshot-gallery","max":100,"max-size":10240}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_bbe494a0b3fc3974_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7d23069ddca2d315_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -680,7 +674,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e049abf4fb1097f7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_7792ea468d57e110_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -708,7 +702,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e049abf4fb1097f7_EOF
+          GH_AW_MCP_CONFIG_7792ea468d57e110_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -975,7 +969,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1011,7 +1004,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: read
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1384,7 +1376,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1446,7 +1437,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: read
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Configure GH_HOST for enterprise compatibility

--- a/.github/workflows/preview-screenshot-gallery.md
+++ b/.github/workflows/preview-screenshot-gallery.md
@@ -4,7 +4,10 @@ on:
     workflows: ["Website Preview"]
     types: [completed]
     branches: ["**"]
-permissions: read-all
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 tools:
   github:
     toolsets: [default]
@@ -23,6 +26,7 @@ safe-outputs:
     max: 100
   add-comment:
     max: 1
+    discussions: false
 network:
   allowed:
     - defaults


### PR DESCRIPTION
## Summary

The first live run of the triage workflow after #294 failed at the
`actions/create-github-app-token` step with:

> HTTP 422: The permissions requested are not granted to this installation.

The default `permissions: read-all` was being expanded by gh-aw into a
request for read access to a long list of scopes (`actions`, `checks`,
`deployments`, `discussions`, `packages`, `pages`, `security-events`,
`statuses`, `vulnerability-alerts`, etc.) that the App is not granted.
GitHub refuses the mint outright when *any* requested permission is
absent from the installation.

The App has exactly: `contents`, `issues`, `pull-requests` (read+write),
and `metadata` (read). So the workflows have been narrowed to match.

## What changes

All three gh-aw workflow `.md` files:

- **Replace `permissions: read-all`** with an explicit read-only block:
  ```yaml
  permissions:
    contents: read
    issues: read
    pull-requests: read
  ```
  Writes happen exclusively through safe-outputs (gh-aw strict mode
  blocks workflow-level `*: write` anyway). The safe-outputs job mints
  its own token with `contents: write` / `issues: write` /
  `pull-requests: write` for the duration of the operation.

- **Add `discussions: false`** to each `add-comment` safe-output. By
  default gh-aw requests `discussions: write` because `add-comment`
  *could* target a discussion thread; ours don't. The flag drops that
  unneeded permission so the safe-outputs token mint only requests
  what the App grants.

Regenerated the three `.lock.yml` files via `gh aw compile --approve`.
Confirmed via `grep "permission-" *.lock.yml` that the minted tokens
now request exactly `contents`, `issues`, `pull-requests` (in matching
read/write pairs) and nothing else.

## Test plan

- [ ] After merge, re-trigger the triage workflow on #288 (or another
      open issue) and confirm:
  - `Generate GitHub App token` step succeeds (no HTTP 422).
  - Workflow runs to completion.
  - Bot still opens a real PR.
- [ ] Spot-check the next implement-plan and preview-screenshot-gallery
      runs to ensure they also mint tokens successfully.