### PR TITLE
feat(cli): add --json output to vip status

### DIFF
--- a/selftests/test_cli_status.py
+++ b/selftests/test_cli_status.py
@@ -1,0 +1,462 @@
+"""Tests for run_status and _collect_status in vip.cli."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    """Build a minimal args namespace for run_status."""
+    defaults = {
+        "config": None,
+        "json": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _make_config(
+    connect_url: str = "",
+    connect_configured: bool = False,
+    workbench_url: str = "",
+    workbench_configured: bool = False,
+    pm_url: str = "",
+    pm_configured: bool = False,
+) -> MagicMock:
+    """Build a minimal VIPConfig mock for run_status."""
+    config = MagicMock()
+
+    connect = MagicMock()
+    connect.is_configured = connect_configured
+    connect.url = connect_url
+    connect.api_key = "test-key"
+    config.connect = connect
+
+    workbench = MagicMock()
+    workbench.is_configured = workbench_configured
+    workbench.url = workbench_url
+    workbench.api_key = "test-key"
+    config.workbench = workbench
+
+    pm = MagicMock()
+    pm.is_configured = pm_configured
+    pm.url = pm_url
+    pm.token = "test-token"
+    config.package_manager = pm
+
+    return config
+
+
+class TestCollectStatus:
+    """_collect_status returns structured data with no side effects."""
+
+    def test_unconfigured_product_is_skip(self):
+        from vip.cli import _collect_status
+
+        config = _make_config()
+        result = _collect_status(config)
+        assert result["products"]["connect"]["state"] == "skip"
+        assert result["products"]["connect"]["configured"] is False
+        assert result["products"]["workbench"]["state"] == "skip"
+        assert result["products"]["package_manager"]["state"] == "skip"
+
+    def test_unconfigured_product_has_detail_not_configured(self):
+        from vip.cli import _collect_status
+
+        config = _make_config()
+        result = _collect_status(config)
+        assert result["products"]["connect"]["detail"] == "not configured"
+
+    def test_configured_ok_product(self):
+        from vip.cli import _collect_status
+
+        config = _make_config(connect_url="https://connect.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            result = _collect_status(config)
+
+        product = result["products"]["connect"]
+        assert product["configured"] is True
+        assert product["state"] == "ok"
+        assert product["url"] == "https://connect.example.com"
+        assert product["http_status"] == 200
+
+    def test_configured_fail_product(self):
+        from vip.cli import _collect_status
+
+        config = _make_config(connect_url="https://connect.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 503
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            result = _collect_status(config)
+
+        product = result["products"]["connect"]
+        assert product["state"] == "fail"
+        assert product["http_status"] == 503
+
+    def test_configured_exception_product(self):
+        from vip.cli import _collect_status
+
+        config = _make_config(connect_url="https://connect.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.side_effect = ConnectionError("refused")
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            result = _collect_status(config)
+
+        product = result["products"]["connect"]
+        assert product["state"] == "fail"
+        assert "refused" in product["detail"]
+        assert "http_status" not in product
+
+    def test_workbench_configured_ok(self):
+        from vip.cli import _collect_status
+
+        config = _make_config(
+            workbench_url="https://workbench.example.com", workbench_configured=True
+        )
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("vip.clients.workbench.WorkbenchClient", return_value=mock_client):
+            result = _collect_status(config)
+
+        assert result["products"]["workbench"]["state"] == "ok"
+        assert result["products"]["workbench"]["http_status"] == 200
+
+    def test_package_manager_configured_ok(self):
+        from vip.cli import _collect_status
+
+        config = _make_config(pm_url="https://pm.example.com", pm_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("vip.clients.packagemanager.PackageManagerClient", return_value=mock_client):
+            result = _collect_status(config)
+
+        assert result["products"]["package_manager"]["state"] == "ok"
+        assert result["products"]["package_manager"]["http_status"] == 200
+
+    def test_outcome_ok_when_all_ok_or_skip(self):
+        from vip.cli import _collect_status
+
+        config = _make_config(connect_url="https://connect.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            result = _collect_status(config)
+
+        assert result["outcome"] == "ok"
+        assert result["exit_status"] == 0
+
+    def test_outcome_fail_when_any_fail(self):
+        from vip.cli import _collect_status
+
+        config = _make_config(connect_url="https://connect.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 503
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            result = _collect_status(config)
+
+        assert result["outcome"] == "fail"
+        assert result["exit_status"] == 1
+
+    def test_all_skip_is_ok(self):
+        from vip.cli import _collect_status
+
+        config = _make_config()
+        result = _collect_status(config)
+        assert result["outcome"] == "ok"
+        assert result["exit_status"] == 0
+
+
+class TestRunStatusTextMode:
+    """Text mode preserves the original format."""
+
+    def _run(self, config, args=None):
+        """Run run_status with mocked load_config and sys.exit, return (out, exit_code)."""
+        if args is None:
+            args = _make_args()
+        exit_code_holder = []
+
+        def fake_exit(code=0):
+            exit_code_holder.append(code)
+
+        with (
+            patch("vip.config.load_config", return_value=config),
+            patch("vip.cli.sys.exit", side_effect=fake_exit),
+        ):
+            import io
+
+            from vip.cli import run_status
+
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                run_status(args)
+            except SystemExit:
+                pass
+            finally:
+                sys.stdout = old_stdout
+
+        return captured.getvalue(), exit_code_holder[0] if exit_code_holder else None
+
+    def test_skip_line_format(self):
+        config = _make_config()
+        out, _ = self._run(config)
+        # Format: "  SKIP  package_manager       not configured"
+        assert "SKIP" in out
+        assert "not configured" in out
+
+    def test_ok_line_format(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            out, _ = self._run(config)
+
+        assert "OK  " in out
+        assert "HTTP 200" in out
+
+    def test_exit_0_when_all_ok_or_skip(self):
+        config = _make_config()
+        _, code = self._run(config)
+        assert code == 0
+
+    def test_exit_1_when_any_fail(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 503
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            _, code = self._run(config)
+
+        assert code == 1
+
+    def test_text_line_width_format(self):
+        """Verify the exact column format: '  {STATE:4s}  {name:20s}  {detail}'."""
+        config = _make_config()
+        out, _ = self._run(config)
+        lines = [line for line in out.splitlines() if line.strip()]
+        assert len(lines) == 3  # one per product
+        for line in lines:
+            # Must start with two spaces
+            assert line.startswith("  "), f"Line does not start with two spaces: {line!r}"
+
+
+class TestRunStatusJsonMode:
+    """JSON mode emits the documented schema to stdout."""
+
+    def _run_json(self, config):
+        """Run run_status with --json flag, return parsed JSON and exit_code."""
+        args = _make_args(json=True)
+        exit_code_holder = []
+
+        def fake_exit(code=0):
+            exit_code_holder.append(code)
+            raise SystemExit(code)
+
+        with (
+            patch("vip.config.load_config", return_value=config),
+            patch("vip.cli.sys.exit", side_effect=fake_exit),
+        ):
+            import io
+
+            from vip.cli import run_status
+
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                run_status(args)
+            except SystemExit:
+                pass
+            finally:
+                sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        parsed = json.loads(output)
+        return parsed, exit_code_holder[0] if exit_code_holder else None
+
+    def test_json_top_level_keys(self):
+        config = _make_config()
+        parsed, _ = self._run_json(config)
+        assert "products" in parsed
+        assert "outcome" in parsed
+        assert "exit_status" in parsed
+
+    def test_json_products_keys(self):
+        config = _make_config()
+        parsed, _ = self._run_json(config)
+        assert set(parsed["products"].keys()) == {"connect", "workbench", "package_manager"}
+
+    def test_json_unconfigured_skip(self):
+        config = _make_config()
+        parsed, _ = self._run_json(config)
+        for name in ("connect", "workbench", "package_manager"):
+            product = parsed["products"][name]
+            assert product["configured"] is False
+            assert product["state"] == "skip"
+            assert product["detail"] == "not configured"
+            assert "url" not in product
+            assert "http_status" not in product
+
+    def test_json_configured_ok(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            parsed, _ = self._run_json(config)
+
+        product = parsed["products"]["connect"]
+        assert product["configured"] is True
+        assert product["state"] == "ok"
+        assert product["url"] == "https://c.example.com"
+        assert product["http_status"] == 200
+
+    def test_json_configured_fail_http(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 503
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            parsed, _ = self._run_json(config)
+
+        product = parsed["products"]["connect"]
+        assert product["state"] == "fail"
+        assert product["http_status"] == 503
+
+    def test_json_configured_exception(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.side_effect = ConnectionError("connection refused")
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            parsed, _ = self._run_json(config)
+
+        product = parsed["products"]["connect"]
+        assert product["state"] == "fail"
+        assert "connection refused" in product["detail"]
+        assert "http_status" not in product
+
+    def test_json_outcome_ok_all_skip(self):
+        config = _make_config()
+        parsed, code = self._run_json(config)
+        assert parsed["outcome"] == "ok"
+        assert parsed["exit_status"] == 0
+        assert code == 0
+
+    def test_json_outcome_ok_with_ok_product(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            parsed, code = self._run_json(config)
+
+        assert parsed["outcome"] == "ok"
+        assert parsed["exit_status"] == 0
+        assert code == 0
+
+    def test_json_outcome_fail_any_fail(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = 503
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            parsed, code = self._run_json(config)
+
+        assert parsed["outcome"] == "fail"
+        assert parsed["exit_status"] == 1
+        assert code == 1
+
+    def test_json_exit_1_on_exception(self):
+        config = _make_config(connect_url="https://c.example.com", connect_configured=True)
+
+        mock_client = MagicMock()
+        mock_client.health.side_effect = OSError("timeout")
+
+        with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
+            parsed, code = self._run_json(config)
+
+        assert parsed["exit_status"] == 1
+        assert code == 1
+
+    def test_json_is_valid_json(self):
+        """stdout must be valid JSON — no extra human-readable text mixed in."""
+        config = _make_config()
+        args = _make_args(json=True)
+
+        with (
+            patch("vip.config.load_config", return_value=config),
+            patch("vip.cli.sys.exit"),
+        ):
+            import io
+
+            from vip.cli import run_status
+
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                run_status(args)
+            except SystemExit:
+                pass
+            finally:
+                sys.stdout = old_stdout
+
+        # Must not raise
+        json.loads(captured.getvalue())
+
+    def test_json_mode_no_human_text_mixed_in(self):
+        """JSON mode must not print any human-readable lines outside the JSON object."""
+        config = _make_config()
+        args = _make_args(json=True)
+
+        with (
+            patch("vip.config.load_config", return_value=config),
+            patch("vip.cli.sys.exit"),
+        ):
+            import io
+
+            from vip.cli import run_status
+
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                run_status(args)
+            except SystemExit:
+                pass
+            finally:
+                sys.stdout = old_stdout
+
+        output = captured.getvalue().strip()
+        # Should be a single JSON object, not multiple lines of mixed text
+        parsed = json.loads(output)
+        assert isinstance(parsed, dict)

--- a/selftests/test_cli_status.py
+++ b/selftests/test_cli_status.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 def _make_args(**overrides) -> argparse.Namespace:
@@ -188,74 +189,61 @@ class TestCollectStatus:
 class TestRunStatusTextMode:
     """Text mode preserves the original format."""
 
-    def _run(self, config, args=None):
-        """Run run_status with mocked load_config and sys.exit, return (out, exit_code)."""
+    def _run(self, config, args=None, capsys=None):
+        """Run run_status, return (out, exit_code) using capsys."""
         if args is None:
             args = _make_args()
-        exit_code_holder = []
 
-        def fake_exit(code=0):
-            exit_code_holder.append(code)
+        from vip.cli import run_status
 
         with (
             patch("vip.config.load_config", return_value=config),
-            patch("vip.cli.sys.exit", side_effect=fake_exit),
         ):
-            import io
-
-            from vip.cli import run_status
-
-            captured = io.StringIO()
-            old_stdout = sys.stdout
-            sys.stdout = captured
-            try:
+            with pytest.raises(SystemExit) as excinfo:
                 run_status(args)
-            except SystemExit:
-                pass
-            finally:
-                sys.stdout = old_stdout
 
-        return captured.getvalue(), exit_code_holder[0] if exit_code_holder else None
+        out = capsys.readouterr().out
+        return out, excinfo.value.code
 
-    def test_skip_line_format(self):
+    def test_skip_line_format(self, capsys):
         config = _make_config()
-        out, _ = self._run(config)
+        out, _ = self._run(config, capsys=capsys)
         # Format: "  SKIP  package_manager       not configured"
         assert "SKIP" in out
         assert "not configured" in out
 
-    def test_ok_line_format(self):
+    def test_ok_line_format(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.return_value = 200
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            out, _ = self._run(config)
+            out, _ = self._run(config, capsys=capsys)
 
         assert "OK  " in out
         assert "HTTP 200" in out
 
-    def test_exit_0_when_all_ok_or_skip(self):
+    def test_exit_0_when_all_ok_or_skip(self, capsys):
         config = _make_config()
-        _, code = self._run(config)
+        _, code = self._run(config, capsys=capsys)
         assert code == 0
 
-    def test_exit_1_when_any_fail(self):
+    def test_exit_1_when_any_fail(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.return_value = 503
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            _, code = self._run(config)
+            _, code = self._run(config, capsys=capsys)
 
         assert code == 1
 
-    def test_text_line_width_format(self):
+    def test_text_line_width_format(self, capsys):
         """Verify the exact column format: '  {STATE:4s}  {name:20s}  {detail}'."""
         config = _make_config()
-        out, _ = self._run(config)
+        out, _ = self._run(config, capsys=capsys)
         lines = [line for line in out.splitlines() if line.strip()]
         assert len(lines) == 3  # one per product
         for line in lines:
@@ -266,52 +254,37 @@ class TestRunStatusTextMode:
 class TestRunStatusJsonMode:
     """JSON mode emits the documented schema to stdout."""
 
-    def _run_json(self, config):
+    def _run_json(self, config, capsys):
         """Run run_status with --json flag, return parsed JSON and exit_code."""
         args = _make_args(json=True)
-        exit_code_holder = []
 
-        def fake_exit(code=0):
-            exit_code_holder.append(code)
-            raise SystemExit(code)
+        from vip.cli import run_status
 
         with (
             patch("vip.config.load_config", return_value=config),
-            patch("vip.cli.sys.exit", side_effect=fake_exit),
         ):
-            import io
-
-            from vip.cli import run_status
-
-            captured = io.StringIO()
-            old_stdout = sys.stdout
-            sys.stdout = captured
-            try:
+            with pytest.raises(SystemExit) as excinfo:
                 run_status(args)
-            except SystemExit:
-                pass
-            finally:
-                sys.stdout = old_stdout
 
-        output = captured.getvalue()
+        output = capsys.readouterr().out
         parsed = json.loads(output)
-        return parsed, exit_code_holder[0] if exit_code_holder else None
+        return parsed, excinfo.value.code
 
-    def test_json_top_level_keys(self):
+    def test_json_top_level_keys(self, capsys):
         config = _make_config()
-        parsed, _ = self._run_json(config)
+        parsed, _ = self._run_json(config, capsys)
         assert "products" in parsed
         assert "outcome" in parsed
         assert "exit_status" in parsed
 
-    def test_json_products_keys(self):
+    def test_json_products_keys(self, capsys):
         config = _make_config()
-        parsed, _ = self._run_json(config)
+        parsed, _ = self._run_json(config, capsys)
         assert set(parsed["products"].keys()) == {"connect", "workbench", "package_manager"}
 
-    def test_json_unconfigured_skip(self):
+    def test_json_unconfigured_skip(self, capsys):
         config = _make_config()
-        parsed, _ = self._run_json(config)
+        parsed, _ = self._run_json(config, capsys)
         for name in ("connect", "workbench", "package_manager"):
             product = parsed["products"][name]
             assert product["configured"] is False
@@ -320,14 +293,14 @@ class TestRunStatusJsonMode:
             assert "url" not in product
             assert "http_status" not in product
 
-    def test_json_configured_ok(self):
+    def test_json_configured_ok(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.return_value = 200
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            parsed, _ = self._run_json(config)
+            parsed, _ = self._run_json(config, capsys)
 
         product = parsed["products"]["connect"]
         assert product["configured"] is True
@@ -335,128 +308,109 @@ class TestRunStatusJsonMode:
         assert product["url"] == "https://c.example.com"
         assert product["http_status"] == 200
 
-    def test_json_configured_fail_http(self):
+    def test_json_configured_fail_http(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.return_value = 503
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            parsed, _ = self._run_json(config)
+            parsed, _ = self._run_json(config, capsys)
 
         product = parsed["products"]["connect"]
         assert product["state"] == "fail"
         assert product["http_status"] == 503
 
-    def test_json_configured_exception(self):
+    def test_json_configured_exception(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.side_effect = ConnectionError("connection refused")
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            parsed, _ = self._run_json(config)
+            parsed, _ = self._run_json(config, capsys)
 
         product = parsed["products"]["connect"]
         assert product["state"] == "fail"
         assert "connection refused" in product["detail"]
         assert "http_status" not in product
 
-    def test_json_outcome_ok_all_skip(self):
+    def test_json_outcome_ok_all_skip(self, capsys):
         config = _make_config()
-        parsed, code = self._run_json(config)
+        parsed, code = self._run_json(config, capsys)
         assert parsed["outcome"] == "ok"
         assert parsed["exit_status"] == 0
         assert code == 0
 
-    def test_json_outcome_ok_with_ok_product(self):
+    def test_json_outcome_ok_with_ok_product(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.return_value = 200
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            parsed, code = self._run_json(config)
+            parsed, code = self._run_json(config, capsys)
 
         assert parsed["outcome"] == "ok"
         assert parsed["exit_status"] == 0
         assert code == 0
 
-    def test_json_outcome_fail_any_fail(self):
+    def test_json_outcome_fail_any_fail(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.return_value = 503
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            parsed, code = self._run_json(config)
+            parsed, code = self._run_json(config, capsys)
 
         assert parsed["outcome"] == "fail"
         assert parsed["exit_status"] == 1
         assert code == 1
 
-    def test_json_exit_1_on_exception(self):
+    def test_json_exit_1_on_exception(self, capsys):
         config = _make_config(connect_url="https://c.example.com", connect_configured=True)
 
         mock_client = MagicMock()
         mock_client.health.side_effect = OSError("timeout")
 
         with patch("vip.clients.connect.ConnectClient", return_value=mock_client):
-            parsed, code = self._run_json(config)
+            parsed, code = self._run_json(config, capsys)
 
         assert parsed["exit_status"] == 1
         assert code == 1
 
-    def test_json_is_valid_json(self):
+    def test_json_is_valid_json(self, capsys):
         """stdout must be valid JSON — no extra human-readable text mixed in."""
         config = _make_config()
         args = _make_args(json=True)
 
+        from vip.cli import run_status
+
         with (
             patch("vip.config.load_config", return_value=config),
-            patch("vip.cli.sys.exit"),
         ):
-            import io
-
-            from vip.cli import run_status
-
-            captured = io.StringIO()
-            old_stdout = sys.stdout
-            sys.stdout = captured
-            try:
+            with pytest.raises(SystemExit):
                 run_status(args)
-            except SystemExit:
-                pass
-            finally:
-                sys.stdout = old_stdout
 
+        output = capsys.readouterr().out
         # Must not raise
-        json.loads(captured.getvalue())
+        json.loads(output)
 
-    def test_json_mode_no_human_text_mixed_in(self):
+    def test_json_mode_no_human_text_mixed_in(self, capsys):
         """JSON mode must not print any human-readable lines outside the JSON object."""
         config = _make_config()
         args = _make_args(json=True)
 
+        from vip.cli import run_status
+
         with (
             patch("vip.config.load_config", return_value=config),
-            patch("vip.cli.sys.exit"),
         ):
-            import io
-
-            from vip.cli import run_status
-
-            captured = io.StringIO()
-            old_stdout = sys.stdout
-            sys.stdout = captured
-            try:
+            with pytest.raises(SystemExit):
                 run_status(args)
-            except SystemExit:
-                pass
-            finally:
-                sys.stdout = old_stdout
 
-        output = captured.getvalue().strip()
+        output = capsys.readouterr().out.strip()
         # Should be a single JSON object, not multiple lines of mixed text
         parsed = json.loads(output)
         assert isinstance(parsed, dict)

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from vip.timeouts import scaled
 
 if TYPE_CHECKING:
-    from vip.config import Mode
+    from vip.config import Mode, VIPConfig
 
 # Buffer subtracted from the user-supplied timeout when setting the pytest
 # timeout inside the K8s Job.  The Job's own deadline is set to args.timeout,
@@ -729,7 +729,7 @@ def run_report(args: argparse.Namespace) -> None:
     sys.exit(result.returncode)
 
 
-def _collect_status(config: object) -> dict:
+def _collect_status(config: VIPConfig) -> dict:
     """Run health checks and return structured status data.
 
     Returns a dict with the schema::
