### PR TITLE
ci: guard against stray uv.lock changes in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,34 @@ jobs:
           fi
           echo "Selftests passed or were skipped"
 
+  lockfile-guard:
+    name: Lockfile Guard
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Bot-generated plan/docs PRs have repeatedly carried a stale uv.lock from
+      # an old base, which is invisible until it breaks the Dependency Audit
+      # (vulnerable transitive pins) or conflicts with main on merge. A real
+      # dependency change always touches pyproject.toml too, so a uv.lock change
+      # on its own is the signal that the lockfile drifted in by accident.
+      - name: Reject uv.lock changes without a pyproject.toml change
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          if printf '%s\n' "$changed" | grep -qx 'uv.lock' \
+            && ! printf '%s\n' "$changed" | grep -qx 'pyproject.toml'; then
+            echo "::error::uv.lock changed without a corresponding pyproject.toml change."
+            echo "Plan/docs PRs must not carry a uv.lock update. Restore it with:"
+            echo "    git checkout origin/${GITHUB_BASE_REF} -- uv.lock && git commit uv.lock"
+            echo "If this is an intentional dependency change, update pyproject.toml in the same PR."
+            exit 1
+          fi
+          echo "uv.lock guard passed: no stray lockfile change detected."
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
             && ! printf '%s\n' "$changed" | grep -qx 'pyproject.toml'; then
             echo "::error::uv.lock changed without a corresponding pyproject.toml change."
             echo "Plan/docs PRs must not carry a uv.lock update. Restore it with:"
-            echo "    git checkout origin/${GITHUB_BASE_REF} -- uv.lock && git commit uv.lock"
+            echo "    git checkout $BASE_SHA -- uv.lock && git commit -m 'restore uv.lock' uv.lock"
             echo "If this is an intentional dependency change, update pyproject.toml in the same PR."
             exit 1
           fi


### PR DESCRIPTION
Bot-generated plan/docs PRs have repeatedly carried a stale `uv.lock` from an old base. It is invisible until it fails the Dependency Audit (vulnerable transitive pins on #309/#317/#346) or conflicts with `main` on merge (#309). A real dependency change always touches `pyproject.toml`, so a lone `uv.lock` change is the drift signal.

Adds a `Lockfile Guard` job: PRs that modify `uv.lock` without `pyproject.toml` fail with instructions to restore the lockfile. Legit dependency bumps (which touch both) and code/docs PRs are unaffected.

Note: the duplicate-module defect from #349 is already caught by ruff F811 in `Lint & Format`, so no separate check is added here.