### PR TITLE
test(connect): add chronicle status verification

### DIFF
--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -401,6 +401,9 @@ enabled = true
 [monitoring]
 enabled = true
 
+[chronicle]
+enabled = true
+
 [security]
 policy_checks_enabled = true
 """
@@ -408,7 +411,13 @@ policy_checks_enabled = true
         cfg = load_config(path)
         assert cfg.email_enabled is True
         assert cfg.monitoring_enabled is True
+        assert cfg.chronicle_enabled is True
         assert cfg.security_policy_checks_enabled is True
+
+    def test_chronicle_disabled_by_default(self, tmp_toml):
+        path = tmp_toml('[connect]\nurl = "https://connect.example.com"\n')
+        cfg = load_config(path)
+        assert cfg.chronicle_enabled is False
 
     def test_performance_section(self, tmp_toml):
         path = tmp_toml(

--- a/src/vip/clients/connect.py
+++ b/src/vip/clients/connect.py
@@ -72,6 +72,17 @@ class ConnectClient(BaseClient):
         resp = self._client.get("/server_settings")
         return resp.status_code
 
+    def chronicle_status(self) -> dict[str, Any]:
+        """Return the embedded Chronicle usage-data subprocess status.
+
+        Reports ``enabled`` (Chronicle is on in the server config) and
+        ``ready`` (the subprocess is running and accepting work). Requires an
+        admin API key.
+        """
+        resp = self._client.get("/v1/system/chronicle")
+        resp.raise_for_status()
+        return resp.json()
+
     # -- Users --------------------------------------------------------------
 
     def current_user(self) -> dict[str, Any]:

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -487,6 +487,7 @@ class VIPConfig:
 
     email_enabled: bool = False
     monitoring_enabled: bool = False
+    chronicle_enabled: bool = False
     security_policy_checks_enabled: bool = False
 
     insecure: bool = False
@@ -580,6 +581,7 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
     data_sources_raw = raw.get("data_sources", {})
     email_raw = raw.get("email", {})
     monitoring_raw = raw.get("monitoring", {})
+    chronicle_raw = raw.get("chronicle", {})
     security_raw = raw.get("security", {})
     runtimes_raw = raw.get("runtimes", {})
     performance_raw = raw.get("performance", {})
@@ -613,6 +615,7 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
         data_sources=data_sources,
         email_enabled=email_raw.get("enabled", False),
         monitoring_enabled=monitoring_raw.get("enabled", False),
+        chronicle_enabled=chronicle_raw.get("enabled", False),
         security_policy_checks_enabled=security_raw.get("policy_checks_enabled", False),
         insecure=tls_raw.get("insecure", False),
         ca_bundle=_resolve_ca_bundle(tls_raw.get("ca_bundle")),

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -256,6 +256,11 @@ def email_enabled(vip_config: VIPConfig) -> bool:
     return vip_config.email_enabled
 
 
+@pytest.fixture(scope="session")
+def chronicle_enabled(vip_config: VIPConfig) -> bool:
+    return vip_config.chronicle_enabled
+
+
 # ---------------------------------------------------------------------------
 # Connect content cleanup — promoted from connect/conftest.py so that any
 # package (workbench, cross_product, …) that creates Connect content can

--- a/src/vip_tests/connect/test_chronicle.feature
+++ b/src/vip_tests/connect/test_chronicle.feature
@@ -1,5 +1,5 @@
 @connect @if_applicable @api_auth
-Feature: Connect Chronicle usage data collection
+Feature: Connect embedded Chronicle
   As a Posit Team administrator
   I want to verify that Connect's embedded Chronicle subprocess is running
   So that I know usage data collection actually came up after enabling it

--- a/src/vip_tests/connect/test_chronicle.feature
+++ b/src/vip_tests/connect/test_chronicle.feature
@@ -1,0 +1,18 @@
+@connect @if_applicable @api_auth
+Feature: Connect Chronicle usage data collection
+  As a Posit Team administrator
+  I want to verify that Connect's embedded Chronicle subprocess is running
+  So that I know usage data collection actually came up after enabling it
+
+  # Chronicle runs as a supervised subprocess inside Connect. The
+  # GET /__api__/v1/system/chronicle endpoint (admin-only) reports whether
+  # Chronicle is enabled in the server config and whether the subprocess is
+  # running and ready to accept work. VIP verifies that a deployment which
+  # declares Chronicle enabled reports both.
+
+  Scenario: Chronicle reports enabled and ready
+    Given Connect is accessible at the configured URL
+    And Chronicle usage data collection is enabled
+    When I query the Chronicle status endpoint
+    Then Chronicle reports it is enabled
+    And Chronicle reports it is ready

--- a/src/vip_tests/connect/test_chronicle.py
+++ b/src/vip_tests/connect/test_chronicle.py
@@ -6,6 +6,7 @@ import pytest
 from pytest_bdd import given, scenario, then, when
 
 
+@pytest.mark.min_version(product="connect", version="2026.06.0")
 @scenario("test_chronicle.feature", "Chronicle reports enabled and ready")
 def test_chronicle_status():
     pass

--- a/src/vip_tests/connect/test_chronicle.py
+++ b/src/vip_tests/connect/test_chronicle.py
@@ -1,0 +1,36 @@
+"""Step definitions for Connect Chronicle usage data collection tests."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+
+@scenario("test_chronicle.feature", "Chronicle reports enabled and ready")
+def test_chronicle_status():
+    pass
+
+
+@given("Chronicle usage data collection is enabled")
+def chronicle_is_enabled(chronicle_enabled):
+    if not chronicle_enabled:
+        pytest.skip("Chronicle is not enabled in vip.toml")
+
+
+@when("I query the Chronicle status endpoint", target_fixture="chronicle_status")
+def query_chronicle_status(connect_client):
+    return connect_client.chronicle_status()
+
+
+@then("Chronicle reports it is enabled")
+def chronicle_reports_enabled(chronicle_status):
+    assert chronicle_status.get("enabled") is True, (
+        f"Chronicle is declared enabled but Connect reports it is not: {chronicle_status}"
+    )
+
+
+@then("Chronicle reports it is ready")
+def chronicle_reports_ready(chronicle_status):
+    assert chronicle_status.get("ready") is True, (
+        f"Chronicle is enabled but its subprocess is not ready: {chronicle_status}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1587,7 +1587,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.18.1"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1610,9 +1610,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/b0/666586d557a71a58cd9960b154fb9aee0ed81dd62a50371195ab95731909/jupyter_server-2.18.1.tar.gz", hash = "sha256:f62be526369b791625e03bd658070563c1a4e9a0a2f439ea1f9dbacea5f7191a", size = 752024, upload-time = "2026-05-05T09:17:51.101Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/45/bfe3779fd06714a379128f2c4eaf7c99414f0eb081f9f34c135f6b3d511c/jupyter_server-2.18.1-py3-none-any.whl", hash = "sha256:db0374d52a975f88a92a7f20de44e08ef5be9763ba7e99630baf16c46ac8dbf0", size = 391844, upload-time = "2026-05-05T09:17:48.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.41.0"
+version = "0.46.1"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/uv.lock
+++ b/uv.lock
@@ -2519,7 +2519,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.47.0"
+version = "0.46.3"
 source = { editable = "." }
 dependencies = [
     { name = "brand-yml" },

--- a/validation_docs/demo-connect-chronicle-status.md
+++ b/validation_docs/demo-connect-chronicle-status.md
@@ -5,7 +5,7 @@
 
 Adds a VIP verification test for Connect's embedded Chronicle usage-data subprocess, using the new admin-only `GET /__api__/v1/system/chronicle` endpoint (posit-dev/connect#40652, merged 2026-06-16), which reports `{enabled, ready}`.
 
-Following VIP's model (verify an operator's declared expectation against a live deployment), the test is scoped behind a `[chronicle] enabled` config flag and auto-skips when not declared — mirroring the existing email/monitoring features. No `min_version` gate and no CI provisioning, consistent with how other optional features are handled.
+Following VIP's model (verify an operator's declared expectation against a live deployment), the test is scoped behind a `[chronicle] enabled` config flag and auto-skips when not declared — mirroring the existing email/monitoring features. A `@pytest.mark.min_version(product="connect", version="2026.06.0")` gate ensures servers older than 2026.06.0 skip cleanly rather than failing on the missing endpoint.
 
 Changes:
 - `src/vip/clients/connect.py` — `chronicle_status()` client method

