### PR TITLE
fix(plugin): suppress pytest-bdd PytestRemovedIn10Warning on pytest 9.1

### DIFF
--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -205,6 +205,31 @@ class TestPluginIntegration:
         result.assert_outcomes()
         result.stdout.fnmatch_lines(["*1 deselected*"])
 
+    def test_pytest_bdd_removed_in10_warning_suppressed(self, selftest_pytester):
+        """pytest-bdd's fixture injection emits PytestRemovedIn10Warning on
+        pytest >= 9.1 (``_register_fixture(nodeid=...)``/``FixtureDef(baseid=...)``).
+        The plugin filters that category so it never reaches users who install
+        vip into their own project. We emit the warning directly because the
+        repo-pinned pytest does not warn yet, which keeps the check meaningful
+        regardless of the installed pytest version.
+        """
+        selftest_pytester.makepyfile(
+            """
+            import warnings
+
+            import pytest
+
+            def test_emits_removed_in10():
+                warnings.warn(
+                    "Passing nodeid to _register_fixture is deprecated.",
+                    pytest.PytestRemovedIn10Warning,
+                )
+            """
+        )
+        result = selftest_pytester.runpytest("--vip-config=vip.toml")
+        result.assert_outcomes(passed=1)
+        result.stdout.no_fnmatch_line("*PytestRemovedIn10Warning*")
+
     def test_performance_deselected_by_default(self, selftest_pytester):
         """_default_marker_expr excludes performance when --performance-tests is not set."""
         import argparse

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -125,6 +125,12 @@ def pytest_configure(config: pytest.Config) -> None:
         "ignore:ssl.TLSVersion.TLSv1_1:DeprecationWarning",
         # pytest-bdd scenario functions return fixture values; not a real issue.
         "ignore::pytest.PytestReturnNotNoneWarning",
+        # pytest-bdd 8.1.0 injects fixtures via _register_fixture(nodeid=...) and
+        # FixtureDef(baseid=...), which pytest >= 9.1 deprecates in favor of node=.
+        # Framework-level and only fixable when pytest-bdd updates; nothing VIP can
+        # change. A category filter is required because the warning surfaces from two
+        # modules (pytest_bdd and _pytest.fixtures), so module/message scoping misses one.
+        "ignore::pytest.PytestRemovedIn10Warning",
         # gevent monkey-patching happens after ssl is imported by other plugins;
         # unavoidable without patching at process start.
         "ignore:Monkey-patching ssl",


### PR DESCRIPTION
## Summary

pytest-bdd 8.1.0 injects fixtures via `_register_fixture(nodeid=...)` and `FixtureDef(baseid=...)`, which **pytest >= 9.1** deprecates in favor of `node=`, emitting `PytestRemovedIn10Warning`. The 0.48.1 lockfile bumps pytest **9.0.3 → 9.1.1**, so these warnings now surface for users running configured product tests.

This registers an ignore filter for the category in the plugin (the canonical location, so it travels with the installed package).

It isn't always seen locally because:

1. **Version** — pytest 9.0.3 does not emit this warning at all; only 9.1+ does. The lockfile bump to 9.1.1 is what introduces it.
2. **When it fires** — `inject_fixture` runs at *step-execution* time, only for steps with a `target_fixture` (`scenario.py:247`), not at collection. With no products configured, product tests are deselected and never run that path. It only appears when running against real configured products.

The warning surfaces from **two** modules (`pytest_bdd.compat` and `_pytest.fixtures`), so module-scoped and message-scoped filters each miss the second one. `pytest.PytestRemovedIn10Warning` exists in both 9.0.3 and 9.1.1, so the filter is safe across the pin range.

## Testing

- Reproduced both exact warnings on pytest 9.1.1; confirmed they vanish with the filter.
- End-to-end: a real `target_fixture` scenario through the vip plugin → `1 passed`, zero warnings.
- Added a version-independent selftest (`test_pytest_bdd_removed_in10_warning_suppressed`) that emits the category directly and asserts suppression — fails without the fix, passes with it.
- `841 passed, 3 skipped`; ruff lint + format clean.
