### PR TITLE
ci: add path filters to ci, preview, and website-preview workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - 'src/**'
+      - 'selftests/**'
+      - 'examples/**'
+      - 'docker/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/ci.yml'
+      - '.github/zizmor.yml'
 
 jobs:
   lint:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'report/**'
       - 'src/**'
+      - 'website/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/preview.yml'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,13 @@ name: Report Preview
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
+    paths:
+      - 'report/**'
+      - 'src/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/preview.yml'
+      - '.github/workflows/example-report.yml'
 
 concurrency: preview-${{ github.ref }}
 

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -3,6 +3,17 @@ name: Website Preview
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
+    paths:
+      - 'website/**'
+      - 'src/vip/**'
+      - 'src/vip_tests/**'
+      - 'report/**'
+      - 'scripts/generate-test-catalog.py'
+      - 'scripts/generate-feature-matrix.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/website-preview.yml'
+      - '.github/workflows/example-report.yml'
 
 concurrency: website-preview-${{ github.ref }}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,7 +15,7 @@ rules:
     #   - website-preview.yml  -- rossjrw/pr-preview-action pushes to gh-pages
     ignore:
       - release.yml:18:9
-      - preview.yml:25:9
-      - preview.yml:45:9
-      - website-preview.yml:25:9
-      - website-preview.yml:89:9
+      - preview.yml:32:9
+      - preview.yml:52:9
+      - website-preview.yml:36:9
+      - website-preview.yml:100:9

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,7 +15,7 @@ rules:
     #   - website-preview.yml  -- rossjrw/pr-preview-action pushes to gh-pages
     ignore:
       - release.yml:18:9
-      - preview.yml:32:9
-      - preview.yml:52:9
+      - preview.yml:33:9
+      - preview.yml:53:9
       - website-preview.yml:36:9
       - website-preview.yml:100:9


### PR DESCRIPTION
## Summary

- `ci.yml` — lint, typecheck, and selftests now only run on PRs that touch `src/`, `selftests/`, `examples/`, `docker/`, `pyproject.toml`, `uv.lock`, or the CI config itself; push to `main` stays unfiltered
- `preview.yml` — report preview build now only triggers when `report/`, `src/`, `pyproject.toml`/`uv.lock`, or the workflow files change
- `website-preview.yml` — website preview build now mirrors the same path list as `website.yml` (which was already scoped), skipping runs for PRs that only touch unrelated files

## Test plan

- [ ] Open a PR that only touches docs or a `thoughts/` file — confirm `CI`, `Report Preview`, and `Website Preview` do not trigger
- [ ] Open a PR that touches `src/` — confirm all three trigger normally
- [ ] Open a PR that touches `website/` — confirm `Website Preview` triggers but `CI` and `Report Preview` do not
- [ ] Confirm preview cleanup still fires when a PR with relevant changes is closed