--- a/validation_docs/demo-connect-chronicle-status.md
+++ b/validation_docs/demo-connect-chronicle-status.md
@@ -1,0 +1,55 @@
+# test(connect): add chronicle status verification
+
+*2026-06-16T20:25:46Z by Showboat 0.6.1*
+<!-- showboat-id: e41df1cd-840a-45d7-a019-d38da14fc72b -->
+
+Adds a VIP verification test for Connect's embedded Chronicle usage-data subprocess, using the new admin-only `GET /__api__/v1/system/chronicle` endpoint (posit-dev/connect#40652, merged 2026-06-16), which reports `{enabled, ready}`.
+
+Following VIP's model (verify an operator's declared expectation against a live deployment), the test is scoped behind a `[chronicle] enabled` config flag and auto-skips when not declared — mirroring the existing email/monitoring features. No `min_version` gate and no CI provisioning, consistent with how other optional features are handled.
+
+Changes:
+- `src/vip/clients/connect.py` — `chronicle_status()` client method
+- `src/vip_tests/connect/test_chronicle.feature` / `test_chronicle.py` — feature + steps
+- `vip.toml.example` — documented `[chronicle] enabled` section
+- `selftests/test_config.py` — config-loading assertions
+
+Verified live against a local Chronicle-enabled Connect (2026.06+): the scenario passed with enabled=true and ready=true. That run is not included below because it requires a Chronicle-enabled server, which CI does not provide; the blocks below run anywhere.
+
+## Config selftests pass (new chronicle flag loads, and defaults to disabled)
+
+```bash
+uv run pytest selftests/test_config.py -q 2>&1 | grep -E "passed|failed" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+100 passed, 1 warning
+```
+
+## The new BDD scenario collects
+
+```bash
+uv run pytest src/vip_tests/connect/test_chronicle.py --collect-only -q --vip-config vip.toml.example 2>&1 | grep -E "chronicle|collected" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+src/vip_tests/connect/test_chronicle.py::test_chronicle_status
+1 test collected
+```
+
+## Lint and format are clean (ruff pinned to CI version 0.15.0)
+
+```bash
+uvx ruff@0.15.0 check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+```
+
+```bash
+uvx ruff@0.15.0 format --check src/ src/vip_tests/ selftests/ examples/ 2>&1 | tail -1
+```
+
+```output
+155 files already formatted
+```

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -158,6 +158,11 @@ enabled = false
 # Set enabled = true if monitoring / logging is configured.
 enabled = false
 
