### PR TITLE
fix(workbench): reliably clean up VIP sessions on test failure

### DIFF
--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -6,9 +6,10 @@ httpx client is replaced with one backed by httpx.MockTransport.
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
-from vip.clients.workbench import is_vip_session
+from vip.clients.workbench import WorkbenchClient, is_vip_session
 
 
 @pytest.mark.parametrize(
@@ -24,3 +25,93 @@ from vip.clients.workbench import is_vip_session
 )
 def test_is_vip_session(label, expected):
     assert is_vip_session(label) is expected
+
+
+def _client_with_handler(handler) -> WorkbenchClient:
+    """Build a WorkbenchClient whose httpx client uses a MockTransport."""
+    wc = WorkbenchClient("https://wb.example.com")
+    wc._client.close()
+    wc._client = httpx.Client(
+        base_url="https://wb.example.com",
+        transport=httpx.MockTransport(handler),
+    )
+    return wc
+
+
+def test_quit_vip_sessions_targets_only_vip_and_skips_others():
+    calls: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append((request.method, request.url.path))
+        if request.url.path == "/api/sessions":
+            return httpx.Response(
+                200,
+                json=[
+                    {"id": "a", "label": "VIP foo"},
+                    {"id": "b", "label": "My real work"},
+                    {"id": "c", "label": "_vip_cap_1_default_0"},
+                ],
+            )
+        return httpx.Response(200)
+
+    wc = _client_with_handler(handler)
+    quit_count = wc.quit_vip_sessions(retries=1)
+
+    assert quit_count == 2
+    assert ("DELETE", "/api/sessions/a") in calls
+    assert ("DELETE", "/api/sessions/c") in calls
+    assert ("DELETE", "/api/sessions/b") not in calls
+
+
+def test_quit_vip_sessions_retries_until_gone():
+    list_calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions":
+            list_calls["n"] += 1
+            # First list shows the session; second list shows it gone.
+            if list_calls["n"] == 1:
+                return httpx.Response(200, json=[{"id": "a", "label": "VIP foo"}])
+            return httpx.Response(200, json=[])
+        return httpx.Response(200)
+
+    wc = _client_with_handler(handler)
+    quit_count = wc.quit_vip_sessions(retries=3, settle_seconds=0)
+
+    assert quit_count == 1
+    assert list_calls["n"] == 2  # stopped re-listing once the session was gone
+
+
+def test_quit_vip_sessions_falls_back_to_suspend():
+    calls: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append((request.method, request.url.path))
+        if request.url.path == "/api/sessions":
+            return httpx.Response(200, json=[{"id": "a", "label": "VIP foo"}])
+        if request.method == "DELETE":
+            return httpx.Response(405)
+        return httpx.Response(200)  # suspend succeeds
+
+    wc = _client_with_handler(handler)
+    quit_count = wc.quit_vip_sessions(retries=1)
+
+    assert quit_count == 1
+    assert ("DELETE", "/api/sessions/a") in calls
+    assert ("POST", "/api/sessions/a/suspend") in calls
+
+
+def test_quit_vip_sessions_returns_zero_on_non_200_list():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    wc = _client_with_handler(handler)
+    assert wc.quit_vip_sessions(retries=2, settle_seconds=0) == 0
+
+
+def test_quit_vip_sessions_does_not_raise_on_transport_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    wc = _client_with_handler(handler)
+    assert wc.quit_vip_sessions(retries=2, settle_seconds=0) == 0

--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -115,3 +115,58 @@ def test_quit_vip_sessions_does_not_raise_on_transport_error():
 
     wc = _client_with_handler(handler)
     assert wc.quit_vip_sessions(retries=2, settle_seconds=0) == 0
