### PR TITLE
ci: scope PR dependency audit; add scheduled full-tree audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,14 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Audit dependencies
-        run: uv run pip-audit --skip-editable
+      # Sync only the shipped runtime dependencies (no extras) and audit that
+      # environment. A CVE disclosed in test-only tooling (jupyter, locust,
+      # pip-audit, ...) must not block feature PRs. The full tree is scanned
+      # daily by security-audit.yml, which files a tracking issue instead.
+      - name: Audit runtime dependencies
+        run: |
+          uv sync
+          uv run --with pip-audit pip-audit --skip-editable
 
   selftest:
     name: Selftests (${{ matrix.os }} / ${{ matrix.python-version }})

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,66 @@
+name: Scheduled Dependency Audit
+
+# Audits the FULL dependency tree (all extras) daily against the live advisory
+# database. Unlike the PR-time audit (ci.yml, scoped to shipped runtime deps),
+# a newly-disclosed CVE here does NOT block PRs -- it opens or updates a
+# tracking issue instead, so a vuln in the world never turns unrelated PRs red.
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily at 6am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: security-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Full dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Audit full dependency tree
+        id: audit
+        run: |
+          set +e
+          uv run pip-audit --skip-editable --format markdown > audit-report.md 2>&1
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          cat audit-report.md
+          exit 0
+
+      - name: Open or update tracking issue on vulnerabilities
+        if: steps.audit.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Dependency audit: known vulnerabilities detected"
+          {
+            echo "The scheduled full-tree dependency audit found known vulnerabilities."
+            echo ""
+            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            cat audit-report.md
+          } > issue-body.md
+          existing=$(gh issue list --state open --json number,title \
+            --jq ".[] | select(.title==\"$title\") | .number" | head -1)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file issue-body.md
+          else
+            gh issue create --title "$title" --body-file issue-body.md
+          fi

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -52,15 +52,16 @@ jobs:
           title="Dependency audit: known vulnerabilities detected"
           {
             echo "The scheduled full-tree dependency audit found known vulnerabilities."
+            echo "This issue is refreshed in place on each daily run; see the edit history for changes."
             echo ""
-            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "Last run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             echo ""
             cat audit-report.md
           } > issue-body.md
-          existing=$(gh issue list --state open --json number,title \
+          existing=$(gh issue list --state open --limit 200 --json number,title \
             --jq ".[] | select(.title==\"$title\") | .number" | head -1)
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body-file issue-body.md
+            gh issue edit "$existing" --body-file issue-body.md
           else
             gh issue create --title "$title" --body-file issue-body.md
           fi


### PR DESCRIPTION
Fixes the recurring Dependency Audit breakage (#425, part 1 of 2).

## Problem
The PR-time audit synced `--all-extras` and ran pip-audit over the full tree against the live advisory DB. A CVE in test-only tooling (jupyter, locust, pip-audit, ...) turned every open PR — and main — red at once, unrelated to the diff, driving a reactive floor-pin treadmill.

## Change
- `ci.yml`: audit only shipped runtime deps (`uv sync` no extras → `uv run --with pip-audit pip-audit --skip-editable`). Still blocking; PRs gate on what users install (66 pkgs vs 206).
- `security-audit.yml` (new): scheduled daily full-tree audit; opens/updates a deduped tracking issue on new vulns instead of failing PRs. `issues: write`, SHA-pinned actions, zizmor-clean.

Dependabot security updates are already enabled, so remediation stays automated.

## Verification
- Runtime-scoped audit locally: `No known vulnerabilities found`.
- `zizmor==1.24.1` on `security-audit.yml`: `No findings to report`.

Part 2 (uv version pin + `just relock` + docs) follows separately.

Refs #425
