### PR TITLE
ci: run Connect tests using with-connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - 'docker/**'
       - 'pyproject.toml'
       - 'uv.lock'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
       - '.github/zizmor.yml'
 
 jobs:

--- a/.github/workflows/connect-integration.yml
+++ b/.github/workflows/connect-integration.yml
@@ -80,9 +80,11 @@ jobs:
       # Resolve the actual Connect version for unambiguous job records
       - name: Resolve Connect version
         id: version
+        env:
+          VIP_CONNECT_API_KEY: ${{ steps.connect.outputs.CONNECT_API_KEY }}
         run: |
           RESPONSE=$(curl -sf \
-            -H "Authorization: Key ${{ steps.connect.outputs.CONNECT_API_KEY }}" \
+            -H "Authorization: Key ${VIP_CONNECT_API_KEY}" \
             "${{ steps.connect.outputs.CONNECT_SERVER }}/__api__/server_settings")
           VERSION=$(echo "${RESPONSE}" | jq -r '.version')
           if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then

--- a/.github/workflows/connect-integration.yml
+++ b/.github/workflows/connect-integration.yml
@@ -116,7 +116,7 @@ jobs:
             --connect-url "${{ steps.connect.outputs.CONNECT_SERVER }}" \
             --api-auth \
             --categories connect \
-            # --filter "not test_list_users" \
+            --filter "not test_list_users" \
             --report results.json \
             -- --junitxml=connect-results.xml
         env:
@@ -200,5 +200,5 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "❌ connect-integration on ${{ github.ref_name }} failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+              "text": "❌ Connect VIP tests failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
             }

--- a/.github/workflows/connect-integration.yml
+++ b/.github/workflows/connect-integration.yml
@@ -191,7 +191,7 @@ jobs:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
     needs: connect-integration
-    if: ${{ failure() && github.event_name != 'pull_request' }}
+    if: ${{ failure() }}
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/workflows/connect-integration.yml
+++ b/.github/workflows/connect-integration.yml
@@ -12,9 +12,6 @@ name: Connect Integration Tests
 on:
   push:
     branches: [main]
-  # TODO" remove the PR before merging
-  pull_request:
-    branches: [main]
   schedule:
     - cron: "0 5 * * *" # daily at 5am UTC
   workflow_dispatch:

--- a/.github/workflows/connect-integration.yml
+++ b/.github/workflows/connect-integration.yml
@@ -116,7 +116,7 @@ jobs:
             --connect-url "${{ steps.connect.outputs.CONNECT_SERVER }}" \
             --api-auth \
             --categories connect \
-            --filter "not test_list_users" \
+            # --filter "not test_list_users" \
             --report results.json \
             -- --junitxml=connect-results.xml
         env:
@@ -186,3 +186,19 @@ jobs:
         uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
         with:
           stop: ${{ steps.connect.outputs.CONTAINER_ID }}
+
+  notify-on-failure:
+    name: Notify Slack on failure
+    runs-on: ubuntu-latest
+    needs: connect-integration
+    if: ${{ failure() && github.event_name != 'pull_request' }}
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_CONNECT_CI }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ connect-integration on ${{ github.ref_name }} failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+            }

