### PR TITLE
fix(plugin): show full skip reasons and dedup auth warning

### DIFF
--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -1271,6 +1271,51 @@ class TestAuthModeStash:
             f"expected both xdist workers to restore mode, got workerids={workerids}"
         )
 
+    @pytest.mark.parametrize(
+        ("auth_flag", "expected_mode"),
+        [("--interactive-auth", "interactive"), ("--headless-auth", "headless")],
+    )
+    def test_auth_mode_forwarded_to_workers_without_auth_session(
+        self, pytester, auth_flag, expected_mode
+    ):
+        """auth_mode stays consistent on workers when no auth product is configured.
+
+        With only a non-auth product (Package Manager) the controller sets the
+        auth mode but never establishes a browser session, so the session path
+        forwards nothing. Workers must still mirror the controller's mode, or
+        the ``auth_mode`` fixture diverges between xdist and non-xdist runs.
+        """
+        pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                '[package_manager]\nurl = "https://p3m.example.com"\n'
+            ),
+        )
+        marker_dir = pytester.path / "worker_markers"
+        marker_dir.mkdir()
+        pytester.makepyfile(
+            f"""
+            import pytest
+            from vip.plugin import _auth_mode_key
+
+            MARKER_DIR = {str(marker_dir)!r}
+
+            @pytest.mark.parametrize("i", list(range(8)))
+            def test_worker_mode(request, i):
+                assert hasattr(request.config, "workerinput"), "expected xdist worker"
+                assert request.config.stash.get(_auth_mode_key, "none") == {expected_mode!r}
+                workerid = request.config.workerinput["workerid"]
+                open(f"{{MARKER_DIR}}/{{workerid}}", "a").close()
+            """
+        )
+        result = pytester.runpytest("--vip-config=vip.toml", auth_flag, "-n", "2", "-v")
+        result.assert_outcomes(passed=8)
+        workerids = {p.name for p in marker_dir.iterdir()}
+        assert len(workerids) == 2, (
+            f"expected both xdist workers to restore mode, got workerids={workerids}"
+        )
+
 
 class TestRestoreWorkerAuth:
     """``_restore_worker_auth`` recreates the controller's auth state on each

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -421,6 +421,51 @@ class TestPluginIntegration:
         result = selftest_pytester.runpytest("--vip-config=vip.toml", "-v")
         result.stdout.fnmatch_lines(["*PASSED*"])
 
+    def test_skip_reason_shown_in_full_inline(self, selftest_pytester, monkeypatch):
+        """A long skip reason renders in full on the verbose (``-v``) test line.
+
+        pytest ellipsizes the inline reason to the terminal width at the default
+        test-case verbosity; the plugin bumps that level to 2 under ``-v`` so the
+        whole reason is shown (it may wrap, but no text is dropped).
+        """
+        monkeypatch.setenv("COLUMNS", "80")
+        reason = (
+            "Workbench session not established by --interactive-auth so this skip "
+            "reason is intentionally far longer than eighty columns and would "
+            "normally be ellipsized before the END_OF_REASON_SENTINEL"
+        )
+        selftest_pytester.makepyfile(
+            f"""
+            import pytest
+
+            @pytest.mark.skip(reason={reason!r})
+            def test_skips():
+                pass
+            """
+        )
+        result = selftest_pytester.runpytest("--vip-config=vip.toml", "-v")
+        result.assert_outcomes(skipped=1)
+        # Collapse whitespace so a wrapped reason still matches end to end.
+        collapsed = "".join(result.stdout.str().split())
+        assert "".join(reason.split()) in collapsed
+        assert "END_OF_REASON_SENTINEL" in collapsed
+
+    def test_skip_reason_not_forced_verbose_in_dot_mode(self, selftest_pytester):
+        """Without ``-v`` the reporter stays in dot mode — the verbosity bump is
+        gated on the user already having asked for per-test lines."""
+        selftest_pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.skip(reason="some reason")
+            def test_skips():
+                pass
+            """
+        )
+        result = selftest_pytester.runpytest("--vip-config=vip.toml")
+        result.assert_outcomes(skipped=1)
+        result.stdout.no_fnmatch_line("*test_skips*SKIPPED*")
+
     def test_json_report_output(self, selftest_pytester):
         selftest_pytester.makepyfile(
             """

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -907,6 +907,33 @@ class TestXdistCompatibility:
                 f"Found xdist worker prefix in output line: {line!r}"
             )
 
+    def test_no_auth_products_warning_not_duplicated_under_xdist(self, selftest_pytester):
+        """The 'no auth-requiring products' skip warning fires once, not per worker.
+
+        ``pytest_configure`` runs on the xdist controller *and* on every worker.
+        The controller-only auth branch must not re-run on workers, or the skip
+        warning floods the output once per worker (controller + N workers).
+        """
+        selftest_pytester.makepyfile(
+            """
+            def test_placeholder():
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest_subprocess(
+            "--vip-config=vip.toml",
+            "--interactive-auth",
+            "-n",
+            "2",
+            "-W",
+            "always",
+        )
+        assert result.ret == 0
+        result.assert_outcomes(passed=1)
+        combined = result.outlines + result.errlines
+        hits = [line for line in combined if "skipping browser authentication" in line]
+        assert len(hits) == 1, f"expected exactly one skip warning, got {len(hits)}: {hits}"
+
     def test_vip_metadata_survives_xdist(self, selftest_pytester):
         """Custom report attributes (markers, scenario fields) survive xdist transit."""
         # Use a plain test file and verify markers/scenario fields are present in results.

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -421,6 +421,25 @@ class TestPluginIntegration:
         result = selftest_pytester.runpytest("--vip-config=vip.toml", "-v")
         result.stdout.fnmatch_lines(["*PASSED*"])
 
+    # A skip reason far longer than 80 columns, ending in a unique sentinel so
+    # we can tell a full reason from one pytest has ellipsized to "(reason...)".
+    _LONG_SKIP_REASON = (
+        "Workbench session not established by --interactive-auth so this skip "
+        "reason is intentionally far longer than eighty columns and would "
+        "normally be ellipsized before the END_OF_REASON_SENTINEL"
+    )
+
+    def _make_long_skip_test(self, selftest_pytester):
+        selftest_pytester.makepyfile(
+            f"""
+            import pytest
+
+            @pytest.mark.skip(reason={self._LONG_SKIP_REASON!r})
+            def test_skips():
+                pass
+            """
+        )
+
     def test_skip_reason_shown_in_full_inline(self, selftest_pytester, monkeypatch):
         """A long skip reason renders in full on the verbose (``-v``) test line.
 
@@ -429,26 +448,37 @@ class TestPluginIntegration:
         whole reason is shown (it may wrap, but no text is dropped).
         """
         monkeypatch.setenv("COLUMNS", "80")
-        reason = (
-            "Workbench session not established by --interactive-auth so this skip "
-            "reason is intentionally far longer than eighty columns and would "
-            "normally be ellipsized before the END_OF_REASON_SENTINEL"
-        )
-        selftest_pytester.makepyfile(
-            f"""
-            import pytest
-
-            @pytest.mark.skip(reason={reason!r})
-            def test_skips():
-                pass
-            """
-        )
+        self._make_long_skip_test(selftest_pytester)
         result = selftest_pytester.runpytest("--vip-config=vip.toml", "-v")
         result.assert_outcomes(skipped=1)
         # Collapse whitespace so a wrapped reason still matches end to end.
         collapsed = "".join(result.stdout.str().split())
-        assert "".join(reason.split()) in collapsed
+        assert "".join(self._LONG_SKIP_REASON.split()) in collapsed
         assert "END_OF_REASON_SENTINEL" in collapsed
+        # The ellipsized form pytest would emit at the default verbosity ends in
+        # "...)" — its absence proves the bump actually fired (and isn't a silent
+        # no-op on a future pytest where the private _inicache write breaks).
+        assert "...)" not in collapsed
+
+    def test_skip_reason_ellipsized_without_bump(self, selftest_pytester, monkeypatch):
+        """Control: with the bump defeated, the same reason IS ellipsized.
+
+        Passing ``-o verbosity_test_cases=1`` makes ``getini`` return ``"1"``
+        instead of ``"auto"``, so the plugin leaves the level alone. This proves
+        the ``COLUMNS=80`` width is honored in-process and that truncation is
+        reachable here — without it, ``test_skip_reason_shown_in_full_inline``
+        could pass vacuously. If this control ever stops truncating, the positive
+        test is no longer meaningful and CI should flag it.
+        """
+        monkeypatch.setenv("COLUMNS", "80")
+        self._make_long_skip_test(selftest_pytester)
+        result = selftest_pytester.runpytest(
+            "--vip-config=vip.toml", "-v", "-o", "verbosity_test_cases=1"
+        )
+        result.assert_outcomes(skipped=1)
+        collapsed = "".join(result.stdout.str().split())
+        assert "...)" in collapsed
+        assert "END_OF_REASON_SENTINEL" not in collapsed
 
     def test_skip_reason_not_forced_verbose_in_dot_mode(self, selftest_pytester):
         """Without ``-v`` the reporter stays in dot mode — the verbosity bump is

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -207,9 +207,14 @@ def pytest_configure(config: pytest.Config) -> None:
     # credentials are forwarded to workers via pytest_configure_node.
     config.stash[_auth_session_key] = None
 
-    if hasattr(config, "workerinput") and config.workerinput.get("vip_interactive_auth"):
-        # xdist worker — restore auth data shared by the controller.
-        _restore_worker_auth(config, vip_cfg)
+    if hasattr(config, "workerinput"):
+        # xdist worker — restore auth data shared by the controller (if any).
+        # Workers must never re-run the controller-only browser-auth branches
+        # below: pytest_configure fires on every worker, so doing so would, for
+        # example, re-emit the "no auth-requiring products" warning once per
+        # worker, flooding the output.
+        if config.workerinput.get("vip_interactive_auth"):
+            _restore_worker_auth(config, vip_cfg)
     elif config.getoption("--interactive-auth"):
         config.stash[_auth_mode_key] = "interactive"
         connect_url = vip_cfg.connect.url if vip_cfg.connect.is_configured else None

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -170,6 +170,26 @@ def pytest_configure(config: pytest.Config) -> None:
     if not config.getoption("--vip-verbose", default=False):
         config.option.reportchars = ""
 
+    # Show skip/xfail reasons in full on the verbose (``-v``) test line instead
+    # of ellipsizing them to the terminal width. pytest only prints the
+    # untrimmed reason at *test-case* verbosity >= 2 (see _pytest/terminal.py).
+    # Bumping that fine-grained level — rather than the global ``-v`` count —
+    # leaves failure tracebacks and assertion reprs at the user's chosen
+    # verbosity, and a skip reason never carries a traceback, so this only ever
+    # lengthens a one-line reason. We act only when the user passed exactly
+    # ``-v`` (resolved test-case verbosity 1): at level 0 the reporter is in
+    # dot mode and bumping would force per-test lines on; above 1 it is already
+    # full. An explicit ``verbosity_test_cases`` in the user's config (anything
+    # other than the "auto" default) is respected.
+    try:
+        if (
+            config.getini("verbosity_test_cases") == "auto"
+            and config.get_verbosity(pytest.Config.VERBOSITY_TEST_CASES) == 1
+        ):
+            config._inicache["verbosity_test_cases"] = "2"
+    except (ValueError, AttributeError):
+        pass
+
     # Load VIP config and stash it for fixtures / collection hooks.
     vip_cfg = load_config(config.getoption("--vip-config"))
     config.stash[_vip_config_key] = vip_cfg

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -215,6 +215,11 @@ def pytest_configure(config: pytest.Config) -> None:
         # worker, flooding the output.
         if config.workerinput.get("vip_interactive_auth"):
             _restore_worker_auth(config, vip_cfg)
+        elif config.workerinput.get("vip_auth_mode"):
+            # No browser session was forwarded (no auth-requiring product), but
+            # still mirror the controller's auth mode so the auth_mode fixture
+            # matches a non-xdist run.
+            config.stash[_auth_mode_key] = config.workerinput["vip_auth_mode"]
     elif config.getoption("--interactive-auth"):
         config.stash[_auth_mode_key] = "interactive"
         connect_url = vip_cfg.connect.url if vip_cfg.connect.is_configured else None
@@ -335,6 +340,13 @@ def _restore_worker_auth(config: pytest.Config, vip_cfg: VIPConfig) -> None:
 
 def pytest_configure_node(node) -> None:
     """xdist controller hook: share interactive-auth credentials with workers."""
+    # Forward the auth mode even when no browser session was established (e.g.
+    # only Package Manager configured, so the flow was skipped). Workers don't
+    # re-run the controller-only auth branch, so without this their auth_mode
+    # fixture would resolve to "none" while a non-xdist run reports the mode.
+    mode = node.config.stash.get(_auth_mode_key, "")
+    if mode:
+        node.workerinput["vip_auth_mode"] = mode
     auth = node.config.stash.get(_auth_session_key, None)
     if auth is not None:
         node.workerinput["vip_interactive_auth"] = True
@@ -344,7 +356,6 @@ def pytest_configure_node(node) -> None:
         node.workerinput["vip_connect_url"] = auth._connect_url
         node.workerinput["vip_workbench_url"] = auth._workbench_url
         node.workerinput["vip_workbench_auth_error"] = auth.workbench_auth_error or ""
-        node.workerinput["vip_auth_mode"] = node.config.stash.get(_auth_mode_key, "")
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/validation_docs/demo-inline-full-skip-reasons.md
+++ b/validation_docs/demo-inline-full-skip-reasons.md
@@ -36,3 +36,25 @@ uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format
 All checks passed!
 2 files already formatted
 ```
+
+Second fix in this branch: when --interactive-auth (or --headless-auth) is passed but no auth-requiring product is configured (e.g. only Package Manager), the 'skipping browser authentication' warning was emitted once per xdist worker. pytest_configure runs on the controller AND every worker; only the controller had a session to forward, so workers fell through to the controller-only auth branch and re-warned. With auto-detected workers this floods the output (1 + N copies). The fix guards the worker branch so workers only restore forwarded credentials and never re-run the controller logic.
+
+```bash
+printf "[general]\ndeployment_name = \"Demo\"\n[package_manager]\nurl = \"https://p3m.dev/\"\n" > _demo_vip.toml
+printf "def test_placeholder():\n    assert True\n" > _demo_pm.py
+echo -n "warning count: "
+uv run pytest _demo_pm.py --vip-config=_demo_vip.toml --interactive-auth -n 2 -W always -p no:cacheprovider 2>&1 | grep -c "skipping browser authentication"
+rm -f _demo_vip.toml _demo_pm.py
+```
+
+```output
+warning count: 1
+```
+
+```bash
+uv run pytest selftests/test_plugin.py -k "no_auth_products_warning_not_duplicated or skip_reason" -q -p no:cacheprovider 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+4 passed
+```

--- a/validation_docs/demo-inline-full-skip-reasons.md
+++ b/validation_docs/demo-inline-full-skip-reasons.md
@@ -1,18 +1,20 @@
 # fix: show full skip/xfail reasons inline under -v
 
-*2026-06-24T22:38:40Z by Showboat 0.6.1*
-<!-- showboat-id: 558d9aa2-a861-4655-bbf0-da35d6756985 -->
+*2026-06-24T22:55:59Z by Showboat 0.6.1*
+<!-- showboat-id: 47266cb6-4730-4624-8a68-d1fb6caf9323 -->
 
 Problem: with the default 'vip verify ... -- -v' run, pytest ellipsizes each SKIPPED reason to the terminal width, so the actionable part of the message is cut off (e.g. 'SKIPPED (Workbench session n...)').
 
 Fix: src/vip/plugin.py bumps pytest's fine-grained *test-case* verbosity to 2 when (and only when) the user passed -v. At test-case verbosity >= 2 pytest prints the skip/xfail reason untrimmed (it may wrap, but no text is dropped). The global verbosity is left alone, so failure tracebacks and assertion reprs are unaffected — and skip reasons never carry a traceback. Dot mode (no -v) is untouched, and an explicit verbosity_test_cases in the user's config is respected.
+
+Tests: a treatment test asserts the full reason (and trailing sentinel) appears with no '...)' ellipsis; a control test defeats the bump via '-o verbosity_test_cases=1' and asserts the SAME reason IS ellipsized — proving COLUMNS=80 is honored in-process and that the bump (not a vacuous setup) is what removes the truncation.
 
 ```bash
 uv run pytest selftests/test_plugin.py -k skip_reason -q -p no:cacheprovider 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
 ```
 
 ```output
-2 passed
+3 passed
 ```
 
 ```bash

--- a/validation_docs/demo-inline-full-skip-reasons.md
+++ b/validation_docs/demo-inline-full-skip-reasons.md
@@ -1,0 +1,36 @@
+# fix: show full skip/xfail reasons inline under -v
+
+*2026-06-24T22:38:40Z by Showboat 0.6.1*
+<!-- showboat-id: 558d9aa2-a861-4655-bbf0-da35d6756985 -->
+
+Problem: with the default 'vip verify ... -- -v' run, pytest ellipsizes each SKIPPED reason to the terminal width, so the actionable part of the message is cut off (e.g. 'SKIPPED (Workbench session n...)').
+
+Fix: src/vip/plugin.py bumps pytest's fine-grained *test-case* verbosity to 2 when (and only when) the user passed -v. At test-case verbosity >= 2 pytest prints the skip/xfail reason untrimmed (it may wrap, but no text is dropped). The global verbosity is left alone, so failure tracebacks and assertion reprs are unaffected — and skip reasons never carry a traceback. Dot mode (no -v) is untouched, and an explicit verbosity_test_cases in the user's config is respected.
+
+```bash
+uv run pytest selftests/test_plugin.py -k skip_reason -q -p no:cacheprovider 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+2 passed
+```
+
+```bash
+printf "import pytest\n\n@pytest.mark.skip(reason=\"Workbench session not established by --interactive-auth (landed on login page: https://workbench.posit.example.com/auth-sign-in?appUri=)\")\ndef test_push_rstudio():\n    pass\n" > _demo_skip.py
+printf "[general]\ndeployment_name = \"Demo\"\n" > _demo_vip.toml
+COLUMNS=220 uv run pytest _demo_skip.py -v -p no:cacheprovider --vip-config=_demo_vip.toml 2>&1 | grep "push_rstudio"
+rm -f _demo_skip.py _demo_vip.toml
+```
+
+```output
+_demo_skip.py::test_push_rstudio SKIPPED (Workbench session not established by --interactive-auth (landed on login page: https://workbench.posit.example.com/auth-sign-in?appUri=))                                  [100%]
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/vip/plugin.py selftests/test_plugin.py
+```
+
+```output
+All checks passed!
+2 files already formatted
+```


### PR DESCRIPTION
## Summary

Two fixes to the output to be more readable and not noisy.

1. **Full skip/xfail reasons inline instead of pytest ellipsized reasons (e.g. `SKIPPED (Workbench session n...)`) so that you can really see what to do to not skip. `src/vip/plugin.py` now bumps pytest's fine-grained *test-case* verbosity to 2 only when the user passed exactly `-v`, so skip/xfail reasons print untrimmed. 

2. **Auth-skip warning no longer floods output under xdist.** When `--interactive-auth` (or `--headless-auth`) is passed but no auth-requiring product is configured (e.g. only Package Manager), the "skipping browser authentication" warning was emitted once per xdist worker. `pytest_configure` runs on the controller *and* every worker; only the controller had a session to forward, so workers fell through to the controller-only auth branch and re-warned (1 + N copies). The worker branch is now guarded so workers only restore forwarded credentials and never re-run the controller logic — the warning fires exactly once.

## Testing

- New selftests: a treatment + control test for skip-reason de-ellipsizing, and `test_no_auth_products_warning_not_duplicated_under_xdist` asserting exactly one warning under `-n 2`.
- Full selftest suite: 850 passed, 3 skipped. Ruff lint + format clean.

## Demo

# fix: show full skip/xfail reasons inline under -v

Problem: with the default 'vip verify ... -- -v' run, pytest ellipsizes each SKIPPED reason to the terminal width, so the actionable part of the message is cut off (e.g. 'SKIPPED (Workbench session n...)').

Fix: src/vip/plugin.py bumps pytest's fine-grained *test-case* verbosity to 2 when (and only when) the user passed -v. At test-case verbosity >= 2 pytest prints the skip/xfail reason untrimmed (it may wrap, but no text is dropped). The global verbosity is left alone, so failure tracebacks and assertion reprs are unaffected — and skip reasons never carry a traceback. Dot mode (no -v) is untouched, and an explicit verbosity_test_cases in the user's config is respected.

Tests: a treatment test asserts the full reason (and trailing sentinel) appears with no '...)' ellipsis; a control test defeats the bump via '-o verbosity_test_cases=1' and asserts the SAME reason IS ellipsized — proving COLUMNS=80 is honored in-process and that the bump (not a vacuous setup) is what removes the truncation.

```bash
uv run pytest selftests/test_plugin.py -k skip_reason -q -p no:cacheprovider 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
```

```output
3 passed
```

```bash
printf "import pytest\n\n@pytest.mark.skip(reason=\"Workbench session not established by --interactive-auth (landed on login page: https://workbench.posit.example.com/auth-sign-in?appUri=)\")\ndef test_push_rstudio():\n    pass\n" > _demo_skip.py
printf "[general]\ndeployment_name = \"Demo\"\n" > _demo_vip.toml
COLUMNS=220 uv run pytest _demo_skip.py -v -p no:cacheprovider --vip-config=_demo_vip.toml 2>&1 | grep "push_rstudio"
rm -f _demo_skip.py _demo_vip.toml
```

```output
_demo_skip.py::test_push_rstudio SKIPPED (Workbench session not established by --interactive-auth (landed on login page: https://workbench.posit.example.com/auth-sign-in?appUri=))                                  [100%]
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/vip/plugin.py selftests/test_plugin.py
```

```output
All checks passed!
2 files already formatted
```

Second fix in this branch: when --interactive-auth (or --headless-auth) is passed but no auth-requiring product is configured (e.g. only Package Manager), the 'skipping browser authentication' warning was emitted once per xdist worker. pytest_configure runs on the controller AND every worker; only the controller had a session to forward, so workers fell through to the controller-only auth branch and re-warned. With auto-detected workers this floods the output (1 + N copies). The fix guards the worker branch so workers only restore forwarded credentials and never re-run the controller logic.

```bash
printf "[general]\ndeployment_name = \"Demo\"\n[package_manager]\nurl = \"https://p3m.dev/\"\n" > _demo_vip.toml
printf "def test_placeholder():\n    assert True\n" > _demo_pm.py
echo -n "warning count: "
uv run pytest _demo_pm.py --vip-config=_demo_vip.toml --interactive-auth -n 2 -W always -p no:cacheprovider 2>&1 | grep -c "skipping browser authentication"
rm -f _demo_vip.toml _demo_pm.py
```

```output
warning count: 1
```

```bash
uv run pytest selftests/test_plugin.py -k "no_auth_products_warning_not_duplicated or skip_reason" -q -p no:cacheprovider 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
```

```output
4 passed
```
