### PR TITLE
feat(workbench): add anonymous git auth mode (none)

### DIFF
--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -616,6 +616,24 @@ class TestGitTestConfig:
         cfg = GitTestConfig(clone_url="https://github.com/org/repo.git", auth_method="none")
         assert cfg.token == ""
 
+    def test_none_auth_method_clears_explicit_token(self):
+        cfg = GitTestConfig(
+            clone_url="https://github.com/org/repo.git",
+            auth_method="none",
+            token="explicit-token",
+        )
+        assert cfg.token == ""
+
+    def test_none_auth_method_from_dict_clears_token(self):
+        cfg = GitTestConfig.from_dict(
+            {
+                "clone_url": "https://github.com/org/repo.git",
+                "auth_method": "none",
+                "token": "explicit-token",
+            }
+        )
+        assert cfg.token == ""
+
     def test_none_auth_method_from_dict(self):
         cfg = GitTestConfig.from_dict(
             {"clone_url": "https://github.com/org/repo.git", "auth_method": "none"}

--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -607,6 +607,22 @@ class TestGitTestConfig:
         with pytest.raises(ValueError, match="auth_method.*not supported"):
             GitTestConfig(clone_url="https://github.com/org/repo.git", auth_method="ssh-key")
 
+    def test_none_auth_method_is_valid(self):
+        cfg = GitTestConfig(clone_url="https://github.com/org/repo.git", auth_method="none")
+        assert cfg.auth_method == "none"
+
+    def test_none_auth_method_leaves_token_empty_with_env(self, monkeypatch):
+        monkeypatch.setenv("VIP_GIT_TOKEN", "ghp_should_be_ignored")
+        cfg = GitTestConfig(clone_url="https://github.com/org/repo.git", auth_method="none")
+        assert cfg.token == ""
+
+    def test_none_auth_method_from_dict(self):
+        cfg = GitTestConfig.from_dict(
+            {"clone_url": "https://github.com/org/repo.git", "auth_method": "none"}
+        )
+        assert cfg.auth_method == "none"
+        assert cfg.clone_url == "https://github.com/org/repo.git"
+
     def test_repr_redacts_token(self):
         cfg = GitTestConfig(clone_url="https://github.com/org/repo.git", token="secret")
         assert "secret" not in repr(cfg)

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -209,7 +209,12 @@ class GitTestConfig:
                 f"workbench.git_test.auth_method={self.auth_method!r} is not supported. "
                 f"Supported values: {', '.join(self._SUPPORTED_AUTH_METHODS)}"
             )
-        if self.auth_method == "https-token" and not self.token:
+        if self.auth_method == "none":
+            # Anonymous mode is genuinely tokenless: discard any token from the
+            # environment or an explicit TOML/constructor value so clones never
+            # inject credentials.
+            self.token = ""
+        elif not self.token:
             self.token = os.environ.get("VIP_GIT_TOKEN", "")
 
     def __repr__(self) -> str:

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -190,15 +190,18 @@ class GitTestConfig:
     against a real Git repository.  All scenarios auto-skip when this block
     is absent from the config file.
 