@@ -751,9 +751,9 @@ def _collect_status(config: object) -> dict:
     from vip.clients.workbench import WorkbenchClient
 
     checks = [
-        ("connect", config.connect),  # type: ignore[attr-defined]
-        ("workbench", config.workbench),  # type: ignore[attr-defined]
-        ("package_manager", config.package_manager),  # type: ignore[attr-defined]
+        ("connect", config.connect),
+        ("workbench", config.workbench),
+        ("package_manager", config.package_manager),
     ]
 
     products: dict[str, dict] = {}

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -729,30 +729,41 @@ def run_report(args: argparse.Namespace) -> None:
     sys.exit(result.returncode)
 
 
-def run_status(args: argparse.Namespace) -> None:
-    """Run preflight health checks against each configured product."""
+def _collect_status(config: object) -> dict:
+    """Run health checks and return structured status data.
+
+    Returns a dict with the schema::
+
+        {
+            "products": {
+                "connect":         {"configured": bool, "state": "ok"|"fail"|"skip", ...},
+                "workbench":       {...},
+                "package_manager": {...},
+            },
+            "outcome": "ok" | "fail",
+            "exit_status": 0 | 1,
+        }
+
+    No printing or sys.exit side effects; callers handle rendering.
+    """
+    from vip.clients.connect import ConnectClient
     from vip.clients.packagemanager import PackageManagerClient
     from vip.clients.workbench import WorkbenchClient
