### PR TITLE
ci: make issue triage opt-in and add issue lifecycle labels

### DIFF
--- a/.github/workflows/implement-plan.lock.yml
+++ b/.github/workflows/implement-plan.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"50367f500b195dac5dc76badbcd50d5d1785b5f55f629eb6b9eeb4b0af7b8913","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d6b0e79bee0232e0764bea0131521b4a8611383382d3e5782f620f6aba9d0947","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -40,7 +40,7 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+#   - github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.25.49
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -207,23 +207,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
+          cat << 'GH_AW_PROMPT_b59eb714cc442b00_EOF'
           <system>
-          GH_AW_PROMPT_5673439332fd00e5_EOF
+          GH_AW_PROMPT_b59eb714cc442b00_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
+          cat << 'GH_AW_PROMPT_b59eb714cc442b00_EOF'
           <safe-output-tools>
-          Tools: add_comment(max:2), create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_5673439332fd00e5_EOF
+          Tools: add_comment(max:2), create_pull_request, add_labels, remove_labels, missing_tool, missing_data, noop
+          GH_AW_PROMPT_b59eb714cc442b00_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
+          cat << 'GH_AW_PROMPT_b59eb714cc442b00_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_5673439332fd00e5_EOF
+          GH_AW_PROMPT_b59eb714cc442b00_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
+          cat << 'GH_AW_PROMPT_b59eb714cc442b00_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,12 +252,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5673439332fd00e5_EOF
+          GH_AW_PROMPT_b59eb714cc442b00_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5673439332fd00e5_EOF'
+          cat << 'GH_AW_PROMPT_b59eb714cc442b00_EOF'
           </system>
           {{#runtime-import .github/workflows/implement-plan.md}}
-          GH_AW_PROMPT_5673439332fd00e5_EOF
+          GH_AW_PROMPT_b59eb714cc442b00_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -369,7 +369,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -476,16 +476,18 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_26b007378839c99c_EOF'
-          {"add_comment":{"max":2},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_26b007378839c99c_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_09517a4aaebad4a2_EOF'
+          {"add_comment":{"max":2,"target":"*"},"add_labels":{"allowed":["implementing"],"max":1,"target":"*"},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["plan-pending-review"],"max":1,"target":"*"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_09517a4aaebad4a2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Supports reply_to_id for discussion threading.",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Branch name will be prefixed with \"bot-\"."
+                "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
+                "add_labels": " CONSTRAINTS: Maximum 1 label(s) can be added. Only these labels are allowed: [\"implementing\"]. Target: *.",
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Branch name will be prefixed with \"bot-\".",
+                "remove_labels": " CONSTRAINTS: Maximum 1 label(s) can be removed. Only these labels can be removed: [plan-pending-review]. Target: *."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -507,6 +509,25 @@ jobs:
                   "reply_to_id": {
                     "type": "string",
                     "maxLength": 256
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
+              },
+              "add_labels": {
+                "defaultMax": 5,
+                "fields": {
+                  "item_number": {
+                    "issueNumberOrTemporaryId": true
+                  },
+                  "labels": {
+                    "required": true,
+                    "type": "array",
+                    "itemType": "string",
+                    "itemSanitize": true,
+                    "itemMaxLength": 128
                   },
                   "repo": {
                     "type": "string",
@@ -612,6 +633,25 @@ jobs:
                   }
                 }
               },
+              "remove_labels": {
+                "defaultMax": 5,
+                "fields": {
+                  "item_number": {
+                    "issueNumberOrTemporaryId": true
+                  },
+                  "labels": {
+                    "required": true,
+                    "type": "array",
+                    "itemType": "string",
+                    "itemSanitize": true,
+                    "itemMaxLength": 128
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
+              },
               "report_incomplete": {
                 "defaultMax": 5,
                 "fields": {
@@ -714,7 +754,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_48f64a51f9d2fc3e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_639009bb216d8677_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -742,7 +782,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_48f64a51f9d2fc3e_EOF
+          GH_AW_MCP_CONFIG_639009bb216d8677_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -774,6 +814,7 @@ jobs:
         # --allow-tool shell(echo)
         # --allow-tool shell(gh issue comment)
         # --allow-tool shell(gh issue view)
+        # --allow-tool shell(gh label create)
         # --allow-tool shell(gh pr comment)
         # --allow-tool shell(gh pr view)
         # --allow-tool shell(git add:*)
@@ -803,7 +844,7 @@ jobs:
         # --allow-tool shell(wc)
         # --allow-tool shell(yq)
         # --allow-tool write
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           set -o pipefail
           printf '%s' "$(date +%s%3N)" > /tmp/gh-aw/agent_cli_start_ms.txt
@@ -820,7 +861,7 @@ jobs:
           fi
           # shellcheck disable=SC1003
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" ${GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS} --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
-            -- /bin/bash -c 'export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(gh issue comment)'\'' --allow-tool '\''shell(gh issue view)'\'' --allow-tool '\''shell(gh pr comment)'\'' --allow-tool '\''shell(gh pr view)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git diff)'\'' --allow-tool '\''shell(git log)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(just)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(npx commitlint)'\'' --allow-tool '\''shell(printf)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(rg)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(uv run)'\'' --allow-tool '\''shell(uvx showboat)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(gh issue comment)'\'' --allow-tool '\''shell(gh issue view)'\'' --allow-tool '\''shell(gh label create)'\'' --allow-tool '\''shell(gh pr comment)'\'' --allow-tool '\''shell(gh pr view)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git diff)'\'' --allow-tool '\''shell(git log)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(just)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(npx commitlint)'\'' --allow-tool '\''shell(printf)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(rg)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(uv run)'\'' --allow-tool '\''shell(uvx showboat)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -1046,7 +1087,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1175,7 +1216,7 @@ jobs:
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "20"
+          GH_AW_TIMEOUT_MINUTES: "30"
           GH_AW_MAX_EFFECTIVE_TOKENS: "25000000"
         with:
           github-token: ${{ steps.safe-outputs-app-token.outputs.token }}
@@ -1214,7 +1255,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1411,7 +1452,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1470,7 +1511,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1584,7 +1625,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":2},\"create_pull_request\":{\"branch_prefix\":\"bot-\",\"draft\":false,\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":2,\"target\":\"*\"},\"add_labels\":{\"allowed\":[\"implementing\"],\"max\":1,\"target\":\"*\"},\"create_pull_request\":{\"branch_prefix\":\"bot-\",\"draft\":false,\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"plan-pending-review\"],\"max\":1,\"target\":\"*\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ steps.safe-outputs-app-token.outputs.token }}
         with:

--- a/.github/workflows/implement-plan.md
+++ b/.github/workflows/implement-plan.md
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "thoughts/shared/plans/**.md"
+timeout-minutes: 30
 engine:
   id: copilot
   model: claude-sonnet-4.6
@@ -21,6 +22,7 @@ tools:
   bash:
     - "gh issue view *"
     - "gh issue comment *"
+    - "gh label create *"
     - "gh pr view *"
     - "gh pr comment *"
     - "rg *"
@@ -40,7 +42,16 @@ safe-outputs:
     private-key: ${{ secrets.POSIT_VIP_TRIAGE_PEM }}
   add-comment:
     max: 2
+    target: "*"
     discussions: false
+  add-labels:
+    max: 1
+    target: "*"
+    allowed: ["implementing"]
+  remove-labels:
+    max: 1
+    target: "*"
+    allowed: ["plan-pending-review"]
   create-pull-request:
     branch-prefix: "bot-"
     draft: false
@@ -87,11 +98,31 @@ Exit silently if **any** of:
 
 ## Step 3 — implement
 
+This workflow runs under a hard time budget (`timeout-minutes: 30`). A
+previous run burned the entire budget and produced **nothing** — never
+let that happen again. Work in the smallest shippable increments and
+commit as you go, so progress is always preserved.
+
 Read the plan in full. Then:
 
 1. Make the code, test, and documentation changes that the plan
    specifies. The plan should be detailed enough that scope is
    unambiguous; if it is not, fall through to Step 5.
+   - **Scope to one coherent surface per run.** If the plan spans
+     several independent deliverables (e.g. multiple IDEs, multiple
+     test categories, a foundation plus consumers), implement the
+     single most foundational one fully and list the rest as a
+     checklist of follow-ups in the PR body — do not attempt all of
+     them in one run.
+   - **Commit incrementally** after each working slice so partial
+     progress is never lost to a timeout.
+   - **If the plan declares a dependency** on another issue or PR that
+     has not yet merged, do not implement against missing
+     infrastructure — open a draft PR noting the blocker and stop.
+   - **If you are running low on time**, stop writing new code, open a
+     **draft** PR with what is done plus a `## Remaining work`
+     checklist, and use `report_incomplete`. A draft PR with partial
+     progress is always better than no output.
 2. For every production code change, write a corresponding selftest
    under `selftests/` (matching this repo's convention of every fix or
    feature shipping with a test).
@@ -132,13 +163,29 @@ PR body must include:
   just demo-save bot-implement-issue-<num>
   ```
 
-Then comment on the originating issue (`#<issue-num>`, which you know)
-that implementation is in progress. Do **not** reference the new
-implementation PR's number — you cannot know it while the run is in
-progress, and you must not invent a placeholder such as `#aw_impl<n>`.
-gh-aw automatically posts a "Related Items" link to the new PR on this
-plan PR, so the cross-link is handled for you; describe the work in
-prose only.
+Then update the originating issue (`#<issue-num>`, which you know) so its
+labels reflect that implementation has started:
+
+1. Ensure the `implementing` label exists (idempotent):
+
+   ```
+   gh label create implementing --color 1D76DB --description "Plan merged; implementation PR in flight" --force
+   ```
+
+2. Move the issue from "plan pending" to "implementing" by calling the
+   safe-output tools with the issue number as the target (these outputs
+   are configured with `target: "*"`, so you must pass
+   `issue_number: <issue-num>`):
+   - `remove_labels` with `{"labels": ["plan-pending-review"], "issue_number": <issue-num>}`
+   - `add_labels` with `{"labels": ["implementing"], "issue_number": <issue-num>}`
+
+3. Add one comment on the issue (`add_comment` with
+   `issue_number: <issue-num>`) saying implementation is in progress. Do
+   **not** reference the new implementation PR's number — you cannot know
+   it while the run is in progress, and you must not invent a placeholder
+   such as `#aw_impl<n>`. gh-aw automatically posts a "Related Items" link
+   to the new PR on this plan PR, so the cross-link is handled for you;
+   describe the work in prose only.
 
 ## Step 5 — bail to comment
 

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fc158c7b297c99c15956766ab0add8e8a23f59a7b0f716ae624a4a2d1cdaff47","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b551371c3aac8784167c4dd0e6e667077bb871311a66f7f0e895a7400720d9c5","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -40,7 +40,7 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+#   - github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.25.49
@@ -57,8 +57,6 @@ on:
     - created
   issues:
     types:
-    - opened
-    - reopened
     - labeled
 
 permissions: {}
@@ -93,7 +91,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -207,23 +205,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7ef9b5ed41a2f117_EOF'
+          cat << 'GH_AW_PROMPT_05a4edd650794646_EOF'
           <system>
-          GH_AW_PROMPT_7ef9b5ed41a2f117_EOF
+          GH_AW_PROMPT_05a4edd650794646_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7ef9b5ed41a2f117_EOF'
+          cat << 'GH_AW_PROMPT_05a4edd650794646_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request, add_labels(max:3), remove_labels, missing_tool, missing_data, noop
-          GH_AW_PROMPT_7ef9b5ed41a2f117_EOF
+          GH_AW_PROMPT_05a4edd650794646_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_7ef9b5ed41a2f117_EOF'
+          cat << 'GH_AW_PROMPT_05a4edd650794646_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_7ef9b5ed41a2f117_EOF
+          GH_AW_PROMPT_05a4edd650794646_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_7ef9b5ed41a2f117_EOF'
+          cat << 'GH_AW_PROMPT_05a4edd650794646_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,15 +250,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_7ef9b5ed41a2f117_EOF
+          GH_AW_PROMPT_05a4edd650794646_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_7ef9b5ed41a2f117_EOF'
+          cat << 'GH_AW_PROMPT_05a4edd650794646_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_7ef9b5ed41a2f117_EOF
+          GH_AW_PROMPT_05a4edd650794646_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -374,7 +372,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -481,18 +479,18 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_96881267fd0f0fd9_EOF'
-          {"add_comment":{"max":1},"add_labels":{"allowed":["triaged-by-bot","needs-human-triage"],"max":3},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["re-triage"],"max":1},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_96881267fd0f0fd9_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5e2305d0175daa28_EOF'
+          {"add_comment":{"max":1},"add_labels":{"allowed":["triaged-by-bot","needs-human-triage","plan-pending-review"],"max":3},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["needs-bot-triage"],"max":1},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_5e2305d0175daa28_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
-                "add_labels": " CONSTRAINTS: Maximum 3 label(s) can be added. Only these labels are allowed: [\"triaged-by-bot\" \"needs-human-triage\"].",
+                "add_labels": " CONSTRAINTS: Maximum 3 label(s) can be added. Only these labels are allowed: [\"triaged-by-bot\" \"needs-human-triage\" \"plan-pending-review\"].",
                 "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Branch name will be prefixed with \"bot-\".",
-                "remove_labels": " CONSTRAINTS: Maximum 1 label(s) can be removed. Only these labels can be removed: [re-triage]."
+                "remove_labels": " CONSTRAINTS: Maximum 1 label(s) can be removed. Only these labels can be removed: [needs-bot-triage]."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -759,7 +757,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_19a1d41c325eb5ec_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_55e864b9c009a3f6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -787,7 +785,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_19a1d41c325eb5ec_EOF
+          GH_AW_MCP_CONFIG_55e864b9c009a3f6_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1094,7 +1092,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1262,7 +1260,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1460,7 +1458,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1519,7 +1517,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b11be78086764c43fa463398aed7ffdcf40549c1 # v0.77.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1633,7 +1631,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"triaged-by-bot\",\"needs-human-triage\"],\"max\":3},\"create_pull_request\":{\"branch_prefix\":\"bot-\",\"draft\":false,\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"re-triage\"],\"max\":1},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"triaged-by-bot\",\"needs-human-triage\",\"plan-pending-review\"],\"max\":3},\"create_pull_request\":{\"branch_prefix\":\"bot-\",\"draft\":false,\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"needs-bot-triage\"],\"max\":1},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ steps.safe-outputs-app-token.outputs.token }}
         with:

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -1,7 +1,7 @@
 ---
 on:
   issues:
-    types: [opened, reopened, labeled]
+    types: [labeled]
   issue_comment:
     types: [created]
 engine:
@@ -45,10 +45,10 @@ safe-outputs:
     discussions: false
   add-labels:
     max: 3
-    allowed: ["triaged-by-bot", "needs-human-triage"]
+    allowed: ["triaged-by-bot", "needs-human-triage", "plan-pending-review"]
   remove-labels:
     max: 1
-    allowed: ["re-triage"]
+    allowed: ["needs-bot-triage"]
   create-pull-request:
     branch-prefix: "bot-"
     draft: false
@@ -67,14 +67,22 @@ of: a pull request, a comment, or a no-op.
 ## Step 1 — gate
 
 Read the issue (`gh issue view ${{ github.event.issue.number }} --json
-number,title,body,labels,author,state`). Exit silently if any of:
+number,title,body,labels,author,state`).
+
+Triage is **opt-in**: the bot does nothing until a maintainer explicitly
+hands it an issue by applying the `needs-bot-triage` label. Exit silently
+if any of:
 
 - `state != "open"`.
 - `skip-triage` is in the labels.
-- `triaged-by-bot` is in the labels AND `re-triage` is NOT.
+- The event is an `issues` event (label added) and `needs-bot-triage` is
+  NOT in the labels. (Adding any other label must not start a triage run.)
 - The event is `issue_comment` and the comment author is not a CODEOWNER
   (`@ian-flores`, `@statik`, `@bdeitte`) OR the comment body does not
   match `@Copilot retry` (case-insensitive).
+
+To request another pass on an already-triaged issue, a maintainer simply
+re-applies `needs-bot-triage` — there is no separate re-triage label.
 
 ## Step 1a — pre-run cleanup (MUST run before Step 2)
 
@@ -82,33 +90,32 @@ Before proceeding to Step 2, you MUST perform these two cleanup actions
 in order. Do not skip them. Do not defer them to the end of the run —
 partial-failure recovery depends on them happening at the start.
 
-1. **Remove the `re-triage` label if it is present.** Look at the labels
-   you read in Step 1. If `re-triage` is among them, remove it by calling
-   the `remove_labels` safe-output tool with `{"labels": ["re-triage"]}`
-   (it targets the triggering issue). Do **not** use a
-   `gh issue edit --remove-label` shell command — the bash policy denies
-   it and any failure is silently swallowed, which is why this label
-   persisted across every earlier run. The `remove_labels` safe-output
-   uses the bot's write-capable token and is the only reliable path, the
-   same way `add_labels` is for adding.
+1. **Consume the opt-in label.** If `needs-bot-triage` is among the labels
+   you read in Step 1, remove it by calling the `remove_labels` safe-output
+   tool with `{"labels": ["needs-bot-triage"]}` (it targets the triggering
+   issue). Do **not** use a `gh issue edit --remove-label` shell command —
+   the bash policy denies it and any failure is silently swallowed. The
+   `remove_labels` safe-output uses the bot's write-capable token and is the
+   only reliable path, the same way `add_labels` is for adding.
 
-   If `re-triage` is not among the labels, do not call the tool.
+   If `needs-bot-triage` is not among the labels (e.g. an `issue_comment`
+   retry), do not call the tool.
 
-   Humans apply `re-triage` to request a re-run; the bot consumes it
-   here at the start of every run. If the label is not removed, the next
-   `issues.labeled` event will not be distinguishable from a fresh
-   re-triage request, and you will appear to ignore maintainer
-   instructions.
+   Maintainers apply `needs-bot-triage` to request a run; the bot consumes
+   it here at the start. Removing it means a later re-application is an
+   unambiguous request for another pass, rather than a stale label that
+   would re-fire on the next unrelated label change.
 
-2. **Create the four triage labels idempotently** so subsequent
-   `--add-label` calls succeed. The `--force` flag makes these safe
-   to run on every invocation:
+2. **Create the lifecycle labels idempotently** so subsequent `--add-label`
+   calls succeed. The `--force` flag makes these safe to run on every
+   invocation:
 
    ```
+   gh label create needs-bot-triage --color FBCA04 --description "Apply to have the triage bot pick up this issue" --force
    gh label create triaged-by-bot --color BFD4F2 --description "Bot has examined this issue" --force
+   gh label create plan-pending-review --color 0E8A16 --description "Bot opened a plan PR; awaiting human review" --force
    gh label create needs-human-triage --color D93F0B --description "Bot could not propose action; needs a maintainer" --force
    gh label create skip-triage --color CCCCCC --description "Do not run the triage agent on this issue" --force
-   gh label create re-triage --color FBCA04 --description "Re-run the triage agent on this issue" --force
    ```
 
 If either action fails, proceed to Step 2 anyway. Label cleanup is
@@ -231,7 +238,10 @@ fall through to Step 5.
       an implementation PR — comment to iterate on the plan first."
 3. Add one comment on the original issue summarizing the plan in 2–3
    sentences and linking to the plan PR.
-4. Apply the `triaged-by-bot` label to the issue.
+4. Apply both the `triaged-by-bot` and `plan-pending-review` labels to the
+   issue. `plan-pending-review` signals that a plan PR is open and awaiting
+   human review; the `implement-plan` workflow removes it when the plan
+   merges and implementation begins.
 
 ## Step 5 — can't-proceed path
 
@@ -250,8 +260,8 @@ denied path, ambiguous request, conflicting labels>
 - [ ] <missing field 1>
 - [ ] <missing field 2>
 
-Once that's added, remove the `needs-human-triage` label and apply
-`re-triage` to give me another pass.
+Once that's added, remove the `needs-human-triage` label and re-apply
+`needs-bot-triage` to give me another pass.
 
 <!-- vip-triage-bot:v1 status=needs-info issue=<num> -->
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ The report lives in `report/` and reads `report/results.json` (written by pytest
 -   **`ci.yml`** -- ruff lint/format (pinned to 0.15.0) + selftests on Python 3.10 and 3.12. Uses uv cache.
 -   **`preview.yml`** -- runs selftests, renders Quarto report, publishes PR preview to gh-pages via `rossjrw/pr-preview-action@v1`. Uses uv and Quarto caches.
 -   **`pr-title.yml`** -- validates PR titles follow conventional commit format. Squash merges use the PR title as the commit message.
--   **`issue-triage.md`** + `issue-triage.lock.yml` -- gh-aw agent that classifies new issues and opens either a fix PR (bugs) or a plan PR (enhancements). See `docs/agentic-workflows.md`.
+-   **`issue-triage.md`** + `issue-triage.lock.yml` -- gh-aw agent that triages issues a maintainer opts in via the `needs-bot-triage` label, opening either a fix PR (bugs) or a plan PR (enhancements). See `docs/agentic-workflows.md`.
 -   **`implement-plan.md`** + `implement-plan.lock.yml` -- gh-aw agent that fires when a plan PR merges and opens the implementation PR.
 
 ## PR titles

--- a/docs/agentic-workflows.md
+++ b/docs/agentic-workflows.md
@@ -5,15 +5,21 @@ for human review.
 
 ## Issue triage (`issue-triage.md`)
 
-Fires on every newly opened issue (and on `re-triage`). The agent reads
-the issue, decides whether it's a bug or an enhancement, and produces
-one of three outputs:
+Triage is **opt-in**. The agent does nothing on its own — it fires only
+when a maintainer applies the `needs-bot-triage` label to an issue,
+explicitly handing it over. (Newly opened issues are ignored until
+labeled.) The bot removes `needs-bot-triage` as soon as it picks the
+issue up, so re-applying the label requests another pass.
+
+Once triggered, the agent reads the issue, decides whether it's a bug or
+an enhancement, and produces one of three outputs:
 
 - **Bug, fixable**: opens a pull request with the production fix, a
   selftest, and an auto-generated showboat demo.
 - **Enhancement**: opens a pull request that adds a markdown plan to
-  `thoughts/shared/plans/` and posts a summary comment on the issue.
-  Merging the plan PR is the human's "approved — go implement" signal.
+  `thoughts/shared/plans/`, posts a summary comment on the issue, and
+  labels it `plan-pending-review`. Merging the plan PR is the human's
+  "approved — go implement" signal.
 - **Can't proceed**: posts a structured comment explaining what's
   missing and labels the issue `needs-human-triage`.
 
@@ -21,26 +27,40 @@ one of three outputs:
 
 Fires when a pull request that touches `thoughts/shared/plans/**` is
 merged. The agent reads the plan, applies it, and opens an
-implementation PR.
+implementation PR. As it starts, it swaps the originating issue's
+`plan-pending-review` label for `implementing`. The issue closes
+automatically when the implementation PR (which carries `Closes #<num>`)
+merges.
 
-## Labels the workflows use
+It runs under a 30-minute budget and is instructed to ship the smallest
+coherent slice — committing incrementally and, if it runs low on time,
+opening a **draft** PR with a remaining-work checklist rather than
+producing nothing.
 
-| Label | Set by | Effect |
+## Issue label lifecycle
+
+An issue moves through these states; the label tells you where it is at
+a glance:
+
+| Label | Set by | Means |
 |---|---|---|
-| `skip-triage` | maintainer, before issue is opened or any time | Triage workflow exits at the gate. |
-| `triaged-by-bot` | bot, after every run | Subsequent triage runs are skipped unless `re-triage` is set. |
-| `needs-human-triage` | bot, on the can't-proceed path | Filter for issues the bot bounced. |
-| `re-triage` | maintainer, manually | Forces another triage run; the bot removes the label after picking it up. |
+| *(none)* | — | Excluded — the bot ignores it until opted in. |
+| `needs-bot-triage` | maintainer | Opt-in: run (or re-run) triage. Bot removes it on pickup. |
+| `triaged-by-bot` | bot, after every run | Bot has examined the issue. |
+| `plan-pending-review` | bot (enhancement path) | A plan PR is open and awaiting human review. |
+| `implementing` | implement-plan, on plan merge | Plan merged; an implementation PR is in flight. |
+| `needs-human-triage` | bot (can't-proceed path) | Bot couldn't propose an action; needs a maintainer. |
+| `skip-triage` | maintainer | Hard opt-out; triage exits at the gate even if `needs-bot-triage` is added. |
 
-## How to opt an issue out
+## How to triage an issue
 
-Apply the `skip-triage` label. The workflow exits at the first step
-without commenting.
+Apply the `needs-bot-triage` label. The bot picks it up, removes the
+label, and runs. To request another pass later, re-apply it.
 
-## How to retry triage
+## How to keep the bot away from an issue
 
-Apply the `re-triage` label. The bot will run again and remove the
-label.
+Leave it unlabeled (the default), or apply `skip-triage` to hard-block
+triage even if someone later adds `needs-bot-triage`.
 
 ## How to iterate on a plan before implementation fires
 


### PR DESCRIPTION
Reworks the bot triage pipeline around a human checkpoint at the front and visible issue state throughout.

**Opt-in triage** (`issue-triage.md`): the agent no longer fires on every newly opened issue. It triggers only when a maintainer applies the `needs-bot-triage` label, and removes the label on pickup (re-apply to re-run). Replaces the old `re-triage` label.

**Issue lifecycle labels:** an issue's labels now show where it is — `needs-bot-triage` (opt-in) → `triaged-by-bot` + `plan-pending-review` (plan PR awaiting review) → `implementing` (plan merged, impl PR in flight) → closed on merge. `implement-plan.md` gained `add-labels`/`remove-labels` outputs (with `target: "*"`) to swap the label on the originating issue and comment there as implementation starts.

**Implement-run resilience** (`implement-plan.md`): `timeout-minutes` raised 20 → 30, plus instructions to ship the smallest coherent slice, commit incrementally, and open a draft PR with a remaining-work checklist instead of producing nothing on timeout (as run 27211949474 did).

Lock files recompiled with `gh aw compile` (v0.74.8); zizmor clean. Docs updated (`docs/agentic-workflows.md`, `AGENTS.md`).