### PR TITLE
fix(workbench): fail fast when a session reaches a terminal state

### DIFF
--- a/selftests/test_workbench_session_active.py
+++ b/selftests/test_workbench_session_active.py
@@ -1,0 +1,61 @@
+"""Tests for fail-fast detection when a Workbench session cannot launch.
+
+A launched session that reaches a terminal "Failed" state will never become
+Active.  Rather than waiting out the full session-start timeout and emitting
+an opaque "Locator expected to be visible" error, the workbench helpers detect
+the terminal state and fail fast with an actionable message.
+
+These tests cover the pure pieces of that behavior: the session-status
+selector (which must match both the legacy and the Workbench 2026.06 status
+markup) and the failure-message builder.  The Playwright polling itself
+requires a live Workbench and is exercised against a real deployment.
+"""
+
+from __future__ import annotations
+
+from vip_tests.workbench.conftest import (
+    TERMINAL_SESSION_FAILURE_STATES,
+    _session_failure_message,
+)
+from vip_tests.workbench.pages import Homepage
+
+
+def test_failed_is_a_terminal_state():
+    assert "Failed" in TERMINAL_SESSION_FAILURE_STATES
+
+
+def test_failure_message_names_session_and_state():
+    msg = _session_failure_message("VIP test - main-123", "Failed")
+    assert "VIP test - main-123" in msg
+    assert "Failed" in msg
+
+
+def test_failure_message_explains_active_was_expected():
+    msg = _session_failure_message("sess", "Failed")
+    assert "Active" in msg
+
+
+def test_failure_message_points_at_the_deployment_not_the_test():
+    """The message must make clear the deployment could not launch the
+    session, so the reader does not chase a phantom locator/test bug."""
+    msg = _session_failure_message("sess", "Failed").lower()
+    assert "workbench could not launch" in msg
+
+
+def test_status_selector_anchors_on_session_name():
+    sel = Homepage.session_row_status("main-123", "Active")
+    assert "tr[aria-label$='main-123']" in sel
+
+
+def test_status_selector_matches_legacy_div_markup():
+    """Workbench before 2026.06 rendered status as div[aria-label]."""
+    sel = Homepage.session_row_status("s", "Active")
+    assert "div[aria-label='Active']" in sel
+
+
+def test_status_selector_matches_2026_06_button_markup():
+    """Workbench 2026.06 renders status as a button whose accessible name is
+    the status word (sourced from text or aria-label)."""
+    sel = Homepage.session_row_status("s", "Failed")
+    assert "button[aria-label='Failed']" in sel
+    assert "button:text-is('Failed')" in sel

--- a/selftests/test_workbench_session_active.py
+++ b/selftests/test_workbench_session_active.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from vip_tests.workbench.conftest import (
     TERMINAL_SESSION_FAILURE_STATES,
     _session_failure_message,
+    format_capacity_failure,
 )
 from vip_tests.workbench.pages import Homepage
 
@@ -59,3 +60,25 @@ def test_status_selector_matches_2026_06_button_markup():
     sel = Homepage.session_row_status("s", "Failed")
     assert "button[aria-label='Failed']" in sel
     assert "button:text-is('Failed')" in sel
+
+
+def test_capacity_failure_lists_counts_and_profiles():
+    msg = format_capacity_failure(3, ["Small", "Large"], ["r1", "r2"])
+    assert "1/3 sessions reached Active" in msg
+    assert "Failed profiles: Small, Large" in msg
+
+
+def test_capacity_failure_preserves_per_session_diagnostics():
+    """The actionable per-session reason (terminal-state message) must survive
+    aggregation, not be discarded in favor of a bare profile list."""
+    reason = _session_failure_message("_vip_cap_Small_0", "Failed")
+    msg = format_capacity_failure(1, ["Small"], [reason])
+    assert reason in msg
+
+
+def test_capacity_failure_without_reasons_still_lists_profiles():
+    """A timeout path may record a profile without a captured reason; the
+    profile list must still render."""
+    msg = format_capacity_failure(2, ["Medium"], [])
+    assert "1/2 sessions reached Active" in msg
+    assert "Failed profiles: Medium" in msg

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -124,6 +124,21 @@ def _session_failure_message(name: str, state: str) -> str:
     )
 
 
