### PR TITLE
fix(workbench): fix terminal-open and SSO sign-out tests

### DIFF
--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -365,8 +365,7 @@ def _ensure_terminal_open(page: Page, timeout: int = 30_000) -> None:
             term_tab.first.click()
     elif page.locator(VSCodeSession.WORKBENCH).count() > 0:
         # VS Code / Positron: open the integrated terminal (creates one if none).
-        page.keyboard.press("Control+Backquote")
-
+        page.keyboard.press("Control+`")
     expect(terminal_input).to_be_visible(timeout=timeout)
 
 

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -27,6 +27,7 @@ from vip_tests.workbench.pages import (
     ConsolePaneSelectors,
     JupyterLabSession,
     PositronSession,
+    RStudioSession,
     VSCodeSession,
 )
 
@@ -162,6 +163,13 @@ def rstudio_eval(page: Page, expr: str, timeout: int = 30_000) -> str:
     """
     start, end = _make_sentinels()
     wrapped = _wrap_r_expr(expr, start, end)
+
+    # Ensure the Console tab is active. Console and Terminal are tabs in the
+    # same RStudio pane, so a prior terminal_run may have left the Terminal tab
+    # selected, which hides the console input and would stall this readback.
+    console_tab = page.locator(ConsolePaneSelectors.TAB)
+    if console_tab.count() > 0:
+        console_tab.click()
 
     console_input = page.locator(ConsolePaneSelectors.INPUT)
     expect(console_input).to_be_visible(timeout=timeout)
@@ -333,6 +341,35 @@ def vscode_eval(page: Page, expr: str, lang: str = "python", timeout: int = 30_0
 # ---------------------------------------------------------------------------
 
 
+def _ensure_terminal_open(page: Page, timeout: int = 30_000) -> None:
+    """Make the IDE's integrated terminal input visible before use.
+
+    A freshly launched session does not start on the terminal: in RStudio the
+    Console tab is selected and the Terminal tab's xterm widget is not rendered
+    until the tab is activated; in VS Code/Positron no terminal panel exists
+    until one is created. ``terminal_run`` therefore cannot assume
+    ``.xterm-helper-textarea`` is already present. This helper is idempotent —
+    it returns immediately when a terminal input is already visible.
+    """
+    terminal_input = page.locator(VSCodeSession.TERMINAL_INPUT)
+    if terminal_input.count() > 0 and terminal_input.first.is_visible():
+        return
+
+    if page.locator(RStudioSession.CONTAINER).count() > 0:
+        # RStudio: activate the Terminal tab in the console pane. Tab ids follow
+        # #rstudio_workbench_tab_<name>; clicking creates a terminal on first open.
+        term_tab = page.locator("#rstudio_workbench_tab_terminal")
+        if term_tab.count() == 0:
+            term_tab = page.get_by_role("tab", name=re.compile(r"\bTerminal\b"))
+        if term_tab.count() > 0:
+            term_tab.first.click()
+    elif page.locator(VSCodeSession.WORKBENCH).count() > 0:
+        # VS Code / Positron: open the integrated terminal (creates one if none).
+        page.keyboard.press("Control+Backquote")
+
+    expect(terminal_input).to_be_visible(timeout=timeout)
+
+
 def terminal_run(
     page: Page,
     cmd: str,
@@ -347,10 +384,12 @@ def terminal_run(
     rather than scraping the xterm canvas/WebGL terminal widget.
 
     Strategy:
-    1. Type ``{cmd} > {tmpfile} 2>&1 && echo VIP_DONE >> {tmpfile}`` in the
+    1. Ensure the IDE terminal is open (activate the RStudio Terminal tab or
+       create a VS Code/Positron terminal) so its input is present.
+    2. Type ``{cmd} > {tmpfile} 2>&1 && echo VIP_DONE >> {tmpfile}`` in the
        terminal input (``.xterm-helper-textarea``).
-    2. Press Enter to execute.
-    3. Poll for the done marker by calling ``read_file`` (which uses
+    3. Press Enter to execute.
+    4. Poll for the done marker by calling ``read_file`` (which uses
        ``rstudio_eval`` or ``vscode_eval`` depending on *readback_lang*).
 
     Args:
@@ -368,8 +407,8 @@ def terminal_run(
     tmpfile = f"/tmp/vip_term_{uuid.uuid4().hex}.txt"
     shell_cmd = f'{cmd} > {tmpfile} 2>&1 && echo "{done_marker}" >> {tmpfile}'
 
+    _ensure_terminal_open(page, timeout=timeout)
     terminal_input = page.locator(VSCodeSession.TERMINAL_INPUT)
-    expect(terminal_input).to_be_visible(timeout=timeout)
     terminal_input.click()
     terminal_input.type(shell_cmd)
     terminal_input.press("Enter")

--- a/src/vip_tests/workbench/test_auth.py
+++ b/src/vip_tests/workbench/test_auth.py
@@ -132,7 +132,8 @@ def redirected_to_login_page(page: Page):
     """
     username = page.locator(LoginPage.USERNAME)
     sign_in_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE))
+    username_or_signin = username.or_(sign_in_button)
     try:
