### PR TITLE
ci: promote full connect category and PM repo tests to smoke

### DIFF
--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -178,7 +178,7 @@ jobs:
           username = "__bootstrap_admin__"
           EOF
 
-      # Run the subset of tests that work against Docker Connect
+      # Run the full connect category against Docker Connect
       - name: Run Connect smoke tests
         run: |
           uv run pytest \
@@ -186,6 +186,12 @@ jobs:
             src/vip_tests/connect/test_auth.py \
             src/vip_tests/connect/test_users.py \
             src/vip_tests/connect/test_runtime_versions.py \
+            src/vip_tests/connect/test_system_checks.py \
+            src/vip_tests/connect/test_content_deploy.py \
+            src/vip_tests/connect/test_packages.py \
+            src/vip_tests/connect/test_email.py \
+            src/vip_tests/connect/test_data_sources.py \
+            src/vip_tests/connect/test_chronicle.py \
             src/vip_tests/security/test_error_handling.py \
             -v \
             -k "not connect_login_ui" \

--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -178,7 +178,7 @@ jobs:
           username = "__bootstrap_admin__"
           EOF
 
-      # Run the full connect category against Docker Connect
+      # Run the full Connect API test suite against Docker Connect (excluding the UI login scenario)
       - name: Run Connect smoke tests
         run: |
           uv run pytest \

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -216,6 +216,8 @@ jobs:
             "src/vip_tests/prerequisites/test_components.py::test_product_server_is_reachable[Package Manager]" \
             src/vip_tests/prerequisites/test_versions.py \
             src/vip_tests/package_manager/test_repos.py \
+            src/vip_tests/package_manager/test_authenticated_repos.py \
+            src/vip_tests/package_manager/test_private_repos.py \
             -v \
             --vip-config=vip.toml \
             --junitxml=smoke-results.xml


### PR DESCRIPTION
## Summary

Priority 1, step 3 (promotion) — Connect and Package Manager only; Workbench deferred (its known-broken selector/auth tests come in a later PR, xfail'd against their issues).

- **connect-smoke** now runs the **full connect category** on every connect-affecting PR, matching the nightly's coverage but on PR triggers: adds `test_system_checks`, `test_content_deploy`, `test_packages`, plus the `@if_applicable` `test_email`/`test_data_sources`/`test_chronicle`.
- **packagemanager-smoke** adds `test_authenticated_repos` and `test_private_repos`.

## Why expand the pytest list instead of `vip verify --categories connect`

The nightly `connect-integration.yml` runs the full category via `vip verify --api-auth` (OIDC/browser auth). connect-smoke authenticates differently — it generates a `vip.toml` with a direct `api_key` and `provider = "password"`. Switching smoke to `vip verify --api-auth` would break its auth path (no OIDC wiring, no `--connect-url`). Expanding the explicit pytest file list preserves the existing API-key auth.

## Auto-skip safety

The `@if_applicable` tests (`email`, `data_sources`, `chronicle`) auto-skip on a bare Docker Connect, and `chronicle` is additionally `min_version`-gated to Connect 2026.06.0. The two PM files are `@if_applicable` and skip when authenticated/private repos aren't configured. So promotion does not redden CI on a feature it can't exercise.

## Risk note

This is the first time smoke exercises `test_content_deploy` under the **API-key** auth path (the nightly proves it under OIDC). If anything in content deploy is auth-mode-sensitive, this PR's CI is where it surfaces.