+def format_capacity_failure(total: int, failures: list[str], reasons: list[str]) -> str:
+    """Build the aggregated failure for the session-capacity scenario.
+
+    Reports how many sessions reached Active and which profiles failed, then
+    appends each per-session diagnostic captured from
+    :func:`wait_for_session_active`.  Keeping the reasons means an aggregated
+    capacity failure still names the terminal state (e.g. ``Failed``) and its
+    likely cause, instead of collapsing to a bare profile list.
+    """
+    passed = total - len(failures)
+    lines = [f"{passed}/{total} sessions reached Active. Failed profiles: {', '.join(failures)}"]
+    lines.extend(reasons)
+    return "\n".join(lines)
+
+
 def wait_for_session_active(
     page: Page, session_name: str, *, timeout: int = TIMEOUT_SESSION_START
 ) -> Locator:

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -10,7 +10,7 @@ import time
 
 import httpx
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from vip_tests.workbench.pages import Homepage, LoginPage
 
@@ -27,6 +27,15 @@ TIMEOUT_CLEANUP = 30_000
 TIMEOUT_CODE_EXEC = 30_000
 TIMEOUT_IDE_LOAD = 60_000
 TIMEOUT_SESSION_START = 90_000
+
+# Poll interval (ms) used while waiting for a session to reach Active.
+_SESSION_POLL_INTERVAL = 500
+
+# Session statuses that are terminal failures: the session has stopped and
+# will never reach Active, so continuing to wait is pointless.  Detecting one
+# of these lets the session-start wait fail fast with an actionable message
+# instead of timing out on an opaque "Locator expected to be visible" error.
+TERMINAL_SESSION_FAILURE_STATES = ("Failed",)
 
 # ---------------------------------------------------------------------------
 