+[chronicle]
+# Set enabled = true if Connect's embedded Chronicle usage data collection
+# is configured. VIP verifies the Chronicle subprocess is running and ready.
+enabled = false
+
 [performance]
 # Thresholds for performance tests.  All time values are in seconds.
 # page_load_timeout = 10.0


### PR DESCRIPTION
Adds a VIP verification test for Connect's embedded Chronicle subprocess (https://github.com/posit-dev/connect/issues/40707)

Note: embedded chronicle is an unreleased feature (going out in 2026.06.0), so the showboat demo just demonstrates it being skipped. I did test it against a server running an appropriate dev version of Connect to show that it works there:

```diff
➜  vip git:(test/connect-chronicle-status) ✗ uv run vip verify --config vip.toml --api-auth --categories connect
Note: Workbench no URL given — Workbench tests will not be collected.
Note: Package Manager no URL given — Package Manager tests will not be collected.
========================================================= test session starts ==========================================================
14 workers [20 items]
scheduling tests via LoadGroupScheduling

src/vip_tests/connect/test_content_deploy.py::test_deploy_dash
src/vip_tests/connect/test_auth.py::test_connect_login_api
src/vip_tests/connect/test_content_deploy.py::test_deploy_rmarkdown
src/vip_tests/connect/test_content_deploy.py::test_deploy_plumber
src/vip_tests/connect/test_content_deploy.py::test_deploy_quarto
src/vip_tests/connect/test_content_deploy.py::test_deploy_shiny
src/vip_tests/connect/test_content_deploy.py::test_deploy_gitbacked
src/vip_tests/connect/test_content_deploy.py::test_deploy_jupyter
src/vip_tests/connect/test_content_deploy.py::test_deploy_fastapi
src/vip_tests/connect/test_chronicle.py::test_chronicle_status
src/vip_tests/connect/test_runtime_versions.py::test_r_versions
src/vip_tests/connect/test_email.py::test_send_email
src/vip_tests/connect/test_packages.py::test_package_repo_configured
src/vip_tests/connect/test_data_sources.py::test_data_sources_reachable
src/vip_tests/connect/test_email.py::test_send_email SKIPPED (Email is not enabled in vip.toml)                                  [  5%]
src/vip_tests/connect/test_data_sources.py::test_data_sources_reachable SKIPPED (No data sources configured in vip.toml)         [ 10%]
src/vip_tests/connect/test_runtime_versions.py::test_r_versions SKIPPED (No expected R versions specified in vip.toml [runti...) [ 15%]
src/vip_tests/connect/test_auth.py::test_connect_login_api PASSED                                                                [ 20%]
src/vip_tests/connect/test_runtime_versions.py::test_python_versions
+ src/vip_tests/connect/test_chronicle.py::test_chronicle_status PASSED                                                            [ 25%]
src/vip_tests/connect/test_packages.py::test_package_repo_configured PASSED                                                      [ 30%]
src/vip_tests/connect/test_runtime_versions.py::test_quarto_versions
src/vip_tests/connect/test_runtime_versions.py::test_python_versions SKIPPED (No expected Python versions specified in vip.t...) [ 35%]
src/vip_tests/connect/test_runtime_versions.py::test_quarto_versions PASSED                                                      [ 40%]
src/vip_tests/connect/test_content_deploy.py::test_deploy_quarto PASSED                                                          [ 45%]
src/vip_tests/connect/test_system_checks.py::test_connect_system_checks
src/vip_tests/connect/test_content_deploy.py::test_deploy_gitbacked PASSED                                                       [ 50%]
src/vip_tests/connect/test_content_deploy.py::test_deploy_dash PASSED                                                            [ 55%]
src/vip_tests/connect/test_users.py::test_list_groups PASSED                                                                     [ 60%]
src/vip_tests/connect/test_content_deploy.py::test_deploy_shiny PASSED                                                           [ 65%]
src/vip_tests/connect/test_users.py::test_list_users SKIPPED (No test user configured — skipping user lookup assertion)          [ 70%]
src/vip_tests/connect/test_system_checks.py::test_connect_system_checks PASSED                                                   [ 75%]
src/vip_tests/connect/test_content_deploy.py::test_deploy_plumber PASSED                                                         [ 80%]
src/vip_tests/connect/test_users.py::test_admin_user PASSED                                                                      [ 85%]
src/vip_tests/connect/test_content_deploy.py::test_deploy_rmarkdown PASSED                                                       [ 90%]
src/vip_tests/connect/test_content_deploy.py::test_deploy_fastapi PASSED                                                         [ 95%]
src/vip_tests/connect/test_content_deploy.py::test_deploy_jupyter PASSED                                                         [100%]

==================================================== 15 passed, 6 skipped in 33.63s ====================================================
```

