### PR TITLE
feat(cli): support help flag before the subcommand

### DIFF
--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1064,3 +1065,21 @@ class TestReorderHelpArgs:
 
         result = _reorder_help_args(["-h", "auth", "mint-connect-key"], self.COMMANDS)
         assert result == ["auth", "mint-connect-key", "--help"]
+
+    def test_help_inserted_before_passthrough_separator(self):
+        from vip.cli import _reorder_help_args
+
+        # The moved help flag must land before ``--`` -- after it argparse
+        # treats every token as a positional, so help would never fire.
+        result = _reorder_help_args(["-h", "verify", "--", "-x"], self.COMMANDS)
+        assert result == ["verify", "--help", "--", "-x"]
+
+    def test_help_with_separator_actually_shows_help(self):
+        from vip.cli import main
+
+        with patch.object(sys, "argv", ["vip", "-h", "verify", "--", "-x"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        # argparse exits 0 after printing help; a nonzero/None code would mean
+        # it fell through to running the command instead.
+        assert exc.value.code == 0

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -1022,3 +1022,45 @@ class TestVerifyLocalTLSFlags:
         finally:
             if path:
                 Path(path).unlink(missing_ok=True)
+
+
+class TestReorderHelpArgs:
+    """`vip -h <subcommand>` should surface the subcommand's help, not top-level."""
+
+    COMMANDS = {"verify", "cleanup", "install", "auth", "cluster", "report"}
+
+    def test_help_before_subcommand_is_moved_after(self):
+        from vip.cli import _reorder_help_args
+
+        result = _reorder_help_args(["-h", "verify"], self.COMMANDS)
+        assert result == ["verify", "--help"]
+
+    def test_long_help_flag_before_subcommand(self):
+        from vip.cli import _reorder_help_args
+
+        result = _reorder_help_args(["--help", "cleanup"], self.COMMANDS)
+        assert result == ["cleanup", "--help"]
+
+    def test_help_after_subcommand_is_untouched(self):
+        from vip.cli import _reorder_help_args
+
+        argv = ["verify", "-h"]
+        assert _reorder_help_args(argv, self.COMMANDS) == argv
+
+    def test_top_level_help_without_subcommand_is_untouched(self):
+        from vip.cli import _reorder_help_args
+
+        argv = ["-h"]
+        assert _reorder_help_args(argv, self.COMMANDS) == argv
+
+    def test_no_help_flag_is_untouched(self):
+        from vip.cli import _reorder_help_args
+
+        argv = ["verify", "--connect-url", "https://example.com"]
+        assert _reorder_help_args(argv, self.COMMANDS) == argv
+
+    def test_help_before_nested_subcommand(self):
+        from vip.cli import _reorder_help_args
+
+        result = _reorder_help_args(["-h", "auth", "mint-connect-key"], self.COMMANDS)
+        assert result == ["auth", "mint-connect-key", "--help"]

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -971,8 +971,8 @@ def _reorder_help_args(argv: list[str], commands: set[str]) -> list[str]:
 
     argparse's top-level parser consumes ``-h``/``--help`` before it delegates to
     a subparser, so a help flag placed *before* the subcommand prints the generic
-    help. If a help flag appears ahead of a known subcommand, move it to the end
-    so the subparser handles it and prints its own help.
+    help. If a help flag appears ahead of a known subcommand, move it after the
+    subcommand so the subparser handles it and prints its own help.
     """
     help_flags = {"-h", "--help"}
     first_help = next((i for i, a in enumerate(argv) if a in help_flags), None)
@@ -983,7 +983,12 @@ def _reorder_help_args(argv: list[str], commands: set[str]) -> list[str]:
         # No subcommand (top-level help is correct) or help already after it.
         return argv
     reordered = [a for a in argv if a not in help_flags]
-    reordered.append("--help")
+    # Insert the help flag before any ``--`` passthrough separator. After ``--``
+    # argparse treats every token as a positional, so an appended ``--help``
+    # would be swallowed as a pytest arg and the command would run instead of
+    # printing help.
+    insert_at = reordered.index("--") if "--" in reordered else len(reordered)
+    reordered.insert(insert_at, "--help")
     return reordered
 
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -966,6 +966,27 @@ def run_cleanup(args: argparse.Namespace) -> None:
     print("Cleanup completed successfully")
 
 
+def _reorder_help_args(argv: list[str], commands: set[str]) -> list[str]:
+    """Let ``vip -h verify`` show verify's help instead of the top-level help.
+
+    argparse's top-level parser consumes ``-h``/``--help`` before it delegates to
+    a subparser, so a help flag placed *before* the subcommand prints the generic
+    help. If a help flag appears ahead of a known subcommand, move it to the end
+    so the subparser handles it and prints its own help.
+    """
+    help_flags = {"-h", "--help"}
+    first_help = next((i for i, a in enumerate(argv) if a in help_flags), None)
+    if first_help is None:
+        return argv
+    first_cmd = next((i for i, a in enumerate(argv) if a in commands), None)
+    if first_cmd is None or first_help > first_cmd:
+        # No subcommand (top-level help is correct) or help already after it.
+        return argv
+    reordered = [a for a in argv if a not in help_flags]
+    reordered.append("--help")
+    return reordered
+
+
 def main() -> None:
     """Main entry point for the VIP CLI."""
     parser = argparse.ArgumentParser(
@@ -1351,7 +1372,8 @@ def main() -> None:
         "app": app_parser,
     }
 
-    args = parser.parse_args()
+    argv = _reorder_help_args(sys.argv[1:], set(subcommand_parsers))
+    args = parser.parse_args(argv)
     if not hasattr(args, "func"):
         sub = subcommand_parsers.get(args.command)
         if sub:


### PR DESCRIPTION
## Summary

A small thing I came across that confused me when using vip today- while "vip verify -h" gave me the info I wanted, I first tried "vip -h verify" and that gave me the top-level info which was confusing.

`vip -h verify` previously printed the top-level help instead of the `verify` subcommand's help, because argparse's top-level parser consumes `-h`/`--help` before delegating to a subparser. The only working form was `vip verify -h`.

This adds a small preprocessing helper, `_reorder_help_args`, that runs before `parse_args()`. When a help flag appears *ahead* of a recognized subcommand, it moves the flag to the end of the arg list so the subparser handles it and prints its own help. It reuses the existing `subcommand_parsers` dict for the command names, so it stays in sync automatically.

## Behavior

| Command | Result |
|---|---|
| `vip -h verify` | now shows full verify help (incl. `--headless-auth`) |
| `vip verify -h` | unchanged, still works |
| `vip -h auth mint-connect-key` | shows the nested subcommand help |
| `vip -h` (no subcommand) | still shows top-level help |

Arg lists are left untouched when there's no help flag, when help already follows the command, or when there's no subcommand.

## Testing

- New `selftests/test_cli_verify.py::TestReorderHelpArgs` (6 cases) — all pass
- Full selftest suite: 570 passed, 3 skipped
- ruff lint + format (0.15.0): clean