-    from vip.config import load_config
-
-    config = load_config(args.config)
 
     checks = [
-        ("connect", config.connect),
-        ("workbench", config.workbench),
-        ("package_manager", config.package_manager),
+        ("connect", config.connect),  # type: ignore[attr-defined]
+        ("workbench", config.workbench),  # type: ignore[attr-defined]
+        ("package_manager", config.package_manager),  # type: ignore[attr-defined]
     ]
 
-    results = []
+    products: dict[str, dict] = {}
     for name, pc in checks:
         if not pc.is_configured:
-            results.append((name, "not configured", "skip"))
+            products[name] = {"configured": False, "state": "skip", "detail": "not configured"}
             continue
         try:
             if name == "connect":
-                from vip.clients.connect import ConnectClient as CC
-
-                client: CC | WorkbenchClient | PackageManagerClient = CC(
+                client = ConnectClient(
                     pc.url,
                     pc.api_key,  # type: ignore[attr-defined]
                 )
@@ -760,16 +771,49 @@ def run_status(args: argparse.Namespace) -> None:
                 client = WorkbenchClient(pc.url, pc.api_key)  # type: ignore[attr-defined]
             else:
                 client = PackageManagerClient(pc.url, pc.token)  # type: ignore[attr-defined]
-            status = client.health()
-            state = "ok" if status < 400 else "fail"
-            results.append((name, f"HTTP {status}", state))
+            http_status = client.health()
+            state = "ok" if http_status < 400 else "fail"
+            products[name] = {
+                "configured": True,
+                "url": pc.url,
+                "http_status": http_status,
+                "state": state,
+            }
         except Exception as e:
-            results.append((name, str(e), "fail"))
+            products[name] = {
+                "configured": True,
+                "url": pc.url,
+                "state": "fail",
+                "detail": str(e),
+            }
 
-    for name, detail, state in results:
-        print(f"  {state.upper():4s}  {name:20s}  {detail}")
+    all_ok = all(p["state"] in ("ok", "skip") for p in products.values())
+    outcome = "ok" if all_ok else "fail"
+    exit_status = 0 if all_ok else 1
+    return {"products": products, "outcome": outcome, "exit_status": exit_status}
 
-    sys.exit(0 if all(s in ("ok", "skip") for _, _, s in results) else 1)
+
+def run_status(args: argparse.Namespace) -> None:
+    """Run preflight health checks against each configured product."""
+    from vip.config import load_config
+
+    config = load_config(args.config)
+    data = _collect_status(config)
+
+    if getattr(args, "json", False):
+        print(json.dumps(data))
+    else:
+        for name, product in data["products"].items():
+            state = product["state"]
+            if state == "skip":
+                detail = product.get("detail", "not configured")
+            elif "http_status" in product:
+                detail = f"HTTP {product['http_status']}"
+            else:
+                detail = product.get("detail", "")
+            print(f"  {state.upper():4s}  {name:20s}  {detail}")
+
+    sys.exit(data["exit_status"])
 
 
 def run_app(args: argparse.Namespace) -> None:
@@ -1439,6 +1483,12 @@ def main() -> None:
         "--config",
         default=None,
         help="Path to vip.toml (default: VIP_CONFIG env var or ./vip.toml)",
+    )
+    status_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit machine-readable JSON instead of human-formatted text",
     )
     status_parser.set_defaults(func=run_status)
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -763,7 +763,7 @@ def _collect_status(config: object) -> dict:
             continue
         try:
             if name == "connect":