@@ -97,6 +106,75 @@ def assert_homepage_loaded(page: Page) -> None:
     """
     expect(page.locator(Homepage.POSIT_LOGO)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
     expect(page.locator(Homepage.NEW_SESSION_BUTTON).first).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+
+
+def _session_failure_message(name: str, state: str) -> str:
+    """Build the error shown when a session reaches a terminal failure state.
+
+    Replaces the opaque "Locator expected to be visible" timeout with a
+    message that names the session, the terminal state observed, and the
+    likely cause — so the reader knows the deployment (not the test) could
+    not launch the session.
+    """
+    return (
+        f"Session {name!r} reached terminal state {state!r} instead of Active — "
+        "Workbench could not launch the session (abnormal exit). Verify the "
+        "deployment can launch sessions: check the launcher, the session image, "
+        "and available CPU/memory/quota."
+    )
+
+
+def wait_for_session_active(
+    page: Page, session_name: str, *, timeout: int = TIMEOUT_SESSION_START
+) -> Locator:
+    """Wait until *session_name* reaches Active, failing fast on terminal states.
+
+    Polls the session row for the Active status.  If the session instead
+    reaches a terminal failure state (see :data:`TERMINAL_SESSION_FAILURE_STATES`),
+    raises ``AssertionError`` immediately with an actionable message rather
+    than waiting out the full ``timeout`` and emitting an opaque
+    "Locator expected to be visible" error.
+
+    Returns the session row locator so callers can chain further actions
+    (e.g. clicking the session's join link).
+    """
+    row = page.locator(Homepage.session_row(session_name))
+    expect(row).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+
+    active = page.locator(Homepage.session_row_status(session_name, "Active"))
+    terminal = {
+        state: page.locator(Homepage.session_row_status(session_name, state))
+        for state in TERMINAL_SESSION_FAILURE_STATES
+    }
+
+    def _active_now() -> bool:
+        return active.count() > 0 and active.first.is_visible()
+
+    def _terminal_now() -> str | None:
+        for state, loc in terminal.items():
+            if loc.count() > 0 and loc.first.is_visible():
+                return state
+        return None
+
+    deadline = time.monotonic() + timeout / 1000
+    while time.monotonic() < deadline:
+        if _active_now():
+            return row
+        failed_state = _terminal_now()
+        if failed_state is not None:
+            raise AssertionError(_session_failure_message(session_name, failed_state))
+        page.wait_for_timeout(_SESSION_POLL_INTERVAL)
+
+    # Final check — the status may have flipped in the last poll interval.
+    if _active_now():
+        return row
+    failed_state = _terminal_now()
+    if failed_state is not None:
+        raise AssertionError(_session_failure_message(session_name, failed_state))
+    raise AssertionError(
+        f"Session {session_name!r} did not reach Active within {timeout // 1000}s "
+        "(no Active or terminal status detected)."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/vip_tests/workbench/pages/homepage.py
+++ b/src/vip_tests/workbench/pages/homepage.py
@@ -174,7 +174,18 @@ class Homepage:
     def session_row_status(name: str, status: str) -> str:
         """Selector for session row with specific status.
 
-        Finds the row containing the session name, then matches if
-        that row's status cell contains the given status.
+        Finds the row containing the session name, then matches that row's
+        status indicator for the given status.
+
+        Workbench rendered the status differently across versions: before
+        2026.06 it was a ``div[aria-label='<status>']``; on 2026.06 it is a
+        button whose accessible name is the status word (sourced from either
+        its text or an ``aria-label``).  Match any of these forms with a
+        comma-separated selector so status checks survive the UI change.
         """
-        return f"tr[aria-label$='{name}'] div[aria-label='{status}']"
+        row = f"tr[aria-label$='{name}']"
+        return (
+            f"{row} div[aria-label='{status}'], "
+            f"{row} button[aria-label='{status}'], "
+            f"{row} button:text-is('{status}')"
+        )

--- a/src/vip_tests/workbench/test_data_sources.py
+++ b/src/vip_tests/workbench/test_data_sources.py
@@ -12,11 +12,10 @@ from pytest_bdd import given, scenario, then, when
 from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_IDE_LOAD,
-    TIMEOUT_PAGE_LOAD,
     TIMEOUT_QUICK,
-    TIMEOUT_SESSION_START,
     assert_homepage_loaded,
     unique_session_name,
+    wait_for_session_active,
     workbench_login,
 )
 from vip_tests.workbench.pages import (
@@ -76,12 +75,12 @@ def _start_session(page: Page, session_name: str) -> None:
 
 
 def _wait_for_active_and_join(page: Page, session_name: str) -> None:
-    """Wait for the session to reach Active state, then navigate into it."""
-    session_row = page.locator(Homepage.session_row(session_name))
-    expect(session_row).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    """Wait for the session to reach Active state, then navigate into it.
 
-    session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
-    expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
+    Fails fast with an actionable message if the session reaches a terminal
+    state (e.g. Failed) rather than waiting out the full session-start timeout.
+    """
+    session_row = wait_for_session_active(page, session_name)
 
     session_link = session_row.locator(f"a[title='join {session_name}']")
     expect(session_link).to_be_visible(timeout=TIMEOUT_DIALOG)

--- a/src/vip_tests/workbench/test_ide_extensions.py
+++ b/src/vip_tests/workbench/test_ide_extensions.py
@@ -30,9 +30,9 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_IDE_LOAD,
     TIMEOUT_PAGE_LOAD,
     TIMEOUT_QUICK,
-    TIMEOUT_SESSION_START,
     assert_homepage_loaded,
     unique_session_name,
+    wait_for_session_active,
     workbench_login,
 )
 from vip_tests.workbench.pages import (
@@ -196,11 +196,9 @@ def session_becomes_active(page: Page, session_context: dict):
     """Verify session transitions from Starting to Active."""
     session_name = session_context["name"]
 
-    session_row = page.locator(Homepage.session_row(session_name))
-    expect(session_row).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
-
-    session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
-    expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
+    # Fails fast with an actionable message if the session reaches a terminal
+    # state (e.g. Failed) instead of waiting out the full session-start timeout.
+    session_row = wait_for_session_active(page, session_name)
 
     session_link = session_row.locator(f"a[title='join {session_name}']")
     expect(session_link).to_be_visible(timeout=TIMEOUT_DIALOG)

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -22,9 +22,9 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_IDE_LOAD,
     TIMEOUT_PAGE_LOAD,
     TIMEOUT_QUICK,
-    TIMEOUT_SESSION_START,
     assert_homepage_loaded,
     unique_session_name,
+    wait_for_session_active,
     workbench_login,
 )
 from vip_tests.workbench.pages import (
@@ -226,13 +226,10 @@ def session_becomes_active(page: Page, session_context: dict):
     """Verify session transitions from Starting to Active."""
     session_name = session_context["name"]
 
-    # Verify our session row appears on the homepage
-    session_row = page.locator(Homepage.session_row(session_name))
-    expect(session_row).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
-
-    # Wait for our session to reach Active state
-    session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
-    expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
+    # Wait for our session to reach Active state.  Fails fast with an
+    # actionable message if it reaches a terminal state (e.g. Failed) instead
+    # of waiting out the full session-start timeout.
+    session_row = wait_for_session_active(page, session_name)
 
     # Navigate into the session (link only appears when Active)
     session_link = session_row.locator(f"a[title='join {session_name}']")

--- a/src/vip_tests/workbench/test_packages.py
+++ b/src/vip_tests/workbench/test_packages.py
@@ -13,11 +13,10 @@ from pytest_bdd import given, scenario, then, when
 from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_IDE_LOAD,
-    TIMEOUT_PAGE_LOAD,
     TIMEOUT_QUICK,
-    TIMEOUT_SESSION_START,
     assert_homepage_loaded,
     unique_session_name,
+    wait_for_session_active,
     workbench_login,
 )
 from vip_tests.workbench.pages import (
@@ -88,12 +87,12 @@ def _start_session(page: Page, session_name: str) -> None:
 
 
 def _wait_for_active_and_join(page: Page, session_name: str) -> None:
-    """Wait for the session to reach Active state, then navigate into it."""
-    session_row = page.locator(Homepage.session_row(session_name))
-    expect(session_row).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    """Wait for the session to reach Active state, then navigate into it.
 
-    session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
-    expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
+    Fails fast with an actionable message if the session reaches a terminal
+    state (e.g. Failed) rather than waiting out the full session-start timeout.
+    """
+    session_row = wait_for_session_active(page, session_name)
 
     session_link = session_row.locator(f"a[title='join {session_name}']")
     expect(session_link).to_be_visible(timeout=TIMEOUT_DIALOG)

--- a/src/vip_tests/workbench/test_session_capacity.py
+++ b/src/vip_tests/workbench/test_session_capacity.py
@@ -25,6 +25,7 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_QUICK,
     assert_homepage_loaded,
+    format_capacity_failure,
     wait_for_session_active,
     workbench_login,
 )
@@ -228,22 +229,23 @@ def launch_sessions(page: Page, vip_config):
 @then("all launched sessions reach Active state")
 def all_sessions_active(launched_sessions: list[dict[str, str | None]], page: Page):
     failures = []
+    reasons = []
     for session in launched_sessions:
         name = session["name"]
         profile = session["profile"] or "default"
         # Fails fast when a session reaches a terminal state (e.g. Failed),
         # so a fully-broken launcher records all profiles quickly instead of
-        # blocking the full session-start timeout per profile.
+        # blocking the full session-start timeout per profile.  Keep the
+        # diagnostic so the aggregated failure still names the terminal state
+        # and its likely cause rather than only listing profiles.
         try:
             wait_for_session_active(page, name)
-        except AssertionError:
+        except AssertionError as exc:
             failures.append(profile)
+            reasons.append(str(exc))
 
     if failures:
-        passed = len(launched_sessions) - len(failures)
-        total = len(launched_sessions)
-        msg = f"{passed}/{total} sessions reached Active. Failed profiles: {', '.join(failures)}"
-        pytest.fail(msg)
+        pytest.fail(format_capacity_failure(len(launched_sessions), failures, reasons))
 
 
 @then("I clean up all launched sessions")

--- a/src/vip_tests/workbench/test_session_capacity.py
+++ b/src/vip_tests/workbench/test_session_capacity.py
@@ -24,8 +24,8 @@ from pytest_bdd import given, scenarios, then, when
 from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_QUICK,
-    TIMEOUT_SESSION_START,
     assert_homepage_loaded,
+    wait_for_session_active,
     workbench_login,
 )
 from vip_tests.workbench.pages import Homepage, NewSessionDialog
@@ -231,9 +231,11 @@ def all_sessions_active(launched_sessions: list[dict[str, str | None]], page: Pa
     for session in launched_sessions:
         name = session["name"]
         profile = session["profile"] or "default"
-        active = page.locator(Homepage.session_row_status(name, "Active")).first
+        # Fails fast when a session reaches a terminal state (e.g. Failed),
+        # so a fully-broken launcher records all profiles quickly instead of
+        # blocking the full session-start timeout per profile.
         try:
-            expect(active).to_be_visible(timeout=TIMEOUT_SESSION_START)
+            wait_for_session_active(page, name)
         except AssertionError:
             failures.append(profile)
 

--- a/src/vip_tests/workbench/test_sessions.py
+++ b/src/vip_tests/workbench/test_sessions.py
@@ -21,6 +21,7 @@ from vip_tests.workbench.conftest import (
     TIMEOUT_SESSION_START,
     assert_homepage_loaded,
     unique_session_name,
+    wait_for_session_active,
     workbench_login,
 )
 from vip_tests.workbench.pages import Homepage, NewSessionDialog
@@ -106,14 +107,13 @@ def start_rstudio_pro_session(page: Page, session_context: dict):
 
 @when("the session reaches Active state")
 def session_becomes_active(page: Page, session_context: dict):
-    """Wait for the session to reach Active state on the homepage."""
+    """Wait for the session to reach Active state on the homepage.
+
+    Fails fast with an actionable message if the session reaches a terminal
+    state (e.g. Failed) rather than waiting out the full session-start timeout.
+    """
     session_name = session_context["name"]
-
-    session_row = page.locator(Homepage.session_row(session_name))
-    expect(session_row).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
-
-    session_active = page.locator(Homepage.session_row_status(session_name, "Active"))
-    expect(session_active).to_be_visible(timeout=TIMEOUT_SESSION_START)
+    wait_for_session_active(page, session_name)
 
 
 @when("the user suspends the session")

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.35.0"
+version = "0.36.2"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-workbench-session-fail-fast.md
+++ b/validation_docs/demo-workbench-session-fail-fast.md
@@ -1,0 +1,67 @@
+# Fix: fail fast when a Workbench session cannot launch
+
+*2026-05-29T21:11:57Z by Showboat 0.6.1*
+<!-- showboat-id: 4858ab79-e705-473a-950b-40222af6c387 -->
+
+## Problem
+
+Running `vip verify --headless-auth --idp okta --workbench-url ...` against Workbench 2026.06 produced 10 failures, all reported as the opaque `AssertionError: Locator expected to be visible` after a 90s wait per test.
+
+Investigation (the Playwright accessibility snapshot in each traceback) showed every launched session had status **Failed** with an *'Abnormal exits'* banner — the deployment genuinely could not launch sessions. The test was correctly detecting a real problem, but:
+
+1. It waited the full `TIMEOUT_SESSION_START` (90s) for an `Active` status that would never come, then emitted an unhelpful 'Locator expected to be visible'.
+2. The status locator only matched the pre-2026.06 `div[aria-label='Active']` markup; 2026.06 renders status as a `button` whose name is the status word.
+
+## Fix
+
+- `Homepage.session_row_status` now matches the status whether it is a legacy `div[aria-label]` or a 2026.06 `button` (text- or aria-label-named).
+- New `wait_for_session_active()` helper polls for `Active` and **fails fast** with an actionable message the moment a terminal state (`Failed`) appears, instead of waiting out the timeout.
+- All six session-active wait sites (ide_extensions, ide_launch, packages, data_sources, sessions, session_capacity) now use the helper.
+
+```bash
+uv run pytest selftests/test_workbench_session_active.py -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+7 passed
+```
+
+```bash
+uv run python -c "
+from vip_tests.workbench.conftest import TERMINAL_SESSION_FAILURE_STATES, _session_failure_message
+from vip_tests.workbench.pages import Homepage
+print(\"terminal states:\", TERMINAL_SESSION_FAILURE_STATES)
+print()
+print(\"status selector (matches legacy div AND 2026.06 button):\")
+print(\" \", Homepage.session_row_status(\"main-1\", \"Active\"))
+print()
+print(\"fail-fast message instead of \x27Locator expected to be visible\x27:\")
+print(\" \", _session_failure_message(\"VIP test - main-1\", \"Failed\"))
+"
+```
+
+```output
+terminal states: ('Failed',)
+
+status selector (matches legacy div AND 2026.06 button):
+  tr[aria-label$='main-1'] div[aria-label='Active'], tr[aria-label$='main-1'] button[aria-label='Active'], tr[aria-label$='main-1'] button:text-is('Active')
+
+fail-fast message instead of 'Locator expected to be visible':
+  Session 'VIP test - main-1' reached terminal state 'Failed' instead of Active — Workbench could not launch the session (abnormal exit). Verify the deployment can launch sessions: check the launcher, the session image, and available CPU/memory/quota.
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+```
+
+```bash
+uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+132 files already formatted
+```

--- a/validation_docs/demo-workbench-session-fail-fast.md
+++ b/validation_docs/demo-workbench-session-fail-fast.md
@@ -1,7 +1,7 @@
 # Fix: fail fast when a Workbench session cannot launch
 
-*2026-05-29T21:11:57Z by Showboat 0.6.1*
-<!-- showboat-id: 4858ab79-e705-473a-950b-40222af6c387 -->
+*2026-05-29T22:16:18Z by Showboat 0.6.1*
+<!-- showboat-id: 283ba6fd-2c62-4ff7-a5ce-f554414747dd -->
 
 ## Problem
 
@@ -17,26 +17,31 @@ Investigation (the Playwright accessibility snapshot in each traceback) showed e
 - `Homepage.session_row_status` now matches the status whether it is a legacy `div[aria-label]` or a 2026.06 `button` (text- or aria-label-named).
 - New `wait_for_session_active()` helper polls for `Active` and **fails fast** with an actionable message the moment a terminal state (`Failed`) appears, instead of waiting out the timeout.
 - All six session-active wait sites (ide_extensions, ide_launch, packages, data_sources, sessions, session_capacity) now use the helper.
+- The capacity scenario aggregates per-session diagnostics via `format_capacity_failure()` so the actionable terminal-state reason survives aggregation (addresses PR review).
 
 ```bash
 uv run pytest selftests/test_workbench_session_active.py -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
 ```
 
 ```output
-7 passed
+10 passed
 ```
 
 ```bash
 uv run python -c "
-from vip_tests.workbench.conftest import TERMINAL_SESSION_FAILURE_STATES, _session_failure_message
+from vip_tests.workbench.conftest import TERMINAL_SESSION_FAILURE_STATES, _session_failure_message, format_capacity_failure
 from vip_tests.workbench.pages import Homepage
 print(\"terminal states:\", TERMINAL_SESSION_FAILURE_STATES)
 print()
 print(\"status selector (matches legacy div AND 2026.06 button):\")
 print(\" \", Homepage.session_row_status(\"main-1\", \"Active\"))
 print()
+reason = _session_failure_message(\"VIP test - main-1\", \"Failed\")
 print(\"fail-fast message instead of \x27Locator expected to be visible\x27:\")
-print(\" \", _session_failure_message(\"VIP test - main-1\", \"Failed\"))
+print(\" \", reason)
+print()
+print(\"capacity aggregation keeps the per-session diagnostic:\")
+print(format_capacity_failure(3, [\"Small\", \"Large\"], [reason, reason.replace(\"main-1\", \"main-2\")]))
 "
 ```
 
@@ -48,6 +53,11 @@ status selector (matches legacy div AND 2026.06 button):
 
 fail-fast message instead of 'Locator expected to be visible':
   Session 'VIP test - main-1' reached terminal state 'Failed' instead of Active — Workbench could not launch the session (abnormal exit). Verify the deployment can launch sessions: check the launcher, the session image, and available CPU/memory/quota.
+
+capacity aggregation keeps the per-session diagnostic:
+1/3 sessions reached Active. Failed profiles: Small, Large
+Session 'VIP test - main-1' reached terminal state 'Failed' instead of Active — Workbench could not launch the session (abnormal exit). Verify the deployment can launch sessions: check the launcher, the session image, and available CPU/memory/quota.
+Session 'VIP test - main-2' reached terminal state 'Failed' instead of Active — Workbench could not launch the session (abnormal exit). Verify the deployment can launch sessions: check the launcher, the session image, and available CPU/memory/quota.
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

I saw this when testing an internal daily Workbench site, both that it was slow and that the error message was just not understandable when there were issues here.

Running `vip verify --headless-auth --idp okta --workbench-url ...` against Workbench 2026.06 produced 10 failures, all surfaced as the opaque `AssertionError: Locator expected to be visible` after a **90s wait per test**.

The Playwright accessibility snapshot in each traceback showed every launched session sitting at status **`Failed`** with an *"Abnormal exits"* banner — the deployment genuinely could not launch sessions. `vip verify` was correctly catching a real problem, but reporting it slowly and unhelpfully.

## Changes

- **`wait_for_session_active()`** (new helper in `workbench/conftest.py`) polls for `Active` and **fails fast** with an actionable message the moment a terminal state (`Failed`) appears, instead of waiting out `TIMEOUT_SESSION_START`.
- Route all six session-active wait sites through the helper: `test_ide_extensions`, `test_ide_launch`, `test_packages`, `test_data_sources`, `test_sessions`, `test_session_capacity`.
- **`Homepage.session_row_status`** now matches the status whether it is the legacy `div[aria-label]` or the Workbench 2026.06 `button` (text- or aria-label-named), so `Active`/`Suspended`/`Failed` detection survives the UI change.
- Add selftests for the status selector and the failure-message builder.

## Scope / non-goals

- This does **not** fix the underlying deployment problem (sessions failing to launch) — that is environmental and separate. It makes VIP report it quickly and clearly.
- This is **not** issue #280 (extensions *search-input* locator); that did not run in this configuration and remains open.

## Demo

# Fix: fail fast when a Workbench session cannot launch

*2026-05-29T21:11:57Z by Showboat 0.6.1*
<!-- showboat-id: 4858ab79-e705-473a-950b-40222af6c387 -->

## Problem

Running `vip verify --headless-auth --idp okta --workbench-url ...` against Workbench 2026.06 produced 10 failures, all reported as the opaque `AssertionError: Locator expected to be visible` after a 90s wait per test.

Investigation (the Playwright accessibility snapshot in each traceback) showed every launched session had status **Failed** with an *'Abnormal exits'* banner — the deployment genuinely could not launch sessions. The test was correctly detecting a real problem, but:

1. It waited the full `TIMEOUT_SESSION_START` (90s) for an `Active` status that would never come, then emitted an unhelpful 'Locator expected to be visible'.
2. The status locator only matched the pre-2026.06 `div[aria-label='Active']` markup; 2026.06 renders status as a `button` whose name is the status word.

## Fix

- `Homepage.session_row_status` now matches the status whether it is a legacy `div[aria-label]` or a 2026.06 `button` (text- or aria-label-named).
- New `wait_for_session_active()` helper polls for `Active` and **fails fast** with an actionable message the moment a terminal state (`Failed`) appears, instead of waiting out the timeout.
- All six session-active wait sites (ide_extensions, ide_launch, packages, data_sources, sessions, session_capacity) now use the helper.

```bash
uv run pytest selftests/test_workbench_session_active.py -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
```

```output
7 passed
```

```bash
uv run python -c "
from vip_tests.workbench.conftest import TERMINAL_SESSION_FAILURE_STATES, _session_failure_message
from vip_tests.workbench.pages import Homepage
print(\"terminal states:\", TERMINAL_SESSION_FAILURE_STATES)
print()
print(\"status selector (matches legacy div AND 2026.06 button):\")
print(\" \", Homepage.session_row_status(\"main-1\", \"Active\"))
print()
print(\"fail-fast message instead of \x27Locator expected to be visible\x27:\")
print(\" \", _session_failure_message(\"VIP test - main-1\", \"Failed\"))
"
```

```output
terminal states: ('Failed',)

status selector (matches legacy div AND 2026.06 button):
  tr[aria-label$='main-1'] div[aria-label='Active'], tr[aria-label$='main-1'] button[aria-label='Active'], tr[aria-label$='main-1'] button:text-is('Active')

fail-fast message instead of 'Locator expected to be visible':
  Session 'VIP test - main-1' reached terminal state 'Failed' instead of Active — Workbench could not launch the session (abnormal exit). Verify the deployment can launch sessions: check the launcher, the session image, and available CPU/memory/quota.
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
```

```bash
uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
132 files already formatted
```