### PR TITLE
fix(implement-plan): stop the agent inventing a placeholder PR number

### DIFF
--- a/.github/workflows/implement-plan.md
+++ b/.github/workflows/implement-plan.md
@@ -132,8 +132,13 @@ PR body must include:
   just demo-save bot-implement-issue-<num>
   ```
 
-Comment on the plan PR ("Implementation PR opened: #<new-pr-num>") and
-on the originating issue ("Implementation in progress: #<new-pr-num>").
+Then comment on the originating issue (`#<issue-num>`, which you know)
+that implementation is in progress. Do **not** reference the new
+implementation PR's number — you cannot know it while the run is in
+progress, and you must not invent a placeholder such as `#aw_impl<n>`.
+gh-aw automatically posts a "Related Items" link to the new PR on this
+plan PR, so the cross-link is handled for you; describe the work in
+prose only.
 
 ## Step 5 — bail to comment
 


### PR DESCRIPTION
On the one implement-plan run so far (#327, from plan PR #314), the agent commented on the plan PR with "Implementation PR opened: #aw_impl303" — an invented placeholder. Step 4 told it to reference the new implementation PR's number, which it cannot know while the run is in progress.

gh-aw provides no template for the just-created PR number, and it already posts an automatic "Related Items" link to the new PR on the plan PR — so the manual reference was both impossible to fill correctly and redundant.

This reworks Step 4 to comment on the originating issue (whose number the agent does know) without referencing the new PR number, and explicitly tells the agent not to invent a placeholder. Prompt-body-only change; no lock regeneration needed (verified: `gh aw compile` leaves the lock unchanged).