### PR TITLE
ci: exempt dependabot from the uv.lock guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,12 @@ jobs:
 
   lockfile-guard:
     name: Lockfile Guard
-    if: github.event_name == 'pull_request'
+    # Dependabot legitimately ships lockfile-only updates (in-range bumps never
+    # touch pyproject.toml), so it is exempt; the guard targets bot-generated
+    # plan/docs PRs that carry a stale uv.lock by accident.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
The Lockfile Guard added in #351 rejects any PR that changes uv.lock without a corresponding pyproject.toml change. That signature is correct for its target (bot-generated plan/docs PRs carrying a stale lockfile from an old base), but it is a false positive for Dependabot: in-range version bumps in the python-dependencies group legitimately update only uv.lock and never touch pyproject.toml — #357 is blocked by exactly this.

This skips the guard job when the PR author is dependabot[bot]. Author-based exemption is safe here because Dependabot lockfile updates are intentional dependency changes, not accidental drift, and they remain covered by the Dependency Audit job.