### PR TITLE
fix(connect): stop data-source step being collected as a stray test

### DIFF
--- a/selftests/test_step_naming.py
+++ b/selftests/test_step_naming.py
@@ -1,0 +1,60 @@
+"""Guard against pytest-bdd step functions being named ``test_*``.
+
+A function decorated with ``@given``/``@when``/``@then`` is a step, not a test.
+If it is *also* named ``test_*`` it matches pytest's default ``python_functions``
+collection pattern, so pytest collects it as a standalone test in addition to
+registering it as a step.
+
+That stray test carries none of the feature file's ``@connect`` /
+``@workbench`` / ``@package_manager`` markers (those are applied only to the
+``@scenario``-decorated function), so the plugin's product deselection never
+excludes it. It then runs against whatever product is configured and errors out
+— e.g. a Connect data-source step running during a Package-Manager-only
+``vip verify``. See the regression that prompted this guard.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_STEP_DECORATORS = {"given", "when", "then"}
+_TESTS_ROOT = Path(__file__).resolve().parent.parent / "src" / "vip_tests"
+
+
+def _decorator_name(node: ast.expr) -> str | None:
+    """Return the bare callable name for a decorator like ``@when(...)`` or ``@when``."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):  # e.g. pytest_bdd.when(...)
+        return node.attr
+    return None
+
+
+def _mis_named_steps(path: Path) -> list[str]:
+    """Return names of step-decorated functions in *path* that start with ``test_``."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not node.name.startswith("test_"):
+            continue
+        decorators = {_decorator_name(d) for d in node.decorator_list}
+        if decorators & _STEP_DECORATORS:
+            offenders.append(node.name)
+    return offenders
+
+
+def test_no_step_function_is_named_test() -> None:
+    offenders: dict[str, list[str]] = {}
+    for path in _TESTS_ROOT.rglob("*.py"):
+        names = _mis_named_steps(path)
+        if names:
+            offenders[str(path.relative_to(_TESTS_ROOT))] = names
+    assert not offenders, (
+        "pytest-bdd step functions must not be named test_* (pytest collects them "
+        f"as stray, unmarked tests): {offenders}"
+    )

--- a/src/vip_tests/connect/test_data_sources.py
+++ b/src/vip_tests/connect/test_data_sources.py
@@ -20,7 +20,7 @@ def data_sources_configured(data_sources):
 
 
 @when("I test connectivity to each data source", target_fixture="ds_results")
-def test_connectivity(data_sources, vip_config):
+def check_connectivity_to_each_data_source(data_sources, vip_config):
     if vip_config.insecure:
         verify: bool | str = False
     elif vip_config.ca_bundle is not None:

--- a/validation_docs/demo-data-source-stray-collection.md
+++ b/validation_docs/demo-data-source-stray-collection.md
@@ -1,0 +1,71 @@
+# Fix: data-source step no longer collected as a stray test
+
+*2026-05-31T20:31:53Z by Showboat 0.6.1*
+<!-- showboat-id: b968a66d-6174-407a-b981-61678a8b2ae9 -->
+
+## The bug
+
+Running `vip verify --package-manager-url ...` errored with:
+
+    ERROR at setup of test_connectivity
+    test_connectivity: an unexpected error occurred: ValueError: connect_client did not yield a value
+
+A Connect test was running during a Package-Manager-only verify.
+
+## Root cause
+
+The Connect `@when` step for "I test connectivity to each data source" was named
+`test_connectivity`. Because it matched pytest's `python_functions = test_*`
+collection pattern, pytest collected it as a standalone test in addition to
+registering it as a pytest-bdd step.
+
+That stray test carried none of the feature file's `@connect` marker (the marker
+is applied only to the `@scenario` function), so the plugin's product deselection
+in `_should_deselect_for_product` never excluded it. It ran during a
+Package-Manager-only run, where the Connect dir's autouse cleanup fixtures pull in
+the `connect_client` fixture — which `return`s (instead of `yield`s) when Connect
+is unconfigured, raising `connect_client did not yield a value`.
+
+## The fix
+
+Rename the step to `check_connectivity_to_each_data_source` (the function name is
+arbitrary — the step is matched by its Gherkin string), and add a selftest that
+fails if any `@given`/`@when`/`@then` step function is named `test_*`.
+
+```bash
+grep -nE "def (test_connectivity|check_connectivity_to_each_data_source)" src/vip_tests/connect/test_data_sources.py
+```
+
+```output
+23:def check_connectivity_to_each_data_source(data_sources, vip_config):
+```
+
+```bash
+printf "[general]\ndeployment_name = \"X\"\n[package_manager]\nurl = \"https://example.com\"\n" > /tmp/vip_pm_demo.toml
+echo "Collecting Connect data-source tests with a Package-Manager-only config:"
+uv run pytest src/vip_tests/connect/test_data_sources.py --collect-only --vip-config=/tmp/vip_pm_demo.toml 2>&1 | grep "^collected"
+```
+
+```output
+Collecting Connect data-source tests with a Package-Manager-only config:
+collected 1 item / 1 deselected / 0 selected
+```
+
+```bash
+uv run pytest selftests/test_step_naming.py -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+1 passed
+```
+
+```bash
+just check
+```
+
+```output
+uv run ruff check src/ selftests/ examples/ docker/
+All checks passed!
+uv run ruff format --check src/ selftests/ examples/ docker/
+136 files already formatted
+```


### PR DESCRIPTION
## Summary

`uv run vip verify --package-manager-url ...` errored out with a **Connect** test running during a Package-Manager-only run:

```
ERROR at setup of test_connectivity
test_connectivity: an unexpected error occurred: ValueError: connect_client did not yield a value
```

### Root cause

The Connect `@when` step for *"I test connectivity to each data source"* was named **`test_connectivity`** (`src/vip_tests/connect/test_data_sources.py`). Because that matches pytest's default `python_functions = test_*` pattern, pytest collected it as a **standalone test** in addition to registering it as a pytest-bdd step.

The stray test carried none of the feature file's `@connect` marker (that marker is applied only to the `@scenario` function), so the plugin's product deselection in `_should_deselect_for_product` never excluded it. During a Package-Manager-only run it executed anyway, where the Connect dir's autouse cleanup fixtures pull in the `connect_client` fixture — which `return`s (instead of `yield`s) when Connect is unconfigured, raising `connect_client did not yield a value`.

It was the only step function in the suite named `test_*`; every other `def test_*` is a legitimate `@scenario` function.

### Changes

- Rename the step to `check_connectivity_to_each_data_source`. The function name is arbitrary (the step is matched by its Gherkin string and exposes state via `target_fixture="ds_results"`), so this is a surgical change.
- Add `selftests/test_step_naming.py`, which scans every step file and fails if any `@given`/`@when`/`@then` function is named `test_*` — preventing this whole class of bug going forward.

### Verification

- New regression test fails on the old name, passes after the rename.
- With a Package-Manager-only config, `test_data_sources.py` now collects `1 item / 1 deselected / 0 selected` (only the scenario, deselected) — the stray test is gone.
- Full selftest suite: 607 passed, 3 skipped. `just check` clean.

## Demo

# Fix: data-source step no longer collected as a stray test

## The bug

Running `vip verify --package-manager-url ...` errored with:

    ERROR at setup of test_connectivity
    test_connectivity: an unexpected error occurred: ValueError: connect_client did not yield a value

A Connect test was running during a Package-Manager-only verify.

## Root cause

The Connect `@when` step for "I test connectivity to each data source" was named
`test_connectivity`. Because it matched pytest's `python_functions = test_*`
collection pattern, pytest collected it as a standalone test in addition to
registering it as a pytest-bdd step.

That stray test carried none of the feature file's `@connect` marker (the marker
is applied only to the `@scenario` function), so the plugin's product deselection
in `_should_deselect_for_product` never excluded it. It ran during a
Package-Manager-only run, where the Connect dir's autouse cleanup fixtures pull in
the `connect_client` fixture — which `return`s (instead of `yield`s) when Connect
is unconfigured, raising `connect_client did not yield a value`.

## The fix

Rename the step to `check_connectivity_to_each_data_source` (the function name is
arbitrary — the step is matched by its Gherkin string), and add a selftest that
fails if any `@given`/`@when`/`@then` step function is named `test_*`.

```bash
grep -nE "def (test_connectivity|check_connectivity_to_each_data_source)" src/vip_tests/connect/test_data_sources.py
```

```output
23:def check_connectivity_to_each_data_source(data_sources, vip_config):
```

```bash
printf "[general]\ndeployment_name = \"X\"\n[package_manager]\nurl = \"https://example.com\"\n" > /tmp/vip_pm_demo.toml
echo "Collecting Connect data-source tests with a Package-Manager-only config:"
uv run pytest src/vip_tests/connect/test_data_sources.py --collect-only --vip-config=/tmp/vip_pm_demo.toml 2>&1 | grep "^collected"
```

```output
Collecting Connect data-source tests with a Package-Manager-only config:
collected 1 item / 1 deselected / 0 selected
```

```bash
uv run pytest selftests/test_step_naming.py -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
```

```output
1 passed
```

```bash
just check
```

```output
uv run ruff check src/ selftests/ examples/ docker/
All checks passed!
uv run ruff format --check src/ selftests/ examples/ docker/
136 files already formatted
```