-        expect(username.or_(sign_in_button).first).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
-    except AssertionError:
+        username_or_signin.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+    except Exception:
         expect(page).to_have_url(re.compile(r"sign-in|login|auth"), timeout=TIMEOUT_PAGE_LOAD)

--- a/src/vip_tests/workbench/test_auth.py
+++ b/src/vip_tests/workbench/test_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from playwright.sync_api import Browser, Page, expect
 from pytest_bdd import given, scenario, then, when
@@ -26,17 +28,28 @@ def test_workbench_signout():
 
 
 @pytest.fixture
-def page(browser: Browser, browser_context_args: dict):
-    """Override the default page fixture to strip storage_state.
+def page(request: pytest.FixtureRequest, browser: Browser, browser_context_args: dict):
+    """Override the default page fixture for the login-form test only.
 
-    Ensures the login form is genuinely exercised even when --headless-auth
-    pre-authenticated other tests by injecting storage_state into
-    browser_context_args.  All other context args (TLS, CA bundle, etc.)
-    are preserved so this test behaves consistently with the rest of the
-    suite.  The autouse _cleanup_sessions fixture in workbench/conftest.py
-    will use this same page, keeping cleanup and execution in the same context.
+    The login scenario must genuinely exercise the password login form, so it
+    needs a *logged-out* context: storage_state (injected by --interactive-auth
+    / --headless-auth) is stripped. Every other test in this module — notably
+    the sign-out scenario — must stay *logged in* via that session, so they
+    keep storage_state. Stripping it for sign-out would leave the browser
+    anonymous and, under SSO, unable to re-authenticate (no password), so the
+    "I am logged in" precondition could never be met.
+
+    All other context args (TLS, CA bundle, etc.) are preserved so this page
+    behaves consistently with the rest of the suite. The autouse
+    _cleanup_sessions fixture in workbench/conftest.py uses this same page,
+    keeping cleanup and execution in the same context.
     """
-    args = {k: v for k, v in browser_context_args.items() if k != "storage_state"}
+    strip_storage_state = request.node.name.startswith("test_workbench_login")
+    args = {
+        k: v
+        for k, v in browser_context_args.items()
+        if not (strip_storage_state and k == "storage_state")
+    }
     context = browser.new_context(**args)
     pg = context.new_page()
     try:
@@ -110,5 +123,16 @@ def sign_out(page: Page):
 
 @then("I am redirected to the Workbench login page")
 def redirected_to_login_page(page: Page):
-    """Verify the login form becomes visible after sign-out."""
-    expect(page.locator(LoginPage.USERNAME)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    """Verify the login page is shown after sign-out.
+
+    Password deployments render the native form (``#username``); SSO/OIDC
+    deployments render a "Sign in with <provider>" page that has no username
+    field. Accept either affordance, and fall back to the login URL so the
+    check is independent of the configured auth provider.
+    """
+    username = page.locator(LoginPage.USERNAME)
+    sign_in_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE))
+    try:
+        expect(username.or_(sign_in_button).first).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    except AssertionError:
+        expect(page).to_have_url(re.compile(r"sign-in|login|auth"), timeout=TIMEOUT_PAGE_LOAD)


### PR DESCRIPTION
## Summary
Two fixes to Workbench product tests found broken during live-deployment
validation of the 2026-06-11/12 merge wave. Both passed unit/smoke tests but
failed against a real SSO deployment.

## Fixes
- **terminal_run never opened the IDE terminal.** It waited on
  `.xterm-helper-textarea` assuming the terminal was already visible, but a
  fresh session isn't on it (RStudio = Console tab active; VS Code/Positron =
  no terminal panel). Added `_ensure_terminal_open` (RStudio Terminal tab, or
  `Ctrl+`` for VS Code/Positron). Also re-activate the RStudio Console tab in
  `rstudio_eval` so the shared-pane file-readback isn't hidden behind Terminal.
- **Sign-out test couldn't run under SSO.** It inherited the login test's
  module-scoped `page` fixture that strips `storage_state`, so it started
  logged out and couldn't re-auth without a password. Now strips storage_state
  only for the login-form test, and the post-sign-out assertion is
  provider-agnostic (SSO "Sign in" page or `auth-sign-in` URL, not just
  `#username`).

## Validation (manual — product tests can't run in CI)
Against `dev.academy.staging.posit.team` (SSO):
- `clone_rstudio` + `push_rstudio` **PASS** (real push + branch delete to config-exchange)
- terminal opens for RStudio, VS Code, and Positron
- sign-out reaches the OIDC login page
- selftests: 275 passed; ruff clean

## Known follow-ups (separate bugs, not in scope here)
- VS Code readback uses the Python Interactive Window (`vscode_eval`), which a
  fresh session doesn't open -> `clone_vscode`/`push_vscode` still fail at readback.
- Positron readback: `read_file`/`file_exists` route `lang="r"` to `rstudio_eval`
  (no Positron path) -> `clone_positron`/`push_positron` fail. So #363 currently
  works for RStudio only.
- Staging session cold-start is slow (needs `VIP_TIMEOUT_SCALE`); cookie-based
  session cleanup fails on that deployment; `Homepage.SESSION_LIST` selector is stale.