--- a/.github/workflows/connect-integration.yml
+++ b/.github/workflows/connect-integration.yml
@@ -1,0 +1,199 @@
+name: Connect Integration Tests
+
+# Runs the full VIP Connect test category against ephemeral Connect servers
+# stood up by `with-connect`, so we detect drift between VIP and Connect.
+#
+# Unlike connect-smoke.yml (a curated, fast subset gated on PRs), this workflow
+# runs as many Connect tests as the default `with-connect` setup supports:
+# `vip verify --api-auth --categories connect` selects every API-key scenario
+# and auto-skips features the bare server doesn't have (email, data sources,
+# additional runtimes). See posit-dev/connect#40047.
+
+on:
+  push:
+    branches: [main]
+  # TODO" remove the PR before merging
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 5 * * *" # daily at 5am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: connect-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  connect-integration:
+    name: Integration tests against Connect ${{ matrix.connect-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # "release" = currently released stable, "preview" = nightly build.
+        connect-version: ["release", "preview"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Start Connect in Docker
+      - name: Start Connect
+        id: connect
+        uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
+        with:
+          version: ${{ matrix.connect-version }}
+          license: ${{ secrets.CONNECT_LICENSE }}
+
+      # Surface license errors as workflow annotations so expired keys
+      # are immediately visible on the Actions run page.
+      - name: Check for license errors
+        if: failure() && steps.connect.outcome == 'failure'
+        run: |
+          # Find the Connect container even if with-connect failed partway
+          CID=$(docker ps -aq --filter "ancestor=rstudio/rstudio-connect" | head -1)
+          if [ -z "${CID}" ]; then
+            echo "::error title=Connect Startup Failed::Connect container not found. The with-connect action failed before creating a container."
+            exit 1
+          fi
+          LOGS=$(docker logs "${CID}" 2>&1 || true)
+          LICENSE_MSG=$(echo "${LOGS}" | grep -i "license" | grep -iE "expired|invalid|unable" | head -1 || true)
+          if [ -n "${LICENSE_MSG}" ]; then
+            echo "::error title=License Error::${LICENSE_MSG}"
+            {
+              echo "## License Error"
+              echo ""
+              echo "The Connect license key is expired or invalid. Update the \`CONNECT_LICENSE\` repository secret."
+              echo ""
+              echo '```'
+              echo "${LICENSE_MSG}"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error title=Connect Startup Failed::Connect failed to start. Check the 'Start Connect' step logs for details."
+          fi
+          exit 1
+
+      # Resolve the actual Connect version for unambiguous job records
+      - name: Resolve Connect version
+        id: version
+        run: |
+          RESPONSE=$(curl -sf \
+            -H "Authorization: Key ${{ steps.connect.outputs.CONNECT_API_KEY }}" \
+            "${{ steps.connect.outputs.CONNECT_SERVER }}/__api__/server_settings")
+          VERSION=$(echo "${RESPONSE}" | jq -r '.version')
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "ERROR: Could not resolve Connect version from server_settings"
+            echo "Response body: ${RESPONSE}"
+            exit 1
+          fi
+          echo "Resolved Connect version: ${VERSION}"
+          echo "resolved=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Set up Python and install VIP
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install Playwright browsers
+        run: uv run vip install --skip-system
+
+      # Run the full Connect category. --api-auth selects every API-key
+      # scenario (the bootstrap admin key from with-connect) and skips the
+      # browser-login scenario; features the bare server lacks (email, data
+      # sources, extra runtimes) auto-skip via @if_applicable.
+      - name: Run Connect integration tests
+        run: |
+          uv run vip verify \
+            --connect-url "${{ steps.connect.outputs.CONNECT_SERVER }}" \
+            --api-auth \
+            --categories connect \
+            --report results.json \
+            -- --junitxml=connect-results.xml
+        env:
+          VIP_CONNECT_API_KEY: ${{ steps.connect.outputs.CONNECT_API_KEY }}
+
+      # Upload test results for debugging failures
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: connect-integration-results-${{ matrix.connect-version }}
+          path: |
+            connect-results.xml
+            results.json
+          if-no-files-found: ignore
+
+      # Write a rich job summary with test details and emoji
+      - name: Write workflow summary
+        if: always()
+        run: |
+          RESOLVED="${{ steps.version.outputs.resolved }}"
+          CONNECT_URL="${{ steps.connect.outputs.CONNECT_SERVER }}"
+          REQUESTED="${{ matrix.connect-version }}"
+          RUN_DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
+          {
+            echo "## 🔗 Connect Integration Tests — v${RESOLVED}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| 🏷️ **Requested version** | \`${REQUESTED}\` |"
+            echo "| ✅ **Resolved version** | \`${RESOLVED}\` |"
+            echo "| 🌐 **Connect URL** | \`${CONNECT_URL}\` |"
+            echo "| 📅 **Run date** | ${RUN_DATE} |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -f connect-results.xml ]; then
+            TESTS=$(grep -oP '(?<=tests=")[^"]+' connect-results.xml | head -1 || echo 0)
+            FAILURES=$(grep -oP '(?<=failures=")[^"]+' connect-results.xml | head -1 || echo 0)
+            ERRORS=$(grep -oP '(?<=errors=")[^"]+' connect-results.xml | head -1 || echo 0)
+            SKIPPED=$(grep -oP '(?<=skipped=")[^"]+' connect-results.xml | head -1 || echo 0)
+            TESTS=${TESTS:-0}; FAILURES=${FAILURES:-0}; ERRORS=${ERRORS:-0}; SKIPPED=${SKIPPED:-0}
+            PASSED=$(( TESTS - FAILURES - ERRORS - SKIPPED ))
+            {
+              echo "### 📊 Test Results"
+              echo ""
+              echo "| Result | Count |"
+              echo "|--------|-------|"
+              echo "| ✅ Passed | ${PASSED} |"
+              echo "| ❌ Failed | ${FAILURES:-0} |"
+              echo "| ⚠️ Errors | ${ERRORS:-0} |"
+              echo "| ⏭️ Skipped | ${SKIPPED:-0} |"
+              echo "| 📝 **Total** | **${TESTS:-0}** |"
+              echo ""
+              if [ "${FAILURES:-0}" = "0" ] && [ "${ERRORS:-0}" = "0" ]; then
+                echo "🎉 **All tests passed!**"
+              else
+                echo "💥 **Some tests failed — check the logs for details.**"
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "> ⚠️ Test results file not found — tests may have been skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Stop Connect
+      - name: Stop Connect
+        if: always()
+        uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
+        with:
+          stop: ${{ steps.connect.outputs.CONTAINER_ID }}
+
+  status:
+    name: Connect Integration Tests Status
+    if: always()
+    needs: [connect-integration]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check integration test result
+        run: |
+          if [ "${{ needs.connect-integration.result }}" = "failure" ] || [ "${{ needs.connect-integration.result }}" = "cancelled" ]; then
+            echo "Connect integration tests failed or were cancelled"
+            exit 1
+          fi
+          echo "Connect integration tests passed or were skipped"

--- a/.github/workflows/connect-integration.yml
+++ b/.github/workflows/connect-integration.yml
@@ -114,6 +114,7 @@ jobs:
             --connect-url "${{ steps.connect.outputs.CONNECT_SERVER }}" \
             --api-auth \
             --categories connect \
+            --filter "not test_list_users" \
             --report results.json \
             -- --junitxml=connect-results.xml
         env:
@@ -183,17 +184,3 @@ jobs:
         uses: posit-dev/with-connect@4f26a6a301716789d6451cc3afd878afdd52189b # main
         with:
           stop: ${{ steps.connect.outputs.CONTAINER_ID }}
-
-  status:
-    name: Connect Integration Tests Status
-    if: always()
-    needs: [connect-integration]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check integration test result
-        run: |
-          if [ "${{ needs.connect-integration.result }}" = "failure" ] || [ "${{ needs.connect-integration.result }}" = "cancelled" ]; then
-            echo "Connect integration tests failed or were cancelled"
-            exit 1
-          fi
-          echo "Connect integration tests passed or were skipped"


### PR DESCRIPTION
Uses [`with-connect`](https://github.com/posit-dev/with-connect) to run the Connect tests on every commit. 

~I have not yet added a license file as a repository secret (*not checked into the code*) yet, but I can if we are going to move in this direction. These tests currently run in trial mode so do actually execute.~ Oh, nevermind that's actually already extant in this repo!