### PR TITLE
ci: scope smoke-test filters per product and cache Playwright browsers

### DIFF
--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -31,7 +31,19 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'src/**'
+              - 'src/vip_tests/connect/**'
+              - 'src/vip/clients/connect.py'
+              # shared across all smoke workflows:
+              - 'src/vip_tests/prerequisites/**'
+              # connect-only shared tests:
+              - 'src/vip_tests/security/**'
+              # shared core — affects all products:
+              - 'src/vip/auth.py'
+              - 'src/vip/idp.py'
+              - 'src/vip/config.py'
+              - 'src/vip/plugin.py'
+              - 'src/vip/cli.py'
+              - 'src/vip_tests/conftest.py'
               - 'pyproject.toml'
               - 'uv.lock'
               - '.github/workflows/connect-smoke.yml'
@@ -134,6 +146,16 @@ jobs:
 
       - name: Install dependencies
         run: uv sync
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(uv run playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
         run: uv run vip install --skip-system

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -31,7 +31,17 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'src/**'
+              - 'src/vip_tests/package_manager/**'
+              - 'src/vip/clients/packagemanager.py'
+              # shared across all smoke workflows:
+              - 'src/vip_tests/prerequisites/**'
+              # shared core — affects all products:
+              - 'src/vip/auth.py'
+              - 'src/vip/idp.py'
+              - 'src/vip/config.py'
+              - 'src/vip/plugin.py'
+              - 'src/vip/cli.py'
+              - 'src/vip_tests/conftest.py'
               - 'pyproject.toml'
               - 'uv.lock'
               - '.github/workflows/packagemanager-smoke.yml'

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -41,6 +41,8 @@ jobs:
               - 'src/vip/config.py'
               - 'src/vip/plugin.py'
               - 'src/vip/cli.py'
+              - 'src/vip/clients/base.py'
+              - 'src/vip/timeouts.py'
               - 'src/vip_tests/conftest.py'
               - 'pyproject.toml'
               - 'uv.lock'

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -41,6 +41,8 @@ jobs:
               - 'src/vip/config.py'
               - 'src/vip/plugin.py'
               - 'src/vip/cli.py'
+              - 'src/vip/clients/base.py'
+              - 'src/vip/timeouts.py'
               - 'src/vip_tests/conftest.py'
               - 'pyproject.toml'
               - 'uv.lock'

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -31,7 +31,17 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'src/**'
+              - 'src/vip_tests/workbench/**'
+              - 'src/vip/clients/workbench.py'
+              # shared across all smoke workflows:
+              - 'src/vip_tests/prerequisites/**'
+              # shared core — affects all products:
+              - 'src/vip/auth.py'
+              - 'src/vip/idp.py'
+              - 'src/vip/config.py'
+              - 'src/vip/plugin.py'
+              - 'src/vip/cli.py'
+              - 'src/vip_tests/conftest.py'
               - 'pyproject.toml'
               - 'uv.lock'
               - '.github/workflows/workbench-smoke.yml'
@@ -150,6 +160,16 @@ jobs:
 
       - name: Install dependencies
         run: uv sync
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(uv run playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
         run: uv run vip install --skip-system


### PR DESCRIPTION
## Summary

Infra-only portion of "Priority 1" from the VIP hardening plan. No test code touched.

- **Per-product path scoping** in each smoke workflow's `changes`/`dorny/paths-filter` gate. Previously all three used a blanket `src/**` filter, so a single-product change (e.g. a Workbench-only edit) spun up Connect *and* Package Manager containers too. Each filter now matches only its product's test dir + client, plus the shared `prerequisites/` tests and shared-core modules (`auth`, `idp`, `config`, `plugin`, `cli`, root `conftest`) that legitimately fan out to all products. Connect also keeps `security/` since connect-smoke runs `security/test_error_handling`.
- **Playwright browser cache** added to connect-smoke and workbench-smoke (the browser-using jobs), keyed on `runner.os` + the resolved Playwright version (`playwright --version`), so routine dependency bumps don't bust the cache — only an actual Playwright version change does. Package Manager smoke is API-only and unchanged.
- `preview.yml` intentionally **left unchanged**: it renders *live* test results (calls `example-report.yml`, which runs pytest then `quarto render`), so narrowing its `src/**` trigger would make previews stale rather than save redundant work.

## Validation

- All three workflow YAML files parse cleanly (`yaml.safe_load`).
- `uv run playwright --version | awk '{print $2}'` resolves to `1.60.0`, confirming the cache-key expression.

## Notes

Follow-up PRs will promote the currently collected-only feature files into these (now-scoped) smoke jobs, category by category, with known-broken Workbench/auth tests xfail'd against their issue numbers.