-                client = ConnectClient(
+                client: ConnectClient | WorkbenchClient | PackageManagerClient = ConnectClient(
                     pc.url,
                     pc.api_key,  # type: ignore[attr-defined]
                 )

--- a/validation_docs/demo-status-json-output.md
+++ b/validation_docs/demo-status-json-output.md
@@ -10,12 +10,10 @@ This adds a `--json` flag to `vip status`. The check loop was refactored into a 
 ### Default text mode is unchanged
 
 ```bash
-uv run vip status
+uv run vip status 2>/dev/null
 ```
 
 ```output
-/Users/ianfloressiaca/ptd-workspace/.worktrees/vip-status-json-output/src/vip/cli.py:800: UserWarning: Config file not found: vip.toml
-  config = load_config(args.config)
   SKIP  connect               not configured
   SKIP  workbench             not configured
   SKIP  package_manager       not configured

--- a/validation_docs/demo-status-json-output.md
+++ b/validation_docs/demo-status-json-output.md
@@ -1,0 +1,82 @@
+# feat(cli): add --json output to vip status (#384)
+
+*2026-06-17T21:21:33Z by Showboat 0.6.1*
+<!-- showboat-id: 6674d762-7c49-4d7c-806f-a38e9756bf6e -->
+
+Issue #384 asks for machine-readable output from `vip status` so headless/CI callers can consume the per-product health check without scraping stdout — the same programmatic parity `vip verify --report` already offers via results.json.
+
+This adds a `--json` flag to `vip status`. The check loop was refactored into a pure `_collect_status(config)` helper so the text and JSON renderers, plus the 0/1 exit code, all derive from one source of truth. The JSON schema is aligned with reporting.py field names (`products` keyed by name, `configured`, `url`, `outcome`, `exit_status`).
+
+### Default text mode is unchanged
+
+```bash
+uv run vip status
+```
+
+```output
+/Users/ianfloressiaca/ptd-workspace/.worktrees/vip-status-json-output/src/vip/cli.py:800: UserWarning: Config file not found: vip.toml
+  config = load_config(args.config)
+  SKIP  connect               not configured
+  SKIP  workbench             not configured
+  SKIP  package_manager       not configured
+```
+
+### New machine-readable JSON mode
+
+Diagnostics go to stderr, so stdout is pure JSON — pipe it straight into a parser:
+
+```bash
+uv run vip status --json 2>/dev/null | python -m json.tool
+```
+
+```output
+{
+    "products": {
+        "connect": {
+            "configured": false,
+            "state": "skip",
+            "detail": "not configured"
+        },
+        "workbench": {
+            "configured": false,
+            "state": "skip",
+            "detail": "not configured"
+        },
+        "package_manager": {
+            "configured": false,
+            "state": "skip",
+            "detail": "not configured"
+        }
+    },
+    "outcome": "ok",
+    "exit_status": 0
+}
+```
+
+### New selftests (27, TDD'd — none existed for run_status before)
+
+```bash
+uv run pytest selftests/test_cli_status.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+27 passed
+```
+
+### Lint and format clean
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+```
+
+```bash
+uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+155 files already formatted
+```


### PR DESCRIPTION
Closes #384.

Adds a `--json` flag to `vip status`, giving headless/CI callers a machine-readable per-product health check — the same programmatic parity `vip verify --report` already offers via `results.json`.

### What changed
- New `--json` flag on `vip status`. Default text output is byte-for-byte unchanged.
- Refactored the check loop into a pure `_collect_status(config)` helper (no printing, no `sys.exit`) so the text renderer, JSON renderer, and 0/1 exit code all derive from one source of truth.
- JSON schema aligns with `reporting.py` field names (`products` keyed by name, `configured`, `url`, `outcome`, `exit_status`).
- Diagnostics stay on stderr, so stdout is pure JSON.

### Testing
- 27 new selftests in `selftests/test_cli_status.py` (none existed for `run_status` before): text mode, JSON schema, ok/fail/skip per product, and outcome/exit-status logic in both modes.
- `ruff check` / `ruff format --check` clean.

### Related
Part of the CI/machine-readable output work tracked in #149 and #150; follows the `results.json` precedent from #162.

## Demo

# feat(cli): add --json output to vip status (#384)

*2026-06-17T21:21:33Z by Showboat 0.6.1*
<!-- showboat-id: 6674d762-7c49-4d7c-806f-a38e9756bf6e -->

Issue #384 asks for machine-readable output from `vip status` so headless/CI callers can consume the per-product health check without scraping stdout — the same programmatic parity `vip verify --report` already offers via results.json.

This adds a `--json` flag to `vip status`. The check loop was refactored into a pure `_collect_status(config)` helper so the text and JSON renderers, plus the 0/1 exit code, all derive from one source of truth. The JSON schema is aligned with reporting.py field names (`products` keyed by name, `configured`, `url`, `outcome`, `exit_status`).

### Default text mode is unchanged

```bash
uv run vip status
```

```output
/Users/ianfloressiaca/ptd-workspace/.worktrees/vip-status-json-output/src/vip/cli.py:800: UserWarning: Config file not found: vip.toml
  config = load_config(args.config)
  SKIP  connect               not configured
  SKIP  workbench             not configured
  SKIP  package_manager       not configured
```

### New machine-readable JSON mode

Diagnostics go to stderr, so stdout is pure JSON — pipe it straight into a parser:

```bash
uv run vip status --json 2>/dev/null | python -m json.tool
```

```output
{
    "products": {
        "connect": {
            "configured": false,
            "state": "skip",
            "detail": "not configured"
        },
        "workbench": {
            "configured": false,
            "state": "skip",
            "detail": "not configured"
        },
        "package_manager": {
            "configured": false,
            "state": "skip",
            "detail": "not configured"
        }
    },
    "outcome": "ok",
    "exit_status": 0
}
```

### New selftests (27, TDD'd — none existed for run_status before)

```bash
uv run pytest selftests/test_cli_status.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
27 passed
```

### Lint and format clean

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
```

```bash
uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
155 files already formatted
```