### PR TITLE
ci(example-report): free disk space before image pulls

### DIFF
--- a/.github/workflows/example-report.yml
+++ b/.github/workflows/example-report.yml
@@ -12,6 +12,22 @@ jobs:
         with:
           persist-credentials: false
 
+      # Free disk space before pulling the Connect, Workbench, and Package
+      # Manager images plus the Playwright Chromium download. The default
+      # ubuntu-latest root volume (~14 GB free) otherwise fills up and the
+      # "Install Playwright browsers" step dies with "No space left on device".
+      # tool-cache is preserved so setup-uv and quarto-actions keep their caches.
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       # Skip Package Manager steps if the license secret is not configured
       - name: Check for RSPM_LICENSE
         id: pm-license


### PR DESCRIPTION
The `Install Playwright browsers` step in the example-report job has
been failing with `No space left on device`. The job pulls three heavy
Docker images (Connect, Workbench, Package Manager) plus the Playwright
Chromium download, which exceeds the ~14 GB free on the ubuntu-latest
root volume.

Adds a `jlumbroso/free-disk-space` step right after checkout — before
the image pulls — to reclaim ~30 GB (dotnet, android, haskell, large
apt packages, swap). `tool-cache` is preserved so `setup-uv` and
`quarto-actions` keep their caches.

This is an environmental failure affecting every PR's Website Preview,
not specific to any feature branch.