### PR TITLE
ci: fix agentic workflow tooling and screenshot PR detection

### DIFF
--- a/.github/workflows/implement-plan.lock.yml
+++ b/.github/workflows/implement-plan.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ef49fd61fa6be1103adaccd9fc1d09010ba7fcc8bbaa054ea5ccc44cc7712161","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8902a769147a4c5dbcec65b9c09926a0cf95c8c21f560487d0588a5bb7942491","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"fac544c07dec837d0ccb6301d7b5580bf5edae39","version":"fac544c07dec837d0ccb6301d7b5580bf5edae39"},{"repo":"extractions/setup-just","sha":"53165ef7e734c5c07cb06b3c8e7b647c5aa16db3","version":"53165ef7e734c5c07cb06b3c8e7b647c5aa16db3"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -40,6 +40,8 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+#   - astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # fac544c07dec837d0ccb6301d7b5580bf5edae39
+#   - extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # 53165ef7e734c5c07cb06b3c8e7b647c5aa16db3
 #   - github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
 #
 # Container images used:
@@ -207,23 +209,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e8173f4cc09cc297_EOF'
+          cat << 'GH_AW_PROMPT_34fb4fcb4b1bd387_EOF'
           <system>
-          GH_AW_PROMPT_e8173f4cc09cc297_EOF
+          GH_AW_PROMPT_34fb4fcb4b1bd387_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e8173f4cc09cc297_EOF'
+          cat << 'GH_AW_PROMPT_34fb4fcb4b1bd387_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_pull_request, add_labels, remove_labels, missing_tool, missing_data, noop
-          GH_AW_PROMPT_e8173f4cc09cc297_EOF
+          GH_AW_PROMPT_34fb4fcb4b1bd387_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_e8173f4cc09cc297_EOF'
+          cat << 'GH_AW_PROMPT_34fb4fcb4b1bd387_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_e8173f4cc09cc297_EOF
+          GH_AW_PROMPT_34fb4fcb4b1bd387_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_e8173f4cc09cc297_EOF'
+          cat << 'GH_AW_PROMPT_34fb4fcb4b1bd387_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -252,12 +254,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e8173f4cc09cc297_EOF
+          GH_AW_PROMPT_34fb4fcb4b1bd387_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e8173f4cc09cc297_EOF'
+          cat << 'GH_AW_PROMPT_34fb4fcb4b1bd387_EOF'
           </system>
           {{#runtime-import .github/workflows/implement-plan.md}}
-          GH_AW_PROMPT_e8173f4cc09cc297_EOF
+          GH_AW_PROMPT_34fb4fcb4b1bd387_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -398,6 +400,13 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          enable-cache: true
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # 53165ef7e734c5c07cb06b3c8e7b647c5aa16db3
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -476,9 +485,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_80a38afaa86ffdd9_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5be96a000b5e1dfb_EOF'
           {"add_comment":{"max":2,"target":"*"},"add_labels":{"allowed":["implementing"],"max":1,"target":"*"},"create_pull_request":{"branch_prefix":"bot-","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["plan-pending-review"],"max":1,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_80a38afaa86ffdd9_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5be96a000b5e1dfb_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -754,7 +763,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_70a02666ed10864b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_db39d7d6e3384dc3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -782,7 +791,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_70a02666ed10864b_EOF
+          GH_AW_MCP_CONFIG_db39d7d6e3384dc3_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/implement-plan.md
+++ b/.github/workflows/implement-plan.md
@@ -56,6 +56,13 @@ safe-outputs:
     branch-prefix: "bot-"
     draft: false
     max: 1
+steps:
+  - name: Install uv
+    uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+    with:
+      enable-cache: true
+  - name: Install just
+    uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 network:
   allowed:
     - defaults

--- a/.github/workflows/preview-screenshot-gallery.lock.yml
+++ b/.github/workflows/preview-screenshot-gallery.lock.yml
@@ -186,6 +186,8 @@ jobs:
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
+          GH_AW_GITHUB_EVENT_WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          GH_AW_GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -250,6 +252,8 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_ENGINE_ID: "copilot"
+          GH_AW_GITHUB_EVENT_WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          GH_AW_GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -265,6 +269,8 @@ jobs:
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
+          GH_AW_GITHUB_EVENT_WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          GH_AW_GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -286,6 +292,8 @@ jobs:
                 GH_AW_EXPR_802A9F6A: process.env.GH_AW_EXPR_802A9F6A,
                 GH_AW_EXPR_FF1D34CE: process.env.GH_AW_EXPR_FF1D34CE,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
+                GH_AW_GITHUB_EVENT_WORKFLOW_RUN_EVENT: process.env.GH_AW_GITHUB_EVENT_WORKFLOW_RUN_EVENT,
+                GH_AW_GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: process.env.GH_AW_GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,

--- a/.github/workflows/preview-screenshot-gallery.lock.yml
+++ b/.github/workflows/preview-screenshot-gallery.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"eba931a0fac48fb0426213ae954e470679ae2acab1223764fb1ef8835248d02e","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0e2bd5f6af12e07774dad1415332195a42cb9c667b8508d674df9f3b0476d451","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","POSIT_VIP_TRIAGE_CLIENT_ID","POSIT_VIP_TRIAGE_PEM"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -195,23 +195,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b66cdd770b70470c_EOF'
+          cat << 'GH_AW_PROMPT_4dae93561d70d100_EOF'
           <system>
-          GH_AW_PROMPT_b66cdd770b70470c_EOF
+          GH_AW_PROMPT_4dae93561d70d100_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/playwright_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b66cdd770b70470c_EOF'
+          cat << 'GH_AW_PROMPT_4dae93561d70d100_EOF'
           <safe-output-tools>
           Tools: add_comment, upload_asset(max:100), missing_tool, missing_data, noop
           
           upload_asset: provide a file path; returns a URL; assets are published after the workflow completes (safeoutputs).
           </safe-output-tools>
-          GH_AW_PROMPT_b66cdd770b70470c_EOF
+          GH_AW_PROMPT_4dae93561d70d100_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b66cdd770b70470c_EOF'
+          cat << 'GH_AW_PROMPT_4dae93561d70d100_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -240,12 +240,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b66cdd770b70470c_EOF
+          GH_AW_PROMPT_4dae93561d70d100_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b66cdd770b70470c_EOF'
+          cat << 'GH_AW_PROMPT_4dae93561d70d100_EOF'
           </system>
           {{#runtime-import .github/workflows/preview-screenshot-gallery.md}}
-          GH_AW_PROMPT_b66cdd770b70470c_EOF
+          GH_AW_PROMPT_4dae93561d70d100_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -473,9 +473,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6aff2de46f5df2e1_EOF'
-          {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/preview-screenshot-gallery","max":100,"max-size":10240}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6aff2de46f5df2e1_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d56032e1bbbc709e_EOF'
+          {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/preview-screenshot-gallery","max":100,"max-size":10240}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_d56032e1bbbc709e_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -682,7 +682,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_77661097ce2b3152_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_0a001a8d01dfe014_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -710,7 +710,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_77661097ce2b3152_EOF
+          GH_AW_MCP_CONFIG_0a001a8d01dfe014_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1037,7 +1037,7 @@ jobs:
           GH_AW_WORKFLOW_NAME: "Capture preview screenshots for PRs"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: "true"
+          GH_AW_NOOP_REPORT_AS_ISSUE: "false"
         with:
           github-token: ${{ steps.safe-outputs-app-token.outputs.token }}
           script: |
@@ -1465,7 +1465,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "accounts.google.com,android.clients.google.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.jsdelivr.net,cdn.playwright.dev,clients2.google.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,fonts.googleapis.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,posit-dev.github.io,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,safebrowsingohttpgateway.googleapis.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.google.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{},\"upload_asset\":{\"allowed-exts\":[\".png\",\".jpg\",\".jpeg\"],\"branch\":\"assets/preview-screenshot-gallery\",\"max\":100,\"max-size\":10240}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{},\"upload_asset\":{\"allowed-exts\":[\".png\",\".jpg\",\".jpeg\"],\"branch\":\"assets/preview-screenshot-gallery\",\"max\":100,\"max-size\":10240}}"
         with:
           github-token: ${{ steps.safe-outputs-app-token.outputs.token }}
           script: |

--- a/.github/workflows/preview-screenshot-gallery.md
+++ b/.github/workflows/preview-screenshot-gallery.md
@@ -27,6 +27,11 @@ safe-outputs:
   add-comment:
     max: 1
     discussions: false
+  noop:
+    # Non-PR / no-PR runs emit a noop so gh-aw does not raise "No Safe Outputs
+    # Generated"; report-as-issue:false keeps these expected no-ops from
+    # creating noisy [aw] failure issues.
+    report-as-issue: false
 network:
   allowed:
     - defaults
@@ -45,11 +50,18 @@ network:
 
 When this workflow runs:
 
-1. Confirm the triggering workflow run succeeded (`conclusion == success`). If it did not, stop immediately and exit silently — do NOT call `report_incomplete`, do NOT create an issue.
+In any of the early-exit cases below, you MUST emit a single `noop` safe output
+with a one-line reason and then stop. Do NOT call `report_incomplete`, do NOT
+create an issue, do NOT add a comment. (Emitting `noop` is required — stopping
+with no safe output at all makes gh-aw raise "No Safe Outputs Generated", which
+is itself a failure. The `noop` output is configured with `report-as-issue:
+false`, so it does not create an issue.)
+
+1. Confirm the triggering workflow run succeeded (`conclusion == success`). If it did not, emit a `noop` (reason: "triggering run did not succeed") and stop.
 2. The triggering run's event type is `${{ github.event.workflow_run.event }}` and its head SHA is `${{ github.event.workflow_run.head_sha }}`.
-   If the event type is not `pull_request` (for example, it is `push`), this run was not triggered by a pull request. **Exit silently and immediately**: do NOT call `report_incomplete`, do NOT create an issue, do NOT add a comment. This is not a failure; it is a normal non-PR run.
+   If the event type is not `pull_request` (for example, it is `push`), this run was not triggered by a pull request — this is normal, not a failure. Emit a `noop` (reason: "triggering run was not a pull_request; nothing to screenshot") and stop.
    Do NOT attempt to read `GITHUB_EVENT_PATH` or any event file on disk.
-3. If the event type IS `pull_request`, find the PR number by using the GitHub MCP tool to search for open pull requests whose head SHA matches `${{ github.event.workflow_run.head_sha }}`. Use the first match as the PR number. If no matching PR is found, exit silently — do NOT call `report_incomplete`.
+3. If the event type IS `pull_request`, find the PR number by using the GitHub MCP tool to search for open pull requests whose head SHA matches `${{ github.event.workflow_run.head_sha }}`. Use the first match as the PR number. If no matching PR is found, emit a `noop` (reason: "no open PR matches the head SHA") and stop.
 4. Compute preview URLs for that PR number:
    - Website: `https://posit-dev.github.io/vip/pr-preview-site/pr-<PR_NUMBER>/`
    - Report: `https://posit-dev.github.io/vip/pr-preview/pr-<PR_NUMBER>/`

--- a/.github/workflows/preview-screenshot-gallery.md
+++ b/.github/workflows/preview-screenshot-gallery.md
@@ -45,9 +45,12 @@ network:
 
 When this workflow runs:
 
-1. Confirm the triggering workflow run succeeded (`conclusion == success`). If it did not, stop.
-2. Read `github.event.workflow_run.pull_requests` and find the first PR number. If no PR is attached, stop.
-3. Compute preview URLs for that PR number:
+1. Confirm the triggering workflow run succeeded (`conclusion == success`). If it did not, stop immediately and exit silently — do NOT call `report_incomplete`, do NOT create an issue.
+2. The triggering run's event type is `${{ github.event.workflow_run.event }}` and its head SHA is `${{ github.event.workflow_run.head_sha }}`.
+   If the event type is not `pull_request` (for example, it is `push`), this run was not triggered by a pull request. **Exit silently and immediately**: do NOT call `report_incomplete`, do NOT create an issue, do NOT add a comment. This is not a failure; it is a normal non-PR run.
+   Do NOT attempt to read `GITHUB_EVENT_PATH` or any event file on disk.
+3. If the event type IS `pull_request`, find the PR number by using the GitHub MCP tool to search for open pull requests whose head SHA matches `${{ github.event.workflow_run.head_sha }}`. Use the first match as the PR number. If no matching PR is found, exit silently — do NOT call `report_incomplete`.
+4. Compute preview URLs for that PR number:
    - Website: `https://posit-dev.github.io/vip/pr-preview-site/pr-<PR_NUMBER>/`
    - Report: `https://posit-dev.github.io/vip/pr-preview/pr-<PR_NUMBER>/`
 


### PR DESCRIPTION
## What

Two fixes to the gh-aw agentic workflows that were repeatedly failing and spawning noisy `[aw] … failed` issues (closed dupes this session: #367/#369/#372/#373 and #159/#377).

### implement-plan — install the tools it's allowed to use
The agent job runs on `ubuntu-latest` and its bash allowlist permits `uv run:*`, `uvx showboat:*`, `just:*`, but **uv and just were never installed**, so every run failed (`which uv` → exit 1; `uv run ruff` blocked). Added setup `steps:` to the frontmatter:
- `astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39` # v8.2.0 (matches the repo's existing pin)
- `extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3` # v4

### preview-screenshot-gallery — stop the noisy non-PR failures
It read the raw event file at runtime (not present in the agent sandbox) and, when the triggering run had no PR (e.g. a push to `main`), called `report_incomplete`, spawning a failure issue. Now it:
- Gates on `${{ github.event.workflow_run.event }}` — if not `pull_request`, **exits silently** (no issue, no comment, no `report_incomplete`).
- Resolves the PR by matching `${{ github.event.workflow_run.head_sha }}` via the GitHub API instead of reading the event file.
- Exits silently in every no-PR path.

## Security review (gh-aw manifest)
- New pinned action: `extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3` (v4). SHA-pinned.
- No new secrets, no new network redirects.

## Validation
`gh aw compile` succeeds (0 errors); locks regenerated. These only fully exercise on real CI triggers — confirm via the next plan-merge `implement-plan` run and a non-PR `Website Preview` run no longer opening an `[aw]` issue.