+
+
+def test_quit_vip_sessions_does_not_raise_on_invalid_json():
+    """A 200 response whose body is not JSON must not raise."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not json")
+
+    wc = _client_with_handler(handler)
+    assert wc.quit_vip_sessions(retries=2, settle_seconds=0) == 0
+
+
+def test_quit_vip_sessions_handles_non_list_body():
+    """A 200 response whose JSON is not a list must not raise."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"oops": True})
+
+    wc = _client_with_handler(handler)
+    assert wc.quit_vip_sessions(retries=2, settle_seconds=0) == 0
+
+
+def test_quit_vip_sessions_skips_null_label_and_non_dict_items():
+    """Null labels and non-dict list items are skipped without raising."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions":
+            return httpx.Response(
+                200,
+                json=[
+                    {"id": "a", "label": None},
+                    "garbage",
+                    42,
+                    {"id": "b", "label": "VIP ok"},
+                ],
+            )
+        return httpx.Response(200)
+
+    wc = _client_with_handler(handler)
+    # Only the valid VIP session is acted on; bad entries are ignored.
+    assert wc.quit_vip_sessions(retries=1) == 1
+
+
+def test_quit_vip_sessions_counts_unique_sessions_under_retry():
+    """A session that persists across retries is counted once, not per attempt."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions":
+            # Always still listed → forces a fresh quit attempt each round.
+            return httpx.Response(200, json=[{"id": "a", "label": "VIP stuck"}])
+        return httpx.Response(200)  # DELETE "succeeds" but the session persists
+
+    wc = _client_with_handler(handler)
+    # 3 attempts each DELETE "a" successfully, but it is one unique session.
+    assert wc.quit_vip_sessions(retries=3, settle_seconds=0) == 1

--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -1,0 +1,26 @@
+"""Selftests for WorkbenchClient VIP-session cleanup helpers.
+
+No real network connections are made: the WorkbenchClient's internal
+httpx client is replaced with one backed by httpx.MockTransport.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vip.clients.workbench import is_vip_session
+
+
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("VIP test_ide_launch.py - gw0-123", True),
+        ("VIP foo", True),
+        ("_vip_cap_1700000000_default_0", True),
+        ("My analysis", False),
+        ("vip lowercase no space", False),
+        ("", False),
+    ],
+)
+def test_is_vip_session(label, expected):
+    assert is_vip_session(label) is expected

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -91,12 +91,14 @@ class WorkbenchClient(BaseClient):
     def quit_vip_sessions(self, *, retries: int = 2, settle_seconds: float = 0.5) -> int:
         """Force-quit every VIP-named session reachable by this client.
 
-        Lists sessions, quits only those matching :func:`is_vip_session`
-        (DELETE, falling back to suspend), then re-lists to confirm they are
-        gone and retries up to *retries* times.  Sessions are matched by label
-        so a real user's sessions are never touched.  Never raises (malformed
-        or unexpected API payloads are ignored); returns the number of distinct
-        sessions for which a quit/suspend call succeeded.
+        Lists sessions and quits only those matching :func:`is_vip_session`
+        (via :meth:`quit_session`: DELETE, falling back to suspend), then
+        re-lists and repeats the quit-and-verify cycle up to *retries* times
+        while VIP sessions remain.  A failed *list* call (non-200 or a thrown
+        exception) ends the run without retrying.  Sessions are matched by
+        label so a real user's sessions are never touched.  Never raises
+        (malformed or unexpected API payloads are ignored); returns the number
+        of distinct sessions for which a quit/suspend call succeeded.
 
         Authentication uses whatever this client already carries (cookies set
         via :meth:`set_cookies`, or an API-key Authorization header).
@@ -121,19 +123,8 @@ class WorkbenchClient(BaseClient):
                 break
             for session in targets:
                 sid = session.get("id") or session.get("session_id") or ""
-                if not sid:
-                    continue
-                for method, path in (
-                    ("DELETE", f"/api/sessions/{sid}"),
-                    ("POST", f"/api/sessions/{sid}/suspend"),
-                ):
-                    try:
-                        r = self._client.request(method, path)
-                        if r.status_code < 400:
-                            quit_ids.add(str(sid))
-                            break
-                    except Exception:
-                        continue
+                if sid and self.quit_session(sid):
+                    quit_ids.add(str(sid))
             if attempt < retries - 1:
                 time.sleep(settle_seconds)
         return len(quit_ids)

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -6,6 +6,7 @@ APIs than Connect, so many checks are done via the web UI with Playwright.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any
 
@@ -86,3 +87,44 @@ class WorkbenchClient(BaseClient):
             except Exception:
                 continue
         return False
