### PR TITLE
fix(workflows): force re-triage cleanup + pin agent models

### DIFF
--- a/.github/workflows/implement-plan.lock.yml
+++ b/.github/workflows/implement-plan.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ff0a407e24eb860aa120883c0a7382498d58b28e2a20156b60b8abf506b9472e","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"50367f500b195dac5dc76badbcd50d5d1785b5f55f629eb6b9eeb4b0af7b8913","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -110,7 +110,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.5' }}
+          GH_AW_INFO_MODEL: "claude-sonnet-4.6"
           GH_AW_INFO_VERSION: "1.0.48"
           GH_AW_INFO_AGENT_VERSION: "1.0.48"
           GH_AW_INFO_CLI_VERSION: "v0.74.8"
@@ -207,23 +207,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
+          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
           <system>
-          GH_AW_PROMPT_74a644680fd33507_EOF
+          GH_AW_PROMPT_5673439332fd00e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
+          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_74a644680fd33507_EOF
+          GH_AW_PROMPT_5673439332fd00e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
+          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_74a644680fd33507_EOF
+          GH_AW_PROMPT_5673439332fd00e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
+          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,12 +252,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_74a644680fd33507_EOF
+          GH_AW_PROMPT_5673439332fd00e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
+          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
           </system>
           {{#runtime-import .github/workflows/implement-plan.md}}
-          GH_AW_PROMPT_74a644680fd33507_EOF
+          GH_AW_PROMPT_5673439332fd00e5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -476,9 +476,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4fae8978cf95b3dc_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_26b007378839c99c_EOF'
           {"add_comment":{"max":2},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4fae8978cf95b3dc_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_26b007378839c99c_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -714,7 +714,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8a3a3fa4f99bbe8f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_48f64a51f9d2fc3e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -742,7 +742,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8a3a3fa4f99bbe8f_EOF
+          GH_AW_MCP_CONFIG_48f64a51f9d2fc3e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -826,7 +826,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.5' }}
+          COPILOT_MODEL: claude-sonnet-4.6
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1342,7 +1342,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || 'claude-sonnet-4.5' }}
+          COPILOT_MODEL: claude-sonnet-4.6
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.74.8
@@ -1451,7 +1451,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
       GH_AW_ENGINE_VERSION: "1.0.48"
       GH_AW_WORKFLOW_ID: "implement-plan"
       GH_AW_WORKFLOW_NAME: "Implement an approved plan PR"

--- a/.github/workflows/implement-plan.lock.yml
+++ b/.github/workflows/implement-plan.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bfe6e1f66aceb76078b1e8f021529d24e8122ac2724edd50205ec58018dd4cea","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ff0a407e24eb860aa120883c0a7382498d58b28e2a20156b60b8abf506b9472e","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -207,23 +207,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           <system>
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,12 +252,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_49a686cd480af02b_EOF'
+          cat << 'GH_AW_PROMPT_74a644680fd33507_EOF'
           </system>
           {{#runtime-import .github/workflows/implement-plan.md}}
-          GH_AW_PROMPT_49a686cd480af02b_EOF
+          GH_AW_PROMPT_74a644680fd33507_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -340,7 +340,10 @@ jobs:
   agent:
     needs: activation
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -437,18 +440,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
-          permission-actions: read
-          permission-checks: read
           permission-contents: read
-          permission-deployments: read
-          permission-discussions: read
           permission-issues: read
-          permission-packages: read
-          permission-pages: read
           permission-pull-requests: read
-          permission-security-events: read
-          permission-statuses: read
-          permission-vulnerability-alerts: read
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -482,9 +476,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4ad05deed1b72574_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4fae8978cf95b3dc_EOF'
           {"add_comment":{"max":2},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4ad05deed1b72574_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4fae8978cf95b3dc_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -720,7 +714,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f91016075891f16d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8a3a3fa4f99bbe8f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -748,7 +742,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f91016075891f16d_EOF
+          GH_AW_MCP_CONFIG_8a3a3fa4f99bbe8f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1038,7 +1032,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1074,7 +1067,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1450,7 +1442,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1520,7 +1511,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Extract base branch from agent output

--- a/.github/workflows/implement-plan.md
+++ b/.github/workflows/implement-plan.md
@@ -5,7 +5,10 @@ on:
     branches: [main]
     paths:
       - "thoughts/shared/plans/**.md"
-permissions: read-all
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 tools:
   github:
     toolsets: [default]
@@ -34,6 +37,7 @@ safe-outputs:
     private-key: ${{ secrets.POSIT_VIP_TRIAGE_PEM }}
   add-comment:
     max: 2
+    discussions: false
   create-pull-request:
     branch-prefix: "bot-"
     draft: false

--- a/.github/workflows/implement-plan.md
+++ b/.github/workflows/implement-plan.md
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "thoughts/shared/plans/**.md"
+engine:
+  id: copilot
+  model: claude-sonnet-4.6
 permissions:
   contents: read
   issues: read

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e3a836bf5d2b3545deb02f74f88a86b174384399b76a4d84bc35c6f113da5be5","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b759d948481d7c74aa664aa8dfb437bf0584312f6b1dea358a1fdfa33bad773b","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -207,23 +207,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           <system>
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request, add_labels(max:3), missing_tool, missing_data, noop
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,15 +252,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_2a9651e5adb869ef_EOF'
+          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_2a9651e5adb869ef_EOF
+          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -345,7 +345,10 @@ jobs:
   agent:
     needs: activation
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -442,18 +445,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
-          permission-actions: read
-          permission-checks: read
           permission-contents: read
-          permission-deployments: read
-          permission-discussions: read
           permission-issues: read
-          permission-packages: read
-          permission-pages: read
           permission-pull-requests: read
-          permission-security-events: read
-          permission-statuses: read
-          permission-vulnerability-alerts: read
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -487,9 +481,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0259cadbc41b64b0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0efee8098bd6d8d2_EOF'
           {"add_comment":{"max":1},"add_labels":{"allowed":["triaged-by-bot","needs-human-triage"],"max":3},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0259cadbc41b64b0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0efee8098bd6d8d2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -745,7 +739,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_d25bf35591415f26_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_379c3c452c0729ea_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -773,7 +767,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d25bf35591415f26_EOF
+          GH_AW_MCP_CONFIG_379c3c452c0729ea_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1065,7 +1059,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1101,7 +1094,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1478,7 +1470,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1548,7 +1539,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Extract base branch from agent output

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b759d948481d7c74aa664aa8dfb437bf0584312f6b1dea358a1fdfa33bad773b","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4b67266597551bb713dc0c9dc38785a36a284175dc3f884207fe7bfb9c176e21","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -109,7 +109,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.5' }}
+          GH_AW_INFO_MODEL: "claude-opus-4.7"
           GH_AW_INFO_VERSION: "1.0.48"
           GH_AW_INFO_AGENT_VERSION: "1.0.48"
           GH_AW_INFO_CLI_VERSION: "v0.74.8"
@@ -207,23 +207,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
+          cat << 'GH_AW_PROMPT_3fac5c09889f3ae7_EOF'
           <system>
-          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
+          GH_AW_PROMPT_3fac5c09889f3ae7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
+          cat << 'GH_AW_PROMPT_3fac5c09889f3ae7_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request, add_labels(max:3), missing_tool, missing_data, noop
-          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
+          GH_AW_PROMPT_3fac5c09889f3ae7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
+          cat << 'GH_AW_PROMPT_3fac5c09889f3ae7_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
+          GH_AW_PROMPT_3fac5c09889f3ae7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
+          cat << 'GH_AW_PROMPT_3fac5c09889f3ae7_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,15 +252,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
+          GH_AW_PROMPT_3fac5c09889f3ae7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_5d5d1faac0f6f674_EOF'
+          cat << 'GH_AW_PROMPT_3fac5c09889f3ae7_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_5d5d1faac0f6f674_EOF
+          GH_AW_PROMPT_3fac5c09889f3ae7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -481,9 +481,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0efee8098bd6d8d2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fab4eb9f29d027ee_EOF'
           {"add_comment":{"max":1},"add_labels":{"allowed":["triaged-by-bot","needs-human-triage"],"max":3},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0efee8098bd6d8d2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_fab4eb9f29d027ee_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -739,7 +739,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_379c3c452c0729ea_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ee3c3250b46e002a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -767,7 +767,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_379c3c452c0729ea_EOF
+          GH_AW_MCP_CONFIG_ee3c3250b46e002a_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -853,7 +853,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.5' }}
+          COPILOT_MODEL: claude-opus-4.7
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1369,7 +1369,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || 'claude-sonnet-4.5' }}
+          COPILOT_MODEL: claude-opus-4.7
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.74.8
@@ -1479,7 +1479,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_MODEL: "claude-opus-4.7"
       GH_AW_ENGINE_VERSION: "1.0.48"
       GH_AW_WORKFLOW_ID: "issue-triage"
       GH_AW_WORKFLOW_NAME: "Triage open issues on `posit-dev/vip`"

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -4,6 +4,9 @@ on:
     types: [opened, reopened, labeled]
   issue_comment:
     types: [created]
+engine:
+  id: copilot
+  model: claude-opus-4.7
 permissions:
   contents: read
   issues: read
@@ -75,14 +78,20 @@ Before proceeding to Step 2, you MUST perform these two cleanup actions
 in order. Do not skip them. Do not defer them to the end of the run —
 partial-failure recovery depends on them happening at the start.
 
-1. **Remove the `re-triage` label** if it is present on the issue.
-   Humans apply this label to request a re-run; the bot consumes it
-   here on every run. Check the labels from Step 1's `gh issue view`
-   output. If `re-triage` is among them, run:
+1. **Remove the `re-triage` label.** Run this command unconditionally
+   — do not check first whether the label is present, do not skip if
+   you think it might not be there. Run it on every invocation. The
+   `|| true` makes it a no-op when the label is absent:
 
    ```
-   gh issue edit ${{ github.event.issue.number }} --remove-label re-triage
+   gh issue edit ${{ github.event.issue.number }} --remove-label re-triage || true
    ```
+
+   Humans apply `re-triage` to request a re-run; the bot consumes it
+   here at the start of every run. If you skip this command, the label
+   persists, the next `issues.labeled` event will not be distinguishable
+   from a fresh re-triage request, and you will appear to ignore
+   maintainer instructions. Run the command.
 
 2. **Create the four triage labels idempotently** so subsequent
    `--add-label` calls succeed. The `--force` flag makes these safe

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -4,7 +4,10 @@ on:
     types: [opened, reopened, labeled]
   issue_comment:
     types: [created]
-permissions: read-all
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 tools:
   github:
     toolsets: [default]
@@ -35,6 +38,7 @@ safe-outputs:
     private-key: ${{ secrets.POSIT_VIP_TRIAGE_PEM }}
   add-comment:
     max: 1
+    discussions: false
   add-labels:
     max: 3
     allowed: ["triaged-by-bot", "needs-human-triage"]

--- a/.github/workflows/preview-screenshot-gallery.lock.yml
+++ b/.github/workflows/preview-screenshot-gallery.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e0d2d8a1939b19458b21ece954547d5a000e600ceb0b539567227efda1744e2b","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f049c2ec70f505fa1dfffdefa25381f8fb3c75f237c1f9ea2ce28fd9680d2e8f","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -193,23 +193,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           <system>
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/playwright_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           <safe-output-tools>
           Tools: add_comment, upload_asset(max:100), missing_tool, missing_data, noop
           
           upload_asset: provide a file path; returns a URL; assets are published after the workflow completes (safeoutputs).
           </safe-output-tools>
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -238,12 +238,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d831a2989c7bf850_EOF'
+          cat << 'GH_AW_PROMPT_6896c01099e7fafa_EOF'
           </system>
           {{#runtime-import .github/workflows/preview-screenshot-gallery.md}}
-          GH_AW_PROMPT_d831a2989c7bf850_EOF
+          GH_AW_PROMPT_6896c01099e7fafa_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -323,7 +323,10 @@ jobs:
   agent:
     needs: activation
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     concurrency:
       group: "gh-aw-copilot-${{ github.workflow }}"
     env:
@@ -426,18 +429,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
-          permission-actions: read
-          permission-checks: read
           permission-contents: read
-          permission-deployments: read
-          permission-discussions: read
           permission-issues: read
-          permission-packages: read
-          permission-pages: read
           permission-pull-requests: read
-          permission-security-events: read
-          permission-statuses: read
-          permission-vulnerability-alerts: read
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -471,9 +465,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_bbe494a0b3fc3974_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7d23069ddca2d315_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/preview-screenshot-gallery","max":100,"max-size":10240}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_bbe494a0b3fc3974_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7d23069ddca2d315_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -680,7 +674,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e049abf4fb1097f7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_7792ea468d57e110_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -708,7 +702,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e049abf4fb1097f7_EOF
+          GH_AW_MCP_CONFIG_7792ea468d57e110_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -975,7 +969,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1011,7 +1004,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: read
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1384,7 +1376,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1446,7 +1437,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: read
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Configure GH_HOST for enterprise compatibility

--- a/.github/workflows/preview-screenshot-gallery.md
+++ b/.github/workflows/preview-screenshot-gallery.md
@@ -4,7 +4,10 @@ on:
     workflows: ["Website Preview"]
     types: [completed]
     branches: ["**"]
-permissions: read-all
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 tools:
   github:
     toolsets: [default]
@@ -23,6 +26,7 @@ safe-outputs:
     max: 100
   add-comment:
     max: 1
+    discussions: false
 network:
   allowed:
     - defaults


### PR DESCRIPTION
## Summary

Two workflow refinements, applied together because both surfaced in the
same triage run after #294 / #295 unblocked the App auth path:

### 1. Force unconditional `re-triage` label removal

Step 1a in `issue-triage.md` still framed the label cleanup as a
conditional ("If `re-triage` is among them, run..."). Copilot
consistently skipped this on real runs — it treats conditionals at the
top of a long prompt as optional even with `MUST` framing. Confirmed
again after the live #283 triage cycle: bot opened the plan PR but
left `re-triage` in place.

Rewrite the instruction so there's no decision left:

- Drop the "if present" condition.
- Use `|| true` so the call is fire-and-forget when the label is
  absent.
- Append a short consequence paragraph explaining why skipping breaks
  the maintainer signaling loop.

### 2. Pin agent models per workflow

The default `claude-sonnet-4.5` is now superseded by newer models that
better match the work each workflow does:

- **`issue-triage`** → `claude-opus-4.7`. The enhancement path is the
  demanding one (writing a plan from a freeform issue) and benefits
  from the strongest model. Bug-path runs under triage are rare and
  Opus handles them well too.
- **`implement-plan`** → `claude-sonnet-4.6`. Pure implementation
  work: take a plan, write the code+tests it specifies. Sonnet is the
  right balance of capability and cost here.
- **`preview-screenshot-gallery`** → unchanged. Default is fine; this
  workflow doesn't fit either bug-fix or planning, and runs on every
  PR website preview so it should stay cheap.

The change is set in each workflow's frontmatter:

```yaml
engine:
  id: copilot
  model: <model-name>
```

Regenerated lock files via `gh aw compile --approve`. Confirmed via
`grep COPILOT_MODEL *.lock.yml` that the models are now hard-coded
rather than reading from the `GH_AW_MODEL_AGENT_COPILOT` repo variable.

## Stacked on #295

This PR is built on top of `narrow-workflow-permissions` (#295). Until
#295 lands, this PR's diff will include #295's changes too. Merge #295
first; the diff here will then narrow to just the changes described
above.

## Test plan

- [ ] After this lands (and #295), re-trigger triage on a labeled
      issue and confirm:
  - The `re-triage` label is gone after the workflow run finishes.
  - Workflow logs show `claude-opus-4.7` in `COPILOT_MODEL`.
- [ ] On the next plan PR merge, confirm `implement-plan` runs with
      `claude-sonnet-4.6`.