## Demo

Adds a VIP verification test for Connect's embedded Chronicle usage-data subprocess

Following VIP's model (verify an operator's declared expectation against a live deployment), the test is scoped behind a `[chronicle] enabled` config flag and auto-skips when not declared — mirroring the existing email/monitoring features. It also carries a `@pytest.mark.min_version(product="connect", version="2026.06.0")` gate, since embedded Chronicle (and its status endpoint) was introduced in Connect 2026.06.0; older servers skip cleanly instead of 404ing. No CI provisioning, consistent with how other optional features are handled.

Changes:
- `src/vip/clients/connect.py` — `chronicle_status()` client method
- `src/vip_tests/connect/test_chronicle.feature` / `test_chronicle.py` — feature + steps
- `vip.toml.example` — documented `[chronicle] enabled` section
- `selftests/test_config.py` — config-loading assertions


## Config selftests pass (new chronicle flag loads, and defaults to disabled)

```bash
uv run pytest selftests/test_config.py -q 2>&1 | grep -E "passed|failed" | sed "s/ in [0-9.]*s//"
```

```output
100 passed, 1 warning
```

## The new BDD scenario collects

```bash
uv run pytest src/vip_tests/connect/test_chronicle.py --collect-only -q --vip-config vip.toml.example 2>&1 | grep -E "chronicle|collected" | sed "s/ in [0-9.]*s//"
```

```output
src/vip_tests/connect/test_chronicle.py::test_chronicle_status
1 test collected
```

## Lint and format are clean (ruff pinned to CI version 0.15.0)

```bash
uvx ruff@0.15.0 check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
```

```bash
uvx ruff@0.15.0 format --check src/ src/vip_tests/ selftests/ examples/ 2>&1 | tail -1
```

```output
155 files already formatted
```