+
+    def quit_vip_sessions(self, *, retries: int = 2, settle_seconds: float = 0.5) -> int:
+        """Force-quit every VIP-named session reachable by this client.
+
+        Lists sessions, quits only those matching :func:`is_vip_session`
+        (DELETE, falling back to suspend), then re-lists to confirm they are
+        gone and retries up to *retries* times.  Sessions are matched by label
+        so a real user's sessions are never touched.  Never raises; returns the
+        number of successful quit/suspend calls.
+
+        Authentication uses whatever this client already carries (cookies set
+        via :meth:`set_cookies`, or an API-key Authorization header).
+        """
+        quit_count = 0
+        for attempt in range(retries):
+            try:
+                resp = self._client.get("/api/sessions")
+            except Exception:
+                break
+            sessions = resp.json() if resp.status_code == 200 else []
+            targets = [s for s in sessions if is_vip_session(s.get("label", ""))]
+            if not targets:
+                break
+            for session in targets:
+                sid = session.get("id") or session.get("session_id", "")
+                if not sid:
+                    continue
+                for method, path in (
+                    ("DELETE", f"/api/sessions/{sid}"),
+                    ("POST", f"/api/sessions/{sid}/suspend"),
+                ):
+                    try:
+                        r = self._client.request(method, path)
+                        if r.status_code < 400:
+                            quit_count += 1
+                            break
+                    except Exception:
+                        continue
+            if attempt < retries - 1:
+                time.sleep(settle_seconds)
+        return quit_count

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -94,24 +94,33 @@ class WorkbenchClient(BaseClient):
         Lists sessions, quits only those matching :func:`is_vip_session`
         (DELETE, falling back to suspend), then re-lists to confirm they are
         gone and retries up to *retries* times.  Sessions are matched by label
