### PR TITLE
ci: fix smoke workflow deadlock by moving path filters to job-level gate

### DIFF
--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -9,18 +9,34 @@ on:
       - 'uv.lock'
       - '.github/workflows/connect-smoke.yml'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/connect-smoke.yml'
 
 permissions:
   contents: read
   checks: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/connect-smoke.yml'
+
   connect-smoke:
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true'
     name: Smoke test against Connect ${{ matrix.connect-version }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -24,6 +24,8 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:

--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -237,11 +237,15 @@ jobs:
   status:
     name: Connect Smoke Tests Status
     if: always()
-    needs: [connect-smoke]
+    needs: [changes, connect-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Check smoke test result
         run: |
+          if [ "${{ needs.changes.result }}" = "failure" ] || [ "${{ needs.changes.result }}" = "cancelled" ]; then
+            echo "Change-detection job failed; cannot confirm smoke scope"
+            exit 1
+          fi
           if [ "${{ needs.connect-smoke.result }}" = "failure" ] || [ "${{ needs.connect-smoke.result }}" = "cancelled" ]; then
             echo "Connect smoke tests failed or were cancelled"
             exit 1

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -9,18 +9,34 @@ on:
       - 'uv.lock'
       - '.github/workflows/packagemanager-smoke.yml'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/packagemanager-smoke.yml'
 
 permissions:
   contents: read
   checks: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/packagemanager-smoke.yml'
+
   packagemanager-smoke:
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true'
     name: Smoke test against Package Manager ${{ matrix.pm-version }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -24,6 +24,8 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -279,11 +279,15 @@ jobs:
   status:
     name: Package Manager Smoke Tests Status
     if: always()
-    needs: [packagemanager-smoke]
+    needs: [changes, packagemanager-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Check smoke test result
         run: |
+          if [ "${{ needs.changes.result }}" = "failure" ] || [ "${{ needs.changes.result }}" = "cancelled" ]; then
+            echo "Change-detection job failed; cannot confirm smoke scope"
+            exit 1
+          fi
           if [ "${{ needs.packagemanager-smoke.result }}" = "failure" ] || [ "${{ needs.packagemanager-smoke.result }}" = "cancelled" ]; then
             echo "Package Manager smoke tests failed or were cancelled"
             exit 1

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -9,19 +9,34 @@ on:
       - 'uv.lock'
       - '.github/workflows/workbench-smoke.yml'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/workbench-smoke.yml'
 
 permissions:
   contents: read
   checks: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/workbench-smoke.yml'
+
   workbench-smoke:
-    if: github.actor != 'dependabot[bot]'
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true' && github.actor != 'dependabot[bot]'
     name: Smoke test against Workbench ${{ matrix.workbench-version }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -24,6 +24,8 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -259,11 +259,15 @@ jobs:
   status:
     name: Workbench Smoke Tests Status
     if: always()
-    needs: [workbench-smoke]
+    needs: [changes, workbench-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Check smoke test result
         run: |
+          if [ "${{ needs.changes.result }}" = "failure" ] || [ "${{ needs.changes.result }}" = "cancelled" ]; then
+            echo "Change-detection job failed; cannot confirm smoke scope"
+            exit 1
+          fi
           if [ "${{ needs.workbench-smoke.result }}" = "failure" ] || [ "${{ needs.workbench-smoke.result }}" = "cancelled" ]; then
             echo "Workbench smoke tests failed or were cancelled"
             exit 1


### PR DESCRIPTION
## Problem

`Connect/Package Manager/Workbench Smoke Tests Status` are **required** checks, but their workflows had a `pull_request: paths:` filter. A PR that doesn't touch `src/**` / `pyproject.toml` / `uv.lock` / the workflow file (e.g. an agentic-workflow or docs PR like #382, or the plan PR #315) never triggers the workflow, so the required check never reports and the ruleset **blocks the PR forever** — a "skipped but required" deadlock that's currently worked around with `--admin` merges.

## Fix

For `connect-smoke.yml`, `packagemanager-smoke.yml`, `workbench-smoke.yml`:
- Remove `paths:` from the `pull_request:` trigger so the workflow **always runs on PRs** (the `push:`-to-`main` trigger keeps its `paths:` filter).
- Add a `changes` job (`dorny/paths-filter@d1c1ffe…` # v3) that detects whether the same relevant paths changed.
- Gate the heavy smoke job on `needs.changes.outputs.relevant == 'true'` — it still runs for real `src/` changes, and is **skipped** for irrelevant PRs.
- The existing `status` job is unchanged: it already passes when the smoke job is skipped, so the required check now always reports.

The gate stays real — any PR touching product code still runs the full smoke suite.

## Security review
- New pinned action: `dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590` (v3.0.3).
- Reuses the repo's existing `actions/checkout@df4cb1c…` pin. No new secrets.