-    Token is never stored in the TOML file.  Set VIP_GIT_TOKEN in the
-    environment (same pattern as VIP_PACKAGE_MANAGER_TOKEN).
+    Token is never stored in the TOML file.  For ``auth_method = "https-token"``
+    set VIP_GIT_TOKEN in the environment (same pattern as
+    VIP_PACKAGE_MANAGER_TOKEN).  ``auth_method = "none"`` performs an anonymous
+    HTTPS clone of a public repository and needs no token; in that mode the
+    clone/connectivity scenarios run and the push/commit scenarios skip.
     """
 
     clone_url: str = ""
-    auth_method: str = "https-token"  # only supported value currently
+    auth_method: str = "https-token"  # "https-token" or "none" (anonymous clone)
     token: str = ""
 
-    _SUPPORTED_AUTH_METHODS = ("https-token",)
+    _SUPPORTED_AUTH_METHODS = ("https-token", "none")
 
     def __post_init__(self) -> None:
         if self.auth_method not in self._SUPPORTED_AUTH_METHODS:
@@ -206,7 +209,7 @@ class GitTestConfig:
                 f"workbench.git_test.auth_method={self.auth_method!r} is not supported. "
                 f"Supported values: {', '.join(self._SUPPORTED_AUTH_METHODS)}"
             )
-        if not self.token:
+        if self.auth_method == "https-token" and not self.token:
             self.token = os.environ.get("VIP_GIT_TOKEN", "")
 
     def __repr__(self) -> str:

--- a/src/vip_tests/workbench/test_git_ops.feature
+++ b/src/vip_tests/workbench/test_git_ops.feature
@@ -2,8 +2,9 @@
 Feature: Git operations from Workbench sessions
   Validate that users inside a Workbench session can clone, commit, and push
   to a Git repository through IDE terminals (RStudio, VS Code, Positron).
-  All scenarios require [workbench.git_test] to be configured in vip.toml
-  and the VIP_GIT_TOKEN environment variable to be set.
+  All scenarios require [workbench.git_test] in vip.toml. Clone scenarios run
+  with auth_method "https-token" (VIP_GIT_TOKEN set) or "none" (anonymous clone
+  of a public repo); push scenarios require "https-token".
 
   Scenario: Clone a Git repository in RStudio terminal
     Given Workbench is accessible and I am logged in
@@ -15,6 +16,7 @@ Feature: Git operations from Workbench sessions
   Scenario: Create a branch, commit, and push from RStudio terminal
     Given Workbench is accessible and I am logged in
     And the Git test config is available
+    And the Git test config supports pushing
     When I launch an RStudio session
     And I clone the repository in the RStudio terminal
     And I create a branch and commit a file in the RStudio terminal
@@ -32,6 +34,7 @@ Feature: Git operations from Workbench sessions
   Scenario: Create a branch, commit, and push from VS Code terminal
     Given Workbench is accessible and I am logged in
     And the Git test config is available
+    And the Git test config supports pushing
     When I launch a VS Code session
     And I clone the repository in the VS Code terminal
     And I create a branch and commit a file in the VS Code terminal
@@ -49,6 +52,7 @@ Feature: Git operations from Workbench sessions
   Scenario: Create a branch, commit, and push from Positron terminal
     Given Workbench is accessible and I am logged in
     And the Git test config is available
+    And the Git test config supports pushing
     When I launch a Positron session
     And I clone the repository in the Positron terminal
     And I create a branch and commit a file in the Positron terminal

--- a/src/vip_tests/workbench/test_git_ops.py
+++ b/src/vip_tests/workbench/test_git_ops.py
@@ -228,7 +228,8 @@ def git_config_available(vip_config):
     if _urlparse(cfg.clone_url).scheme != "https":
         pytest.skip(
             f"workbench.git_test.clone_url scheme is not https: {cfg.clone_url!r}. "
-            "Token injection requires an https:// clone URL."
+            "Git test scenarios require an https:// clone URL "
+            "(token injection for auth_method='https-token' relies on it)."
         )
     if cfg.auth_method == "https-token" and not cfg.token:
         pytest.skip(

--- a/src/vip_tests/workbench/test_git_ops.py
+++ b/src/vip_tests/workbench/test_git_ops.py
@@ -3,8 +3,10 @@
 Tests cover terminal-based Git operations (clone, branch, commit, push) in
 RStudio, VS Code, and Positron sessions.
 
-Requires [workbench.git_test] in vip.toml and VIP_GIT_TOKEN set in the
-environment.  All scenarios auto-skip when the config block is absent.
+Requires [workbench.git_test] in vip.toml.  Clone scenarios run with
+auth_method "https-token" (VIP_GIT_TOKEN set) or "none" (anonymous clone of a
+public repo); push scenarios require "https-token".  All scenarios auto-skip
+when the config block is absent.
 """
 
 from __future__ import annotations
@@ -211,12 +213,12 @@ def git_config_available(vip_config):
         pytest.skip(
             "Git test config is not configured. "
             "Add a [workbench.git_test] block to vip.toml with clone_url and auth_method, "
-            "and set VIP_GIT_TOKEN in the environment."
+            "and set VIP_GIT_TOKEN in the environment (for auth_method='https-token')."
         )
-    if cfg.auth_method != "https-token":
+    if cfg.auth_method not in ("https-token", "none"):
         pytest.skip(
             f"workbench.git_test.auth_method={cfg.auth_method!r} is not supported. "
-            "Only 'https-token' is supported."
+            "Supported values: 'https-token', 'none'."
         )
     if not cfg.clone_url:
         pytest.skip(
@@ -228,12 +230,23 @@ def git_config_available(vip_config):
             f"workbench.git_test.clone_url scheme is not https: {cfg.clone_url!r}. "
             "Token injection requires an https:// clone URL."
         )
-    if not cfg.token:
+    if cfg.auth_method == "https-token" and not cfg.token:
         pytest.skip(
             "VIP_GIT_TOKEN is not set. "
-            "Export VIP_GIT_TOKEN=<personal-access-token> before running Git test scenarios."
+            "Export VIP_GIT_TOKEN=<personal-access-token> before running Git test scenarios, "
+            "or set auth_method='none' for an anonymous public-repo clone."
         )
     return cfg
