### PR TITLE
fix: extend connect system checks default timeout to 5min

### DIFF
--- a/src/vip/clients/connect.py
+++ b/src/vip/clients/connect.py
@@ -436,7 +436,7 @@ class ConnectClient(BaseClient):
         import time
 
         transient_status_codes = {404, 502, 503, 504}
-        effective_timeout = scaled(120.0) if timeout is None else timeout
+        effective_timeout = scaled(300.0) if timeout is None else timeout
         deadline = time.time() + effective_timeout
         last_exception: Exception | None = None
 


### PR DESCRIPTION
System checks seem to take 3-4min on servers closer to our minimum recommended specs. This should remedy timeout issues for smaller hosts.