### PR TITLE
feat(examples): add custom test extension example and vip scaffold (closes #298)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,10 @@
 !README.md
 plans/
 selftests/
-examples/
+examples/*
+# Keep the scaffold template: pyproject force-includes it into the wheel, so
+# `uv sync` inside the Docker builds needs it present in the build context.
+!examples/cross_product_validation
 .gitignore
 .gitattributes
 vip.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Key principles:
 
 | File | Purpose |
 |------------------------------------|------------------------------------|
-| `src/vip/cli.py` | CLI entry point: verify, cleanup, install, uninstall, cluster, auth commands |
+| `src/vip/cli.py` | CLI entry point: verify, cleanup, install, uninstall, cluster, auth, scaffold commands |
 | `src/vip/config.py` | TOML config loader, dataclasses, `Mode` enum, per-mode validation |
 | `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers |
 | `src/vip/idp.py` | IdP login form strategies for headless auth (Keycloak, Okta) |
@@ -170,6 +170,25 @@ Key principles:
 | `src/vip_tests/conftest.py` | Root fixtures: clients, auth, runtimes, data sources |
 | `report/index.qmd` | Quarto summary page |
 | `report/details.qmd` | Quarto detailed results page |
+
+## Extension examples
+
+VIP ships two canonical extension examples in `examples/`:
+
+| Directory | Purpose |
+|---|---|
+| `examples/custom_tests/` | Minimal HTTP health-check extension (simpler starting point) |
+| `examples/cross_product_validation/` | GxP/regulated-environment pattern: runtime version checks + DESeq2/PyDeSEQ2 package installability across Connect and Workbench |
+
+Generate the cross-product example in a new directory with:
+
+```bash
+vip scaffold --output ./my-custom-tests
+```
+
+When writing a new extension example, follow the same four-layer architecture and add
+`@pytest.mark.connect` / `@pytest.mark.workbench` decorators to every `@scenario` function so
+auto-skip works correctly (feature-level Gherkin tags alone are not sufficient).
 
 ## Fixtures available in product tests
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -231,3 +231,41 @@ The `.feature` files only need to change when the requirements change.
 - **Fat step definitions**: If a step definition is more than ~10 lines, it's doing too much. Push logic down to the client layer.
 - **Shared mutable state**: Use `target_fixture` to pass state between steps, not module-level globals.
 - **Testing implementation, not behavior**: Scenarios should describe what the user experiences, not how the system works internally.
+
+## Writing a Test Extension
+
+VIP's extension mechanism lets you load custom test directories alongside the built-in suite:
+
+```bash
+vip verify --config vip.toml --extensions ./my-custom-tests
+```
+
+Or in `vip.toml`:
+
+```toml
+[general]
+extension_dirs = ["./my-custom-tests"]
+```
+
+Use `vip scaffold` to generate a ready-to-run reference implementation:
+
+```bash
+vip scaffold --output ./my-custom-tests
+```
+
+This creates `examples/cross_product_validation/` — a full GxP validation example that verifies
+R/Python runtime versions and package installability across Connect and Workbench. It follows the
+same four-layer architecture as the built-in suite.
+
+Two canonical examples ship with VIP:
+
+- `examples/custom_tests/` — minimal HTTP health-check (simplest possible extension)
+- `examples/cross_product_validation/` — cross-product runtime + package validation (GxP pattern)
+
+**Key requirement for auto-skip to work in extensions:** apply `@pytest.mark.connect` and/or
+`@pytest.mark.workbench` decorators directly on every `@scenario` function. Feature-level Gherkin
+tags (`@connect`, `@workbench`) alone are not sufficient for extensions — the pytest plugin's
+`_should_deselect_for_product` function keys off pytest markers set on the test item via
+`item.get_closest_marker()`, and Gherkin tags only flow into markers for the built-in step
+definitions that include a `Given <product> is accessible` step. Direct marker decoration is the
+reliable, portable mechanism.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -263,9 +263,11 @@ Two canonical examples ship with VIP:
 - `examples/cross_product_validation/` — cross-product runtime + package validation (GxP pattern)
 
 **Key requirement for auto-skip to work in extensions:** apply `@pytest.mark.connect` and/or
-`@pytest.mark.workbench` decorators directly on every `@scenario` function. Feature-level Gherkin
-tags (`@connect`, `@workbench`) alone are not sufficient for extensions — the pytest plugin's
-`_should_deselect_for_product` function keys off pytest markers set on the test item via
-`item.get_closest_marker()`, and Gherkin tags only flow into markers for the built-in step
-definitions that include a `Given <product> is accessible` step. Direct marker decoration is the
-reliable, portable mechanism.
+`@pytest.mark.workbench` decorators directly on every `@scenario` function. With pytest-bdd,
+scenario-level Gherkin tags (e.g. `@connect` on a `Scenario:` block) do become pytest markers and
+participate in auto-deselect via `item.get_closest_marker()`. However, feature-level tags apply to
+every scenario in the file — if you tag the whole `Feature:` with both `@connect` and `@workbench`,
+every scenario requires both products, which causes incorrect deselection when only one product is
+configured. The safe, portable pattern is to tag each `Scenario:` with only the product(s) it
+actually uses, or to apply `@pytest.mark.connect`/`@pytest.mark.workbench` directly on the
+`@scenario` decorator function in Python.

--- a/examples/cross_product_validation/README.md
+++ b/examples/cross_product_validation/README.md
@@ -1,0 +1,91 @@
+# Cross-product validation example
+
+This example demonstrates how to write a VIP test extension that verifies
+runtime version requirements and package installability across both Workbench
+and Connect. It is designed as a starting point for GxP deployments and other
+regulated environments that need to verify specific software configurations.
+
+Generate this directory from scratch using:
+
+```bash
+vip scaffold --output ./my-custom-tests
+```
+
+## What this example tests
+
+| Scenario | Product | Layer |
+|---|---|---|
+| Connect R versions match requirements | Connect API | httpx |
+| Connect Python versions match requirements | Connect API | httpx |
+| R package (DESeq2) is installable on Connect | Connect API + bundle deploy | httpx |
+| Python package (PyDeSEQ2) is installable on Connect | Connect API + bundle deploy | httpx |
+| R package installable in Workbench RStudio session | Workbench terminal | Playwright |
+
+## Running the example
+
+```bash
+# Run with a vip.toml that has both Connect and Workbench configured
+vip verify --config vip.toml --extensions ./cross_product_validation
+
+# Dry-run: collect tests without executing
+vip verify --config vip.toml --extensions ./cross_product_validation --collect-only
+
+# Skip the slow package-install scenarios
+# Edit conftest.py and set check_packages to return False
+```
+
+## Configuration
+
+Add a `[runtimes]` block to your `vip.toml` to specify the versions to check:
+
+```toml
+[runtimes]
+r_versions = ["4.4.0", "4.3.1"]
+python_versions = ["3.11.0", "3.10.0"]
+```
+
+Without a `[runtimes]` block, the version-check scenarios are skipped automatically.
+
+## Customizing
+
+### Change the packages being verified
+
+Edit `conftest.py` and override the `r_package_name` and `python_package_name` fixtures:
+
+```python
+@pytest.fixture(scope="session")
+def r_package_name() -> str:
+    return "ggplot2"
+
+@pytest.fixture(scope="session")
+def python_package_name() -> str:
+    return "pandas"
+```
+
+### Skip install checks
+
+Set `check_packages` to `False` in `conftest.py` when you only need
+runtime-version verification (much faster):
+
+```python
+@pytest.fixture(scope="session")
+def check_packages() -> bool:
+    return False
+```
+
+### Add more scenarios
+
+Follow VIP's four-layer test architecture:
+
+1. Add a `Scenario:` block to `test_gxp_validation.feature`
+2. Add step definitions in `test_gxp_validation.py`
+3. Add the `@pytest.mark.connect` or `@pytest.mark.workbench` decorator on the
+   `@scenario` function so auto-skip works correctly
+
+## Further reading
+
+- `src/vip_tests/connect/test_packages.py` — full Connect package source verification
+- `src/vip_tests/workbench/test_packages.py` — Workbench package install patterns
+- `src/vip_tests/workbench/exec.py` — `terminal_run`, `rstudio_eval` primitives
+- `docs/test-architecture.md` — VIP's four-layer test architecture guide
+- `examples/custom_tests/` — simpler HTTP health-check extension example

--- a/examples/cross_product_validation/README.md
+++ b/examples/cross_product_validation/README.md
@@ -17,7 +17,7 @@ vip scaffold --output ./my-custom-tests
 |---|---|---|
 | Connect R versions match requirements | Connect API | httpx |
 | Connect Python versions match requirements | Connect API | httpx |
-| R package (DESeq2) is installable on Connect | Connect API + bundle deploy | httpx |
+| R package (jsonlite) is installable on Connect | Connect API + bundle deploy | httpx |
 | Python package (PyDeSEQ2) is installable on Connect | Connect API + bundle deploy | httpx |
 | R package installable in Workbench RStudio session | Workbench terminal | Playwright |
 
@@ -25,10 +25,10 @@ vip scaffold --output ./my-custom-tests
 
 ```bash
 # Run with a vip.toml that has both Connect and Workbench configured
-vip verify --config vip.toml --extensions ./cross_product_validation
+vip verify --config vip.toml --extensions .
 
 # Dry-run: collect tests without executing
-vip verify --config vip.toml --extensions ./cross_product_validation --collect-only
+vip verify --config vip.toml --extensions . --collect-only
 
 # Skip the slow package-install scenarios
 # Edit conftest.py and set check_packages to return False

--- a/examples/cross_product_validation/conftest.py
+++ b/examples/cross_product_validation/conftest.py
@@ -1,0 +1,67 @@
+"""Fixtures for the cross-product GxP validation example.
+
+All VIP core fixtures (vip_config, connect_client, workbench_client,
+expected_r_versions, expected_python_versions, page, etc.) are available
+automatically via the VIP plugin.
+
+This conftest adds only the fixtures unique to this example:
+  - check_packages   -- set to False to skip slow install-verification scenarios
+  - r_package_name   -- the R package to verify (default: DESeq2)
+  - python_package_name -- the Python package to verify (default: PyDeSEQ2)
+
+Note: expected_r_versions and expected_python_versions are intentionally NOT
+redefined here. They are already provided by VIP's core conftest
+(src/vip_tests/conftest.py) and are wired to vip.toml [runtimes]. Redefining
+them here would silently shadow the config-driven versions.
+
+To populate these fixtures with real data, add a [runtimes] block to vip.toml:
+
+    [runtimes]
+    r_versions = ["4.4.0", "4.3.1"]
+    python_versions = ["3.11.0", "3.10.0"]
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def check_packages() -> bool:
+    """Control whether package install scenarios are executed.
+
+    Set to False to skip the slow DESeq2/PyDeSEQ2 install checks when you
+    only need runtime-version verification. Override in your own conftest.py:
+
+        @pytest.fixture(scope="session")
+        def check_packages() -> bool:
+            return False
+    """
+    return True
+
+
+@pytest.fixture(scope="session")
+def r_package_name() -> str:
+    """The R package to verify is installable on Connect and Workbench.
+
+    Defaults to DESeq2. Override in your own conftest.py to check a
+    different package:
+
+        @pytest.fixture(scope="session")
+        def r_package_name() -> str:
+            return "ggplot2"
+    """
+    return "DESeq2"
+
+
+@pytest.fixture(scope="session")
+def python_package_name() -> str:
+    """The Python package to verify is installable on Connect.
+
+    Defaults to PyDeSEQ2. Override in your own conftest.py:
+
+        @pytest.fixture(scope="session")
+        def python_package_name() -> str:
+            return "pandas"
+    """
+    return "PyDeSEQ2"

--- a/examples/cross_product_validation/conftest.py
+++ b/examples/cross_product_validation/conftest.py
@@ -6,7 +6,7 @@ automatically via the VIP plugin.
 
 This conftest adds only the fixtures unique to this example:
   - check_packages   -- set to False to skip slow install-verification scenarios
-  - r_package_name   -- the R package to verify (default: DESeq2)
+  - r_package_name   -- the R package to verify (default: jsonlite)
   - python_package_name -- the Python package to verify (default: PyDeSEQ2)
 
 Note: expected_r_versions and expected_python_versions are intentionally NOT
@@ -30,7 +30,7 @@ import pytest
 def check_packages() -> bool:
     """Control whether package install scenarios are executed.
 
-    Set to False to skip the slow DESeq2/PyDeSEQ2 install checks when you
+    Set to False to skip the slow package install checks when you
     only need runtime-version verification. Override in your own conftest.py:
 
         @pytest.fixture(scope="session")
@@ -44,14 +44,14 @@ def check_packages() -> bool:
 def r_package_name() -> str:
     """The R package to verify is installable on Connect and Workbench.
 
-    Defaults to DESeq2. Override in your own conftest.py to check a
-    different package:
+    Defaults to jsonlite (a standard CRAN package). Override in your own
+    conftest.py to check a different package:
 
         @pytest.fixture(scope="session")
         def r_package_name() -> str:
             return "ggplot2"
     """
-    return "DESeq2"
+    return "jsonlite"
 
 
 @pytest.fixture(scope="session")

--- a/examples/cross_product_validation/test_gxp_validation.feature
+++ b/examples/cross_product_validation/test_gxp_validation.feature
@@ -1,22 +1,24 @@
-@connect @workbench
 Feature: Cross-product runtime and package validation
   As a Posit Team administrator in a regulated environment
   I want to verify that specific R and Python versions are available
   And that key packages are installable across Workbench and Connect
   So that GxP and other compliance requirements are continuously met
 
+  @connect
   Scenario: Connect R versions match requirements
     Given Connect is accessible at the configured URL
     And expected R versions are specified in vip.toml
     When I query Connect for available R versions
     Then all expected R versions are present on Connect
 
+  @connect
   Scenario: Connect Python versions match requirements
     Given Connect is accessible at the configured URL
     And expected Python versions are specified in vip.toml
     When I query Connect for available Python versions
     Then all expected Python versions are present on Connect
 
+  @connect
   Scenario: R package is installable on Connect
     Given Connect is accessible at the configured URL
     And package install checks are enabled
@@ -24,6 +26,7 @@ Feature: Cross-product runtime and package validation
     Then the deployment succeeds
     And I clean up the deployed content
 
+  @connect
   Scenario: Python package is installable on Connect
     Given Connect is accessible at the configured URL
     And package install checks are enabled
@@ -31,6 +34,7 @@ Feature: Cross-product runtime and package validation
     Then the deployment succeeds
     And I clean up the deployed content
 
+  @workbench
   Scenario: R package is installable in Workbench RStudio session
     Given a Workbench RStudio session is open
     And package install checks are enabled

--- a/examples/cross_product_validation/test_gxp_validation.feature
+++ b/examples/cross_product_validation/test_gxp_validation.feature
@@ -1,0 +1,38 @@
+@connect @workbench
+Feature: Cross-product runtime and package validation
+  As a Posit Team administrator in a regulated environment
+  I want to verify that specific R and Python versions are available
+  And that key packages are installable across Workbench and Connect
+  So that GxP and other compliance requirements are continuously met
+
+  Scenario: Connect R versions match requirements
+    Given Connect is accessible at the configured URL
+    And expected R versions are specified in vip.toml
+    When I query Connect for available R versions
+    Then all expected R versions are present on Connect
+
+  Scenario: Connect Python versions match requirements
+    Given Connect is accessible at the configured URL
+    And expected Python versions are specified in vip.toml
+    When I query Connect for available Python versions
+    Then all expected Python versions are present on Connect
+
+  Scenario: R package is installable on Connect
+    Given Connect is accessible at the configured URL
+    And package install checks are enabled
+    When I deploy a minimal content item that installs the R package
+    Then the deployment succeeds
+    And I clean up the deployed content
+
+  Scenario: Python package is installable on Connect
+    Given Connect is accessible at the configured URL
+    And package install checks are enabled
+    When I deploy a minimal content item that installs the Python package
+    Then the deployment succeeds
+    And I clean up the deployed content
+
+  Scenario: R package is installable in Workbench RStudio session
+    Given a Workbench RStudio session is open
+    And package install checks are enabled
+    When I install the R package in the terminal
+    Then the installation succeeds

--- a/examples/cross_product_validation/test_gxp_validation.py
+++ b/examples/cross_product_validation/test_gxp_validation.py
@@ -2,7 +2,7 @@
 
 Demonstrates how to write a VIP test extension that:
 - Verifies specific R/Python versions are available on Connect
-- Verifies that key packages (DESeq2, PyDeSEQ2) are installable on Connect
+- Verifies that key packages (jsonlite, PyDeSEQ2) are installable on Connect
 - Verifies package installation in a live Workbench RStudio session
 
 This file uses VIP's four-layer architecture:
@@ -148,9 +148,9 @@ _PLUMBER_R = '#* @get /\nfunction() list(status = "ok")\n'
 
 @when(
     "I deploy a minimal content item that installs the R package",
-    target_fixture="r_deploy_state",
+    target_fixture="deploy_state",
 )
-def deploy_r_package(connect_client, r_package_name):
+def deploy_r_package(connect_client, r_package_name, vip_config):
     content_name = f"vip_test_r_pkg_{r_package_name.lower()}_check"
     content = connect_client.create_content(
         content_name,
@@ -166,8 +166,22 @@ def deploy_r_package(connect_client, r_package_name):
     }
     bundle_bytes = _make_tar_gz(bundle_files)
     bundle = connect_client.upload_bundle(guid, bundle_bytes)
-    connect_client.deploy_bundle(guid, bundle["id"])
-    return {"guid": guid}
+    result = connect_client.deploy_bundle(guid, bundle["id"])
+    task_id = result["task_id"]
+
+    timeout = vip_config.connect.deploy_timeout
+    task = connect_client.wait_for_task(task_id, timeout=timeout)
+    if not task.get("finished"):
+        output = "\n".join(task.get("output", []))
+        pytest.fail(
+            f"Deployment did not complete within {timeout} seconds\n\n--- Task output ---\n{output}"
+        )
+    if task.get("code") != 0:
+        output = "\n".join(task.get("output", []))
+        error = task.get("error", "unknown error")
+        pytest.fail(f"Deployment failed: {error}\n\n--- Task output ---\n{output}")
+
+    return {"guid": guid, "task_result": task}
 
 
 def _python_package_manifest(package_name: str) -> str:
@@ -195,9 +209,9 @@ _FLASK_APP_PY = (
 
 @when(
     "I deploy a minimal content item that installs the Python package",
-    target_fixture="python_deploy_state",
+    target_fixture="deploy_state",
 )
-def deploy_python_package(connect_client, python_package_name):
+def deploy_python_package(connect_client, python_package_name, vip_config):
     content_name = f"vip_test_py_pkg_{python_package_name.lower()}_check"
     content = connect_client.create_content(
         content_name,
@@ -213,8 +227,22 @@ def deploy_python_package(connect_client, python_package_name):
     }
     bundle_bytes = _make_tar_gz(bundle_files)
     bundle = connect_client.upload_bundle(guid, bundle_bytes)
-    connect_client.deploy_bundle(guid, bundle["id"])
-    return {"guid": guid}
+    result = connect_client.deploy_bundle(guid, bundle["id"])
+    task_id = result["task_id"]
+
+    timeout = vip_config.connect.deploy_timeout
+    task = connect_client.wait_for_task(task_id, timeout=timeout)
+    if not task.get("finished"):
+        output = "\n".join(task.get("output", []))
+        pytest.fail(
+            f"Deployment did not complete within {timeout} seconds\n\n--- Task output ---\n{output}"
+        )
+    if task.get("code") != 0:
+        output = "\n".join(task.get("output", []))
+        error = task.get("error", "unknown error")
+        pytest.fail(f"Deployment failed: {error}\n\n--- Task output ---\n{output}")
+
+    return {"guid": guid, "task_result": task}
 
 
 @when(
@@ -249,14 +277,15 @@ def python_versions_present(expected_python_versions, available_python):
 
 
 @then("the deployment succeeds")
-def deployment_succeeds(r_deploy_state, connect_client):
-    # connect_client.deploy_bundle raises on failure; reaching here means success.
-    assert r_deploy_state.get("guid"), "No GUID recorded for deployed content"
+def deployment_succeeds(deploy_state):
+    # deploy_bundle raises on task failure (handled in the When step);
+    # reaching here means the deployment completed successfully.
+    assert deploy_state.get("guid"), "No GUID recorded for deployed content"
 
 
 @then("I clean up the deployed content")
-def cleanup_deployed_content(r_deploy_state, connect_client):
-    guid = r_deploy_state.get("guid")
+def cleanup_deployed_content(deploy_state, connect_client):
+    guid = deploy_state.get("guid")
     if guid:
         connect_client.cleanup_content([guid])
 
@@ -266,6 +295,6 @@ def r_install_succeeds(install_output, r_package_name):
     # Rscript exits 0 on success. If the package was not found or install
     # failed, the output typically contains "ERROR" or "Warning message".
     lowered = install_output.lower()
-    assert "error" not in lowered or "warning" in lowered, (
+    assert "error" not in lowered and "warning" not in lowered, (
         f"R package installation may have failed. Output:\n{install_output}"
     )

--- a/examples/cross_product_validation/test_gxp_validation.py
+++ b/examples/cross_product_validation/test_gxp_validation.py
@@ -1,0 +1,271 @@
+"""Step definitions for cross-product GxP validation example.
+
+Demonstrates how to write a VIP test extension that:
+- Verifies specific R/Python versions are available on Connect
+- Verifies that key packages (DESeq2, PyDeSEQ2) are installable on Connect
+- Verifies package installation in a live Workbench RStudio session
+
+This file uses VIP's four-layer architecture:
+  Layer 1: feature file (Gherkin)
+  Layer 2: these step definitions + conftest fixtures
+  Layer 3: ConnectClient / Playwright page from VIP core
+  Layer 4: httpx (API) / Playwright (browser)
+
+To run this extension:
+  vip verify --config vip.toml --extensions /path/to/cross_product_validation
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from vip_tests.workbench.exec import terminal_run
+
+# ---------------------------------------------------------------------------
+# Scenarios — each carries explicit pytest markers for auto-skip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.connect
+@scenario("test_gxp_validation.feature", "Connect R versions match requirements")
+def test_connect_r_versions():
+    pass
+
+
+@pytest.mark.connect
+@scenario("test_gxp_validation.feature", "Connect Python versions match requirements")
+def test_connect_python_versions():
+    pass
+
+
+@pytest.mark.connect
+@scenario("test_gxp_validation.feature", "R package is installable on Connect")
+def test_connect_r_package():
+    pass
+
+
+@pytest.mark.connect
+@scenario("test_gxp_validation.feature", "Python package is installable on Connect")
+def test_connect_python_package():
+    pass
+
+
+@pytest.mark.workbench
+@scenario(
+    "test_gxp_validation.feature",
+    "R package is installable in Workbench RStudio session",
+)
+def test_workbench_r_package():
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Given steps
+# ---------------------------------------------------------------------------
+
+
+@given("Connect is accessible at the configured URL")
+def connect_accessible(connect_client):
+    assert connect_client is not None, "Connect client not configured"
+    status = connect_client.health()
+    assert status < 400, f"Connect returned HTTP {status}"
+
+
+@given("expected R versions are specified in vip.toml")
+def r_versions_specified(expected_r_versions):
+    if not expected_r_versions:
+        pytest.skip("No expected R versions specified in vip.toml [runtimes]")
+
+
+@given("expected Python versions are specified in vip.toml")
+def python_versions_specified(expected_python_versions):
+    if not expected_python_versions:
+        pytest.skip("No expected Python versions specified in vip.toml [runtimes]")
+
+
+@given("package install checks are enabled")
+def package_checks_enabled(check_packages):
+    if not check_packages:
+        pytest.skip("Package install checks skipped (check_packages=False in conftest.py)")
+
+
+@given("a Workbench RStudio session is open")
+def workbench_session_open(page):
+    # The `page` fixture is provided by VIP core when Workbench is configured.
+    assert page is not None, "Workbench browser session not available"
+
+
+# ---------------------------------------------------------------------------
+# When steps
+# ---------------------------------------------------------------------------
+
+
+@when("I query Connect for available R versions", target_fixture="available_r")
+def query_r_versions(connect_client):
+    return connect_client.r_versions()
+
+
+@when("I query Connect for available Python versions", target_fixture="available_python")
+def query_python_versions(connect_client):
+    return connect_client.python_versions()
+
+
+def _make_tar_gz(files: dict[str, str]) -> bytes:
+    """Create an in-memory tar.gz archive from a dict of {filename: content}."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _r_package_manifest(package_name: str) -> str:
+    """Return a minimal Connect bundle manifest for an R package install check."""
+    return json.dumps(
+        {
+            "version": 1,
+            "locale": "en_US",
+            "platform": "4.4.0",
+            "metadata": {"appmode": "api", "primary_rmd": None, "primary_html": None},
+            "packages": {
+                package_name: {"Source": "CRAN", "Repository": "https://cran.r-project.org"}
+            },
+            "files": {"plumber.R": {"checksum": ""}},
+        }
+    )
+
+
+_PLUMBER_R = '#* @get /\nfunction() list(status = "ok")\n'
+
+
+@when(
+    "I deploy a minimal content item that installs the R package",
+    target_fixture="r_deploy_state",
+)
+def deploy_r_package(connect_client, r_package_name):
+    content_name = f"vip_test_r_pkg_{r_package_name.lower()}_check"
+    content = connect_client.create_content(
+        content_name,
+        description=f"VIP package install check for {r_package_name}",
+        access_type="acl",
+        tags=["_vip_test"],
+    )
+    guid = content["guid"]
+
+    bundle_files = {
+        "plumber.R": _PLUMBER_R,
+        "manifest.json": _r_package_manifest(r_package_name),
+    }
+    bundle_bytes = _make_tar_gz(bundle_files)
+    bundle = connect_client.upload_bundle(guid, bundle_bytes)
+    connect_client.deploy_bundle(guid, bundle["id"])
+    return {"guid": guid}
+
+
+def _python_package_manifest(package_name: str) -> str:
+    """Return a minimal Connect bundle manifest for a Python package install check."""
+    return json.dumps(
+        {
+            "version": 1,
+            "locale": "en_US",
+            "metadata": {"appmode": "python-api", "entry_point": "app:app"},
+            "python": {"version": "3.11.0", "package_manager": {"name": "pip", "version": "24.0"}},
+            "packages": {package_name: {"Source": "PyPI", "Version": "latest"}},
+            "files": {"app.py": {"checksum": ""}},
+        }
+    )
+
+
+_FLASK_APP_PY = (
+    "from flask import Flask\n"
+    "app = Flask(__name__)\n\n"
+    '@app.route("/")\n'
+    "def index():\n"
+    '    return {"status": "ok"}\n'
+)
+
+
+@when(
+    "I deploy a minimal content item that installs the Python package",
+    target_fixture="python_deploy_state",
+)
+def deploy_python_package(connect_client, python_package_name):
+    content_name = f"vip_test_py_pkg_{python_package_name.lower()}_check"
+    content = connect_client.create_content(
+        content_name,
+        description=f"VIP package install check for {python_package_name}",
+        access_type="acl",
+        tags=["_vip_test"],
+    )
+    guid = content["guid"]
+
+    bundle_files = {
+        "app.py": _FLASK_APP_PY,
+        "manifest.json": _python_package_manifest(python_package_name),
+    }
+    bundle_bytes = _make_tar_gz(bundle_files)
+    bundle = connect_client.upload_bundle(guid, bundle_bytes)
+    connect_client.deploy_bundle(guid, bundle["id"])
+    return {"guid": guid}
+
+
+@when(
+    "I install the R package in the terminal",
+    target_fixture="install_output",
+)
+def install_r_package_workbench(page, r_package_name):
+    cmd = (
+        f"Rscript -e \"install.packages('{r_package_name}', "
+        f"repos='https://cran.r-project.org', quiet=TRUE)\" 2>&1 || true"
+    )
+    return terminal_run(page, cmd, timeout=120_000)
+
+
+# ---------------------------------------------------------------------------
+# Then steps
+# ---------------------------------------------------------------------------
+
+
+@then("all expected R versions are present on Connect")
+def r_versions_present(expected_r_versions, available_r):
+    missing = [v for v in expected_r_versions if v not in available_r]
+    assert not missing, f"Missing R versions on Connect: {missing}. Available: {available_r}"
+
+
+@then("all expected Python versions are present on Connect")
+def python_versions_present(expected_python_versions, available_python):
+    missing = [v for v in expected_python_versions if v not in available_python]
+    assert not missing, (
+        f"Missing Python versions on Connect: {missing}. Available: {available_python}"
+    )
+
+
+@then("the deployment succeeds")
+def deployment_succeeds(r_deploy_state, connect_client):
+    # connect_client.deploy_bundle raises on failure; reaching here means success.
+    assert r_deploy_state.get("guid"), "No GUID recorded for deployed content"
+
+
+@then("I clean up the deployed content")
+def cleanup_deployed_content(r_deploy_state, connect_client):
+    guid = r_deploy_state.get("guid")
+    if guid:
+        connect_client.cleanup_content([guid])
+
+
+@then("the installation succeeds")
+def r_install_succeeds(install_output, r_package_name):
+    # Rscript exits 0 on success. If the package was not found or install
+    # failed, the output typically contains "ERROR" or "Warning message".
+    lowered = install_output.lower()
+    assert "error" not in lowered or "warning" in lowered, (
+        f"R package installation may have failed. Output:\n{install_output}"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/vip", "src/vip_tests"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"examples/cross_product_validation" = "vip/_scaffold/cross_product_validation"
+
 [tool.pytest.ini_options]
 testpaths = ["src/vip_tests"]
 addopts = "-n auto --dist loadgroup"

--- a/selftests/test_cli_scaffold.py
+++ b/selftests/test_cli_scaffold.py
@@ -1,0 +1,167 @@
+"""Tests for the ``vip scaffold`` subcommand (run_scaffold in vip.cli)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    """Build a minimal args namespace for run_scaffold."""
+    defaults = {
+        "output": "./custom_tests",
+        "force": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestScaffoldCreatesExpectedFiles:
+    """run_scaffold copies the expected files to the output directory."""
+
+    def test_scaffold_creates_feature_file(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        assert (dest / "test_gxp_validation.feature").is_file()
+
+    def test_scaffold_creates_step_definitions(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        assert (dest / "test_gxp_validation.py").is_file()
+
+    def test_scaffold_creates_conftest(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        assert (dest / "conftest.py").is_file()
+
+    def test_scaffold_creates_readme(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        assert (dest / "README.md").is_file()
+
+
+class TestScaffoldFileContent:
+    """Scaffolded files have the expected content for auto-skip and VIP patterns."""
+
+    def test_feature_file_has_connect_workbench_tags(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        feature_text = (dest / "test_gxp_validation.feature").read_text()
+        assert "@connect" in feature_text
+        assert "@workbench" in feature_text
+
+    def test_step_file_imports_pytest_bdd(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        step_text = (dest / "test_gxp_validation.py").read_text()
+        assert "from pytest_bdd import" in step_text
+
+    def test_step_file_has_pytest_mark_connect(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        step_text = (dest / "test_gxp_validation.py").read_text()
+        assert "pytest.mark.connect" in step_text
+
+    def test_step_file_has_pytest_mark_workbench(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        step_text = (dest / "test_gxp_validation.py").read_text()
+        assert "pytest.mark.workbench" in step_text
+
+    def test_conftest_defines_check_packages(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        conftest_text = (dest / "conftest.py").read_text()
+        assert "check_packages" in conftest_text
+
+    def test_conftest_does_not_shadow_expected_r_versions(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        run_scaffold(_make_args(output=str(dest)))
+
+        conftest_text = (dest / "conftest.py").read_text()
+        # Must NOT redefine these — they are provided by VIP core conftest
+        assert "def expected_r_versions" not in conftest_text
+        assert "def expected_python_versions" not in conftest_text
+
+
+class TestScaffoldOverwriteBehavior:
+    """Overwrite behavior: --force flag controls whether existing dest is replaced."""
+
+    def test_scaffold_fails_if_dest_exists_without_force(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        dest.mkdir()
+        (dest / "existing.txt").write_text("keep me")
+
+        import pytest
+
+        with pytest.raises(SystemExit):
+            run_scaffold(_make_args(output=str(dest), force=False))
+
+        # Original file should still be present (not clobbered)
+        assert (dest / "existing.txt").is_file()
+
+    def test_scaffold_overwrites_with_force(self, tmp_path):
+        from vip.cli import run_scaffold
+
+        dest = tmp_path / "my_tests"
+        dest.mkdir()
+        (dest / "stale.txt").write_text("old content")
+
+        run_scaffold(_make_args(output=str(dest), force=True))
+
+        # Stale file should be gone; scaffold files present
+        assert not (dest / "stale.txt").exists()
+        assert (dest / "test_gxp_validation.feature").is_file()
+
+
+class TestScaffoldCLI:
+    """``vip scaffold`` appears in the CLI help and produces a valid output."""
+
+    def test_scaffold_in_cli_help(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "vip.cli", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert "scaffold" in result.stdout
+
+    def test_scaffold_subcommand_help(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "vip.cli", "scaffold", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--output" in result.stdout

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -940,20 +940,34 @@ def run_uninstall(args: argparse.Namespace) -> None:
 
 def run_scaffold(args: argparse.Namespace) -> None:
     """Copy the cross_product_validation example to a user-specified directory."""
+    import importlib.resources
     import shutil
 
-    src = Path(__file__).parent.parent.parent / "examples" / "cross_product_validation"
-    if not src.is_dir():
-        # Installed package: examples live alongside the package source.
-        # Fall back to a path relative to the installed package location.
-        import vip as _vip_pkg
+    # Prefer the bundled copy inside the installed wheel (_scaffold/ is embedded
+    # via [tool.hatch.build.targets.wheel.force-include]).  Fall back to the
+    # repo's top-level examples/ directory so in-repo usage and selftests work
+    # without building a wheel first.
+    src: Path | None = None
+    try:
+        scaffold_pkg = importlib.resources.files("vip") / "_scaffold" / "cross_product_validation"
+        # files() returns a Traversable; we need a real Path for shutil.copytree.
+        with importlib.resources.as_file(scaffold_pkg) as p:
+            if p.is_dir():
+                src = p
+    except (TypeError, FileNotFoundError):
+        pass
 
-        src = Path(_vip_pkg.__file__).parent.parent / "examples" / "cross_product_validation"
+    if src is None:
+        # Source checkout: three levels up from src/vip/cli.py → repo root.
+        repo_root = Path(__file__).parent.parent.parent
+        candidate = repo_root / "examples" / "cross_product_validation"
+        if candidate.is_dir():
+            src = candidate
 
-    if not src.is_dir():
+    if src is None:
         print(
             "Error: could not locate examples/cross_product_validation/. "
-            "Ensure VIP is installed from source or with the examples included.",
+            "Ensure VIP is installed from source or as a wheel built with examples.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -967,20 +981,23 @@ def run_scaffold(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     if dest.exists():
-        shutil.rmtree(dest)
+        if dest.is_dir() and not dest.is_symlink():
+            shutil.rmtree(dest)
+        else:
+            dest.unlink()
 
     shutil.copytree(src, dest)
     print(f"Scaffolded extension to: {dest}")
     print(
         f"\nNext steps:\n"
-        f"  1. Edit {dest}/conftest.py to set your package names and versions.\n"
+        f"  1. Edit {dest / 'conftest.py'} to set your package names and versions.\n"
         f"  2. Add a [runtimes] block to vip.toml:\n"
         f"       [runtimes]\n"
         f'       r_versions = ["4.4.0"]\n'
         f'       python_versions = ["3.11.0"]\n'
         f"  3. Run the extension:\n"
         f"       vip verify --config vip.toml --extensions {dest}\n"
-        f"\nSee {dest}/README.md for full customization instructions."
+        f"\nSee {dest / 'README.md'} for full customization instructions."
     )
 
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -938,6 +938,52 @@ def run_uninstall(args: argparse.Namespace) -> None:
     sys.exit(rc)
 
 
+def run_scaffold(args: argparse.Namespace) -> None:
+    """Copy the cross_product_validation example to a user-specified directory."""
+    import shutil
+
+    src = Path(__file__).parent.parent.parent / "examples" / "cross_product_validation"
+    if not src.is_dir():
+        # Installed package: examples live alongside the package source.
+        # Fall back to a path relative to the installed package location.
+        import vip as _vip_pkg
+
+        src = Path(_vip_pkg.__file__).parent.parent / "examples" / "cross_product_validation"
+
+    if not src.is_dir():
+        print(
+            "Error: could not locate examples/cross_product_validation/. "
+            "Ensure VIP is installed from source or with the examples included.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    dest = Path(args.output)
+    if dest.exists() and not args.force:
+        print(
+            f"Error: destination already exists: {dest}\nPass --force to overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if dest.exists():
+        shutil.rmtree(dest)
+
+    shutil.copytree(src, dest)
+    print(f"Scaffolded extension to: {dest}")
+    print(
+        f"\nNext steps:\n"
+        f"  1. Edit {dest}/conftest.py to set your package names and versions.\n"
+        f"  2. Add a [runtimes] block to vip.toml:\n"
+        f"       [runtimes]\n"
+        f'       r_versions = ["4.4.0"]\n'
+        f'       python_versions = ["3.11.0"]\n'
+        f"  3. Run the extension:\n"
+        f"       vip verify --config vip.toml --extensions {dest}\n"
+        f"\nSee {dest}/README.md for full customization instructions."
+    )
+
+
 def run_cleanup(args: argparse.Namespace) -> None:
     """Delete VIP test credentials and resources.
 
@@ -1377,6 +1423,35 @@ def main() -> None:
     )
     status_parser.set_defaults(func=run_status)
 
+    # vip scaffold
+    scaffold_parser = subparsers.add_parser(
+        "scaffold",
+        help="Generate a ready-to-run custom test extension directory",
+        description=(
+            "Copy the cross_product_validation example to a new directory, ready to\n"
+            "customise and run with:\n\n"
+            "  vip verify --config vip.toml --extensions <output-dir>\n\n"
+            "The example verifies specific R/Python runtime versions and package\n"
+            "installability across Workbench and Connect. Edit the generated\n"
+            "conftest.py to set your own package names and version requirements.\n\n"
+            "See vip.toml.example for the [runtimes] block you need to populate."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    scaffold_parser.add_argument(
+        "--output",
+        default="./custom_tests",
+        metavar="DIR",
+        help="Destination directory for the scaffolded extension (default: ./custom_tests)",
+    )
+    scaffold_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite destination if it already exists",
+    )
+    scaffold_parser.set_defaults(func=run_scaffold)
+
     # vip app
     app_parser = subparsers.add_parser(
         "app",
@@ -1408,6 +1483,7 @@ def main() -> None:
         "report": report_parser,
         "status": status_parser,
         "app": app_parser,
+        "scaffold": scaffold_parser,
     }
 
     argv = _reorder_help_args(sys.argv[1:], set(subcommand_parsers))

--- a/validation_docs/demo-custom-extension-example.md
+++ b/validation_docs/demo-custom-extension-example.md
@@ -8,8 +8,9 @@ This PR adds two things to VIP:
 1. A new `vip scaffold` CLI subcommand that copies a reference cross-product validation
    example to a user-specified directory.
 2. The reference example itself at `examples/cross_product_validation/`, which verifies
-   R/Python runtime versions and DESeq2/PyDeSEQ2 package installability across Connect
-   and Workbench — the pattern GxP deployments and other regulated environments need.
+   R/Python runtime versions and package installability (jsonlite/PyDeSEQ2 by default,
+   overridable) across Connect and Workbench — the pattern GxP deployments and other
+   regulated environments need.
 
 Selftests at `selftests/test_cli_scaffold.py` verify the scaffold command output.
 
@@ -73,7 +74,7 @@ test_gxp_validation.py
 ```
 
 ```bash
-uv run pytest --vip-config=/tmp/claude/vip-test.toml --vip-extensions=/tmp/claude/scaffold-demo --collect-only -q 2>&1 | grep -E 'test_gxp|collected'
+uv run pytest --vip-config=/tmp/claude/vip-test.toml --vip-extensions=/tmp/claude/scaffold-demo --collect-only -q 2>&1 | grep -E 'test_gxp|collected' | sed 's/ in [0-9.]*s//'
 ```
 
 ```output
@@ -82,7 +83,7 @@ test_gxp_validation.py::test_connect_python_versions
 test_gxp_validation.py::test_connect_r_package
 test_gxp_validation.py::test_connect_python_package
 test_gxp_validation.py::test_workbench_r_package
-93/121 tests collected (28 deselected) in 0.07s
+93/121 tests collected (28 deselected)
 ```
 
 ```bash

--- a/validation_docs/demo-custom-extension-example.md
+++ b/validation_docs/demo-custom-extension-example.md
@@ -1,0 +1,120 @@
+# feat(examples): add custom test extension example and vip scaffold (closes #298)
+
+*2026-06-11T18:20:12Z by Showboat 0.6.1*
+<!-- showboat-id: 94a56b1b-51f2-4ad3-9e74-7749b60bd31a -->
+
+This PR adds two things to VIP:
+
+1. A new `vip scaffold` CLI subcommand that copies a reference cross-product validation
+   example to a user-specified directory.
+2. The reference example itself at `examples/cross_product_validation/`, which verifies
+   R/Python runtime versions and DESeq2/PyDeSEQ2 package installability across Connect
+   and Workbench — the pattern GxP deployments and other regulated environments need.
+
+Selftests at `selftests/test_cli_scaffold.py` verify the scaffold command output.
+
+```bash
+uv run vip --help 2>&1 | grep -E 'scaffold|verify'
+```
+
+```output
+           {auth,verify,cleanup,install,uninstall,cluster,report,status,scaffold,app}
+  {auth,verify,cleanup,install,uninstall,cluster,report,status,scaffold,app}
+    verify              Run VIP tests against a Posit Team deployment
+    scaffold            Generate a ready-to-run custom test extension
+```
+
+```bash
+uv run vip scaffold --help
+```
+
+```output
+usage: vip scaffold [-h] [--output DIR] [--force]
+
+Copy the cross_product_validation example to a new directory, ready to
+customise and run with:
+
+  vip verify --config vip.toml --extensions <output-dir>
+
+The example verifies specific R/Python runtime versions and package
+installability across Workbench and Connect. Edit the generated
+conftest.py to set your own package names and version requirements.
+
+See vip.toml.example for the [runtimes] block you need to populate.
+
+options:
+  -h, --help    show this help message and exit
+  --output DIR  Destination directory for the scaffolded extension (default:
+                ./custom_tests)
+  --force       Overwrite destination if it already exists
+```
+
+```bash
+uv run vip scaffold --output /tmp/claude/scaffold-demo --force && ls /tmp/claude/scaffold-demo
+```
+
+```output
+Scaffolded extension to: /tmp/claude/scaffold-demo
+
+Next steps:
+  1. Edit /tmp/claude/scaffold-demo/conftest.py to set your package names and versions.
+  2. Add a [runtimes] block to vip.toml:
+       [runtimes]
+       r_versions = ["4.4.0"]
+       python_versions = ["3.11.0"]
+  3. Run the extension:
+       vip verify --config vip.toml --extensions /tmp/claude/scaffold-demo
+
+See /tmp/claude/scaffold-demo/README.md for full customization instructions.
+conftest.py
+README.md
+test_gxp_validation.feature
+test_gxp_validation.py
+```
+
+```bash
+uv run pytest --vip-config=/tmp/claude/vip-test.toml --vip-extensions=/tmp/claude/scaffold-demo --collect-only -q 2>&1 | grep -E 'test_gxp|collected'
+```
+
+```output
+test_gxp_validation.py::test_connect_r_versions
+test_gxp_validation.py::test_connect_python_versions
+test_gxp_validation.py::test_connect_r_package
+test_gxp_validation.py::test_connect_python_package
+test_gxp_validation.py::test_workbench_r_package
+93/121 tests collected (28 deselected) in 0.07s
+```
+
+```bash
+uv run pytest selftests/test_cli_scaffold.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+14 passed
+```
+
+```bash
+uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+712 passed, 3 skipped, 20 warnings
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && echo 'ruff check: OK'
+```
+
+```output
+All checks passed!
+ruff check: OK
+```
+
+```bash
+uv run ruff format --check src/ src/vip_tests/ selftests/ examples/ && echo 'ruff format: OK'
+```
+
+```output
+148 files already formatted
+ruff format: OK
+```


### PR DESCRIPTION
## Summary

- Adds `vip scaffold` CLI subcommand that copies `examples/cross_product_validation/` to a user-specified directory, giving users a ready-to-run extension they can customise without copy-pasting boilerplate
- Adds `examples/cross_product_validation/` — a GxP/regulated-environment reference implementation that verifies specific R/Python runtime versions on Connect and confirms DESeq2/PyDeSEQ2 are installable on Connect and in a Workbench RStudio session
- Adds `selftests/test_cli_scaffold.py` with 14 tests covering file presence, content checks (auto-skip tags, pytest_bdd imports, fixture naming safety), overwrite behavior, and CLI discoverability
- Updates `AGENTS.md` and `docs/test-architecture.md` with extension authoring guidance

This re-drives the failed `implement-plan` run for the merged plan PR #299.

Closes #298

## Test plan

- [x] `uv run pytest selftests/ -q` — 712 passed, 3 skipped
- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/` — all checks passed
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/` — 148 files already formatted
- [x] Extension tests collect via `--vip-extensions` when Connect/Workbench are configured in vip.toml
- [x] `vip scaffold --help` shows `--output` and `--force` options
- [x] `vip --help` lists `scaffold` as a subcommand

## Demo

```bash
uv run vip --help 2>&1 | grep -E 'scaffold|verify'
```

```output
           {auth,verify,cleanup,install,uninstall,cluster,report,status,scaffold,app}
  {auth,verify,cleanup,install,uninstall,cluster,report,status,scaffold,app}
    verify              Run VIP tests against a Posit Team deployment
    scaffold            Generate a ready-to-run custom test extension
```

```bash
uv run vip scaffold --output /tmp/claude/scaffold-demo --force && ls /tmp/claude/scaffold-demo
```

```output
Scaffolded extension to: /tmp/claude/scaffold-demo

conftest.py
README.md
test_gxp_validation.feature
test_gxp_validation.py
```

```bash
uv run pytest --vip-config=vip.toml --vip-extensions=/tmp/claude/scaffold-demo --collect-only -q 2>&1 | grep 'test_gxp'
```

```output
test_gxp_validation.py::test_connect_r_versions
test_gxp_validation.py::test_connect_python_versions
test_gxp_validation.py::test_connect_r_package
test_gxp_validation.py::test_connect_python_package
test_gxp_validation.py::test_workbench_r_package
```

```bash
uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed' | sed 's/ in [0-9.]*s//'
```

```output
712 passed, 3 skipped, 20 warnings
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/ && echo 'lint: OK'
```

```output
All checks passed!
148 files already formatted
lint: OK
```