-        so a real user's sessions are never touched.  Never raises; returns the
-        number of successful quit/suspend calls.
+        so a real user's sessions are never touched.  Never raises (malformed
+        or unexpected API payloads are ignored); returns the number of distinct
+        sessions for which a quit/suspend call succeeded.
 
         Authentication uses whatever this client already carries (cookies set
         via :meth:`set_cookies`, or an API-key Authorization header).
         """
-        quit_count = 0
+        quit_ids: set[str] = set()
         for attempt in range(retries):
             try:
                 resp = self._client.get("/api/sessions")
+                sessions = resp.json() if resp.status_code == 200 else []
             except Exception:
+                # Connection error, non-JSON body, etc. — give up this run.
                 break
-            sessions = resp.json() if resp.status_code == 200 else []
-            targets = [s for s in sessions if is_vip_session(s.get("label", ""))]
+            if not isinstance(sessions, list):
+                break
+            # Coerce label to str so a null/non-string label never raises.
+            targets = [
+                s
+                for s in sessions
+                if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
+            ]
             if not targets:
                 break
             for session in targets:
-                sid = session.get("id") or session.get("session_id", "")
+                sid = session.get("id") or session.get("session_id") or ""
                 if not sid:
                     continue
                 for method, path in (
@@ -121,10 +130,10 @@ class WorkbenchClient(BaseClient):
                     try:
                         r = self._client.request(method, path)
                         if r.status_code < 400:
-                            quit_count += 1
+                            quit_ids.add(str(sid))
                             break
                     except Exception:
                         continue
             if attempt < retries - 1:
                 time.sleep(settle_seconds)
-        return quit_count
+        return len(quit_ids)

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -11,6 +11,17 @@ from typing import Any
 
 from vip.clients.base import BaseClient
 
+_VIP_SESSION_PREFIXES = ("VIP ", "_vip_")
+
+
+def is_vip_session(label: str) -> bool:
+    """Return True if *label* matches a VIP-created session naming pattern.
+
+    VIP names sessions either ``"VIP <file> - <worker>-<ns>"`` (most tests,
+    via ``unique_session_name``) or ``"_vip_cap_<ts>_..."`` (capacity tests).
+    """
+    return any(label.startswith(prefix) for prefix in _VIP_SESSION_PREFIXES)
+
 
 class WorkbenchClient(BaseClient):
     """Minimal Workbench HTTP wrapper."""

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -283,9 +283,11 @@ def _wb_cleanup_state(vip_config, workbench_client):
             insecure=vip_config.insecure,
             ca_bundle=vip_config.ca_bundle,
         )
-    elif vip_config.workbench.api_key:
-        # No cookies were ever captured (e.g. every test skipped before login)
-        # but an API key is configured — use it as a fallback.
+    # Belt-and-suspenders: when an API key is configured, also sweep with it.
+    # Run this even if cookies were captured, because cookies may have expired
+    # during a long run (a cookie sweep would then quietly clean up nothing).
+    # quit_vip_sessions is idempotent, so this is a no-op when nothing remains.
+    if vip_config.workbench.api_key:
         try:
             workbench_client.quit_vip_sessions()
         except Exception:

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 import os
 import time
 
-import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from vip.clients.workbench import WorkbenchClient
 from vip_tests.workbench.pages import Homepage, LoginPage
 
 pytestmark = [pytest.mark.workbench, pytest.mark.xdist_group("workbench")]
@@ -238,42 +238,81 @@ def workbench_login(
 # ---------------------------------------------------------------------------
 
 
+def _quit_vip_sessions_via_cookies(
+    base_url: str,
+    cookies: dict[str, str],
+    *,
+    insecure: bool,
+    ca_bundle,
+) -> int:
+    """Quit VIP-named sessions using a scratch cookie-authenticated client.
+
+    A scratch ``WorkbenchClient`` is used so the session-scoped
+    ``workbench_client`` fixture's cookie jar is never mutated.  TLS config
+    (``--insecure`` / ``--ca-bundle``) is honoured via *insecure*/*ca_bundle*.
+    """
+    try:
+        scratch = WorkbenchClient(base_url, insecure=insecure, ca_bundle=ca_bundle)
+        try:
+            scratch.set_cookies(cookies)
+            return scratch.quit_vip_sessions()
+        finally:
+            scratch.close()
+    except Exception:
+        return 0
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _wb_cleanup_state(vip_config, workbench_client):
+    """End-of-run safety net: sweep any VIP sessions left behind.
+
+    Holds the most recent authenticated cookies captured by the per-test
+    ``_cleanup_sessions`` fixture.  On teardown (after the whole Workbench
+    run) it does one final ``quit_vip_sessions`` sweep, catching sessions
+    orphaned when a per-test cleanup failed outright (e.g. the page crashed).
+    """
+    state: dict[str, object] = {"cookies": None, "base_url": None}
+    yield state
+    if workbench_client is None:
+        return
+    cookies = state["cookies"]
+    if cookies:
+        _quit_vip_sessions_via_cookies(
+            str(state["base_url"]),
+            cookies,  # type: ignore[arg-type]
+            insecure=vip_config.insecure,
+            ca_bundle=vip_config.ca_bundle,
+        )
+    elif vip_config.workbench.api_key:
+        # No cookies were ever captured (e.g. every test skipped before login)
+        # but an API key is configured — use it as a fallback.
+        try:
+            workbench_client.quit_vip_sessions()
+        except Exception:
+            pass
+
+
 @pytest.fixture(autouse=True)
-def _cleanup_sessions(page, workbench_client):
-    """Quit any Workbench sessions created during the test."""
+def _cleanup_sessions(page, workbench_client, vip_config, _wb_cleanup_state):
+    """Quit any VIP-named Workbench sessions created during the test."""
     yield
     if workbench_client is None:
         return
     try:
         cookies = {c["name"]: c["value"] for c in page.context.cookies()}
-        # Use a temporary client so the session-scoped workbench_client's
-        # cookie jar is never mutated.  Inherit TLS config from the session
-        # client so --insecure / --ca-bundle are honoured here too.
-        with httpx.Client(
-            base_url=workbench_client.base_url,
-            cookies=cookies,
-            timeout=30.0,
-            verify=workbench_client.verify,
-        ) as tmp:
-            resp = tmp.get("/api/sessions")
-            sessions = resp.json() if resp.status_code == 200 else []
-            for session in sessions:
-                sid = session.get("id") or session.get("session_id", "")
-                if not sid:
-                    continue
-                for method, path in (
-                    ("DELETE", f"/api/sessions/{sid}"),
-                    ("POST", f"/api/sessions/{sid}/suspend"),
-                ):
-                    try:
-                        r = tmp.request(method, path)
-                        if r.status_code < 400:
-                            break
-                    except Exception:
-                        continue
     except Exception:
-        # Best-effort cleanup; don't mask test failures.
-        pass
+        cookies = {}
+    if not cookies:
+        return
+    # Remember the latest good cookies for the end-of-run sweep.
+    _wb_cleanup_state["cookies"] = cookies
+    _wb_cleanup_state["base_url"] = workbench_client.base_url
+    _quit_vip_sessions_via_cookies(
+        workbench_client.base_url,
+        cookies,
+        insecure=vip_config.insecure,
+        ca_bundle=vip_config.ca_bundle,
+    )
 
 
 @pytest.fixture

--- a/src/vip_tests/workbench/test_session_capacity.py
+++ b/src/vip_tests/workbench/test_session_capacity.py
@@ -127,13 +127,13 @@ def _launch_session(
 
 
 def _cleanup_sessions_via_api(
-    page: Page, workbench_base_url: str, launched: list[dict[str, str | None]]
+    page: Page, workbench_base_url: str, *, insecure: bool, ca_bundle
 ) -> None:
     """Quit the VIP capacity sessions created by this test run.
 
     Delegates to the shared cookie-based cleanup helper, which targets all
-    VIP-named sessions (``_vip_cap_`` prefix included).  The *launched* arg is
-    retained for signature compatibility with the calling step.
+    VIP-named sessions (``_vip_cap_`` prefix included).  TLS config is threaded
+    through so cleanup works against self-signed / custom-CA deployments.
     """
     try:
         cookies = {c["name"]: c["value"] for c in page.context.cookies()}
@@ -141,7 +141,9 @@ def _cleanup_sessions_via_api(
         return
     if not cookies:
         return
-    _quit_vip_sessions_via_cookies(workbench_base_url, cookies, insecure=False, ca_bundle=None)
+    _quit_vip_sessions_via_cookies(
+        workbench_base_url, cookies, insecure=insecure, ca_bundle=ca_bundle
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -235,9 +237,11 @@ def all_sessions_active(launched_sessions: list[dict[str, str | None]], page: Pa
 
 @then("I clean up all launched sessions")
 def cleanup_sessions(
-    launched_sessions: list[dict[str, str | None]], page: Page, workbench_url: str
+    launched_sessions: list[dict[str, str | None]], page: Page, workbench_url: str, vip_config
 ):
-    _cleanup_sessions_via_api(page, workbench_url, launched_sessions)
+    _cleanup_sessions_via_api(
+        page, workbench_url, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+    )
 
     for session in launched_sessions:
         row = page.locator(Homepage.session_row(session["name"]))

--- a/src/vip_tests/workbench/test_session_capacity.py
+++ b/src/vip_tests/workbench/test_session_capacity.py
@@ -16,7 +16,6 @@ Requires ``--interactive-auth`` or ``--headless-auth`` since session launching i
 
 from __future__ import annotations
 
-import httpx
 import pytest
 from playwright.sync_api import Page, expect
 from pytest_bdd import given, scenarios, then, when
@@ -25,6 +24,7 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_QUICK,
     TIMEOUT_SESSION_START,
+    _quit_vip_sessions_via_cookies,
     assert_homepage_loaded,
     workbench_login,
 )
@@ -129,30 +129,19 @@ def _launch_session(
 def _cleanup_sessions_via_api(
     page: Page, workbench_base_url: str, launched: list[dict[str, str | None]]
 ) -> None:
-    """Delete only sessions created by this test run."""
-    launched_names = {s["name"] for s in launched}
+    """Quit the VIP capacity sessions created by this test run.
+
+    Delegates to the shared cookie-based cleanup helper, which targets all
+    VIP-named sessions (``_vip_cap_`` prefix included).  The *launched* arg is
+    retained for signature compatibility with the calling step.
+    """
     try:
         cookies = {c["name"]: c["value"] for c in page.context.cookies()}
-        with httpx.Client(base_url=workbench_base_url, cookies=cookies, timeout=30.0) as client:
-            resp = client.get("/api/sessions")
-            sessions = resp.json() if resp.status_code == 200 else []
-            for session in sessions:
-                sid = session.get("id") or session.get("session_id", "")
-                name = session.get("label", "")
-                if not sid or name not in launched_names:
-                    continue
-                for method, path in (
-                    ("DELETE", f"/api/sessions/{sid}"),
-                    ("POST", f"/api/sessions/{sid}/suspend"),
-                ):
-                    try:
-                        r = client.request(method, path)
-                        if r.status_code < 400:
-                            break
-                    except Exception:
-                        continue
     except Exception:
-        pass
+        return
+    if not cookies:
+        return
+    _quit_vip_sessions_via_cookies(workbench_base_url, cookies, insecure=False, ca_bundle=None)
 
 
 # ---------------------------------------------------------------------------

--- a/validation_docs/demo-workbench-session-cleanup.md
+++ b/validation_docs/demo-workbench-session-cleanup.md
@@ -1,0 +1,38 @@
+# Fix: reliable Workbench session cleanup (#277)
+
+*2026-05-29T18:53:34Z by Showboat 0.6.1*
+<!-- showboat-id: 8db398fc-5077-4456-b28c-ce839a3b2f33 -->
+
+Issue #277: when a Workbench test failed mid-IDE, the session it launched was left running on the homepage, forcing users to quit orphans by hand. Cleanup is now centralized in WorkbenchClient.quit_vip_sessions(), which lists sessions and force-quits only VIP-named ones (the 'VIP ' and '_vip_' prefixes), then re-lists to verify they are gone and retries. It is resilient to malformed API payloads (non-JSON bodies, null/non-string labels) and counts unique sessions. A session-scoped end-of-run sweep is a safety net so a single failed per-test cleanup no longer orphans a session, with an API-key fallback for long runs where browser cookies may have expired. Cleanup authenticates with the browser's cookies, so no API key is required.
+
+```bash
+uv run pytest selftests/test_workbench_cleanup.py -n0 -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+15 passed
+```
+
+```bash
+uvx ruff@0.15.0 check src/ selftests/ examples/ docker/
+```
+
+```output
+All checks passed!
+```
+
+```bash
+uvx ruff@0.15.0 format --check src/ selftests/ examples/ docker/
+```
+
+```output
+133 files already formatted
+```
+
+```bash
+uv run pytest src/vip_tests/workbench/ --collect-only -q 2>&1 | tail -1 | sed "s/ in [0-9.]*s//"
+```
+
+```output
+no tests collected (12 deselected)
+```


### PR DESCRIPTION
Closes #277.

## Problem

When a Workbench test failed mid-execution (e.g. during IDE interaction), the session it launched was not reliably terminated, leaving orphaned sessions on the Workbench homepage that users had to quit by hand. The old per-test cleanup quit **all** of the user's sessions, fired a single request without verifying it worked, swallowed every error, and had no end-of-run backstop.

## Approach

Cleanup logic is centralized in `WorkbenchClient.quit_vip_sessions()`:

- Targets **only VIP-named sessions** (`VIP ` and `_vip_` label prefixes), so a real user's sessions are never touched.
- **Verify-and-retry**: after issuing DELETE (falling back to suspend), it re-lists and repeats while VIP sessions remain.
- **Resilient**: never raises on malformed API payloads (non-JSON bodies, non-list responses, `null`/non-string labels); returns the count of *distinct* sessions quit.
- Authenticates with the browser's session cookies, so **no API key is required**.

Test-suite wiring (`src/vip_tests/workbench/conftest.py`):

- The per-test autouse `_cleanup_sessions` fixture now targets only VIP sessions and stashes the latest good cookies.
- A new session-scoped `_wb_cleanup_state` fixture runs a final **end-of-run sweep** as a safety net for sessions orphaned when a per-test cleanup fails outright, with an **API-key fallback** for long runs where browser cookies may have expired.
- The capacity test's duplicated inline httpx cleanup now routes through the same shared helper (TLS config threaded through for self-signed / custom-CA deployments).

15 new selftests cover the predicate and `quit_vip_sessions` (target filtering, retry-until-gone, suspend fallback, malformed payloads, unique counting, error paths) using `httpx.MockTransport`.

## Design note

Cleanup deliberately quits **all** VIP-named sessions rather than scoping to a single scenario's launched names — that broad sweep is what catches orphans whose names weren't tracked. Within a run, Workbench tests are serialized onto one xdist worker, so there's no concurrent sibling session to disturb. The accepted trade-off is that two simultaneous runs sharing one Workbench account could interfere; this is still strictly safer than the prior behavior, which quit *all* sessions regardless of name.

## Demo

# Fix: reliable Workbench session cleanup (#277)

Issue #277: when a Workbench test failed mid-IDE, the session it launched was left running on the homepage, forcing users to quit orphans by hand. Cleanup is now centralized in `WorkbenchClient.quit_vip_sessions()`, which lists sessions and force-quits only VIP-named ones (the `VIP ` and `_vip_` prefixes), then re-lists to verify they are gone and retries. It is resilient to malformed API payloads (non-JSON bodies, null/non-string labels) and counts unique sessions. A session-scoped end-of-run sweep is a safety net so a single failed per-test cleanup no longer orphans a session, with an API-key fallback for long runs where browser cookies may have expired. Cleanup authenticates with the browser's cookies, so no API key is required.

```bash
uv run pytest selftests/test_workbench_cleanup.py -n0 -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
```

```output
15 passed
```

```bash
uvx ruff@0.15.0 check src/ selftests/ examples/ docker/
```

```output
All checks passed!
```

```bash
uvx ruff@0.15.0 format --check src/ selftests/ examples/ docker/
```

```output
133 files already formatted
```

```bash
uv run pytest src/vip_tests/workbench/ --collect-only -q 2>&1 | tail -1 | sed "s/ in [0-9.]*s//"
```

```output
no tests collected (12 deselected)
```