+
+
+@given("the Git test config supports pushing")
+def git_config_supports_pushing(git_cfg):
+    """Skip write scenarios under anonymous (read-only) auth."""
+    if git_cfg.auth_method == "none":
+        pytest.skip(
+            "workbench.git_test.auth_method='none' is anonymous (read-only). "
+            "Push/commit scenarios require auth_method='https-token' with VIP_GIT_TOKEN set."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/validation_docs/demo-git-anonymous-auth.md
+++ b/validation_docs/demo-git-anonymous-auth.md
@@ -1,0 +1,38 @@
+# Feature: anonymous (none) git auth mode
+
+*2026-06-24T15:33:09Z by Showboat 0.6.1*
+<!-- showboat-id: d06f42a9-f1b6-4539-af0a-5ae9f71e7e76 -->
+
+Adds auth_method='none' to [workbench.git_test]: clone scenarios run against a public repo with no VIP_GIT_TOKEN; push/commit scenarios skip.
+
+```bash
+uv run pytest selftests/test_config.py::TestGitTestConfig -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+15 passed
+```
+
+```bash
+uv run pytest src/vip_tests/workbench/test_git_ops.py --collect-only -q 2>&1 | grep -E 'tests? collected' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+no tests collected (6 deselected)
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+```
+
+```bash
+uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+159 files already formatted
+```

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -99,12 +99,15 @@ url = "https://workbench.example.com"
 # (RStudio terminal, VS Code terminal, Positron terminal, and RStudio Git pane).
 # All Git scenarios auto-skip when this block is absent.
 #
-# Token is never stored in this file — set VIP_GIT_TOKEN in the environment.
+# auth_method = "https-token": set VIP_GIT_TOKEN in the environment (never in
+#   this file); clone and push scenarios run.
 #   export VIP_GIT_TOKEN="ghp_..."
+# auth_method = "none": anonymous HTTPS clone of a public repo; no token needed;
+#   only the clone/connectivity scenarios run (push/commit scenarios skip).
 #
 # [workbench.git_test]
 # clone_url = "https://github.com/org/repo.git"
-# auth_method = "https-token"    # only supported value; SSH is out of scope
+# auth_method = "https-token"    # "https-token" or "none"; SSH is out of scope
 
 [package_manager]
 enabled = true


### PR DESCRIPTION
## Summary

Adds an anonymous `auth_method = "none"` to the `[workbench.git_test]` config so you can verify Workbench Git connectivity against a public HTTPS repo **without supplying a token**. Requested by a user who wanted to "check git connectivity/tests" but found "needing to add a random token doesn't make sense if all I'm testing is git functionality."

### Behavior

| `auth_method` | Token required | Clone scenarios | Push/commit scenarios |
|---------------|----------------|-----------------|-----------------------|
| `https-token` (default) | yes (`VIP_GIT_TOKEN`) | run | run |
| `none` | no | run | **skip** |

Under `none`, the clone runs anonymously (token injection is a no-op when the token is empty), and the branch/commit/push scenarios auto-skip since they can't succeed without write credentials.

### Changes

- **`src/vip/config.py`** — `GitTestConfig` accepts `auth_method = "none"`; the `VIP_GIT_TOKEN` fallback is now scoped to `https-token`, so `none` mode stays genuinely tokenless even if `VIP_GIT_TOKEN` is exported. Docstring + field comment updated.
- **`src/vip_tests/workbench/test_git_ops.py`** — `git_config_available` accepts both modes and only requires a token for `https-token`; new Given `the Git test config supports pushing` skips the write scenarios under `none`. Module docstring updated.
- **`src/vip_tests/workbench/test_git_ops.feature`** — the three push scenarios gain `And the Git test config supports pushing`; the three clone scenarios run unchanged. Feature description updated.
- **`vip.toml.example`** — documents the `none` mode.
- **`selftests/test_config.py`** — new cases: `none` is valid, leaves the token empty even with `VIP_GIT_TOKEN` set, and parses via `from_dict`.

`clone_url` remains required and HTTPS-only in both modes. Existing `https-token` behavior is unchanged.

## Test plan

- `uv run pytest selftests/` — 844 passed, 3 skipped
- `uv run pytest src/vip_tests/workbench/test_git_ops.py --collect-only` — 6 scenarios parse
- `uv run ruff check` / `ruff format --check` — clean

## Demo

```bash
uv run pytest selftests/test_config.py::TestGitTestConfig -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
15 passed
```

```bash
uv run pytest src/vip_tests/workbench/test_git_ops.py --collect-only -q 2>&1 | grep -E 'tests? collected' | sed 's/ in [0-9.]*s//'
```

```output
no tests collected (6 deselected)
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
```

```bash
uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
159 files already formatted
```
