### PR TITLE
feat: add robust version gating, N/A status, versioned page objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ Key principles:
 | `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers |
 | `src/vip/idp.py` | IdP login form strategies for headless auth (Keycloak, Okta) |
 | `src/vip/plugin.py` | pytest plugin: markers, auto-skip, JSON report output |
+| `src/vip/version.py` | `ProductVersion` -- Posit calendar-version parsing and comparison for `min_version` gating |
 | `src/vip/reporting.py` | Report data model for Quarto templates |
 | `src/vip/clients/connect.py` | httpx client for Connect API |
 | `src/vip/clients/workbench.py` | httpx client for Workbench API |

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -88,7 +88,11 @@ Use the `min_version` marker for features that only exist in certain product ver
 @pytest.mark.min_version(product="connect", version="2024.09.0")
 ```
 
-This skips the test when the deployed version is older than the specified minimum, so the same test suite works across multiple product releases.
+This skips the test when the deployed version is older than the specified minimum, so the same test suite works across multiple product releases. Versions are parsed and compared with `vip.version.ProductVersion`, which understands Posit's calendar versioning scheme (`YYYY.MM.patch` plus `-dev`/`-daily`/`-preview`/`+build` suffixes).
+
+When the deployed or required version cannot be determined at all (unconfigured, or unparseable), the test is skipped and flagged with a distinct **"N/A (version)"** report status rather than run optimistically -- a version gap should be visible in the report, not hidden behind a possibly-spurious pass.
+
+`min_version` can only skip a whole test. When a UI change requires switching *behavior or selectors* rather than skipping outright -- for example, a redesigned dialog that closes via Escape instead of a Cancel button -- use a versioned page-object class plus a `get_<page>(version)` factory in `src/vip_tests/workbench/pages/`. Subclasses hold only the delta from the version they change in (cumulative inheritance), and behavior differences that aren't expressible as a selector change use a strategy dict keyed by version threshold, mirroring `vip.idp`'s IdP strategy dict. See `src/vip_tests/workbench/pages/homepage.py` (`Homepage_2026_05`, `get_homepage`, `get_new_session_dialog_close_strategy`) for the pattern.
 
 ## Layer 2: The DSL (step definitions + fixtures)
 

--- a/report/details.qmd
+++ b/report/details.qmd
@@ -51,12 +51,14 @@ _OUTCOME_STYLES = {
     "passed": ("PASS", "#16a34a", "#dcfce7"),
     "failed": ("FAIL", "#dc2626", "#fecaca"),
     "skipped": ("SKIP", "#6b7280", "#e5e7eb"),
+    "na_version": ("N/A", "#d97706", "#fde68a"),
 }
 
 _BORDER_COLORS = {
     "passed": "#16a34a",
     "failed": "#dc2626",
     "skipped": "#d1d5db",
+    "na_version": "#d97706",
 }
 
 _PRODUCT_BADGE_CSS = {
@@ -232,7 +234,8 @@ else:
         cat_label = cat.replace("_", " ").title()
         cat_passed = sum(1 for i in items if i.outcome == "passed")
         cat_failed = sum(1 for i in items if i.outcome == "failed")
-        cat_skipped = sum(1 for i in items if i.outcome == "skipped")
+        cat_skipped = sum(1 for i in items if i.status == "skipped")
+        cat_na_version = sum(1 for i in items if i.status == "na_version")
 
         counts = []
         if cat_passed:
@@ -241,6 +244,8 @@ else:
             counts.append(f"{cat_failed} failed")
         if cat_skipped:
             counts.append(f"{cat_skipped} skipped")
+        if cat_na_version:
+            counts.append(f"{cat_na_version} N/A (version)")
 
         _html.append(
             f'<div class="vip-cat-section">'
@@ -251,9 +256,9 @@ else:
 
         for item in items:
             label, fg, badge_bg = _OUTCOME_STYLES.get(
-                item.outcome, ("?", "#6b7280", "#e5e7eb")
+                item.status, ("?", "#6b7280", "#e5e7eb")
             )
-            border_color = _BORDER_COLORS.get(item.outcome, "#d1d5db")
+            border_color = _BORDER_COLORS.get(item.status, "#d1d5db")
             raw_title = item.scenario_title or (
                 item.nodeid.split("::")[-1] if "::" in item.nodeid else item.nodeid
             )

--- a/report/index.qmd
+++ b/report/index.qmd
@@ -107,6 +107,7 @@ _OUTCOME_STYLES = {
     "passed": ("PASS", "#16a34a", "#f0fdf4", "#dcfce7"),
     "failed": ("FAIL", "#dc2626", "#fef2f2", "#fecaca"),
     "skipped": ("SKIP", "#6b7280", "#f9fafb", "#e5e7eb"),
+    "na_version": ("N/A", "#d97706", "#fffbeb", "#fde68a"),
 }
 
 _PRODUCT_BADGE_CSS = {
@@ -117,9 +118,19 @@ _PRODUCT_BADGE_CSS = {
     "prerequisites": ("badge-prerequisites", "Prerequisites"),
 }
 
-_OUTCOME_ORDER = ["failed", "passed", "skipped"]
-_OUTCOME_LABELS = {"failed": "Failed", "passed": "Passed", "skipped": "Skipped"}
-_OUTCOME_COLORS = {"passed": "#16a34a", "failed": "#dc2626", "skipped": "#6b7280"}
+_OUTCOME_ORDER = ["failed", "passed", "skipped", "na_version"]
+_OUTCOME_LABELS = {
+    "failed": "Failed",
+    "passed": "Passed",
+    "skipped": "Skipped",
+    "na_version": "N/A (version)",
+}
+_OUTCOME_COLORS = {
+    "passed": "#16a34a",
+    "failed": "#dc2626",
+    "skipped": "#6b7280",
+    "na_version": "#d97706",
+}
 
 
 def _product_tag(item):
@@ -138,10 +149,12 @@ def _product_tag(item):
 if not data.results:
     display(Markdown("No test results to display."))
 else:
-    # Group: outcome → product tag → items
+    # Group: status → product tag → items. Uses TestResult.status (not raw
+    # outcome) so N/A-by-version results get their own section instead of
+    # being folded into "Skipped".
     _by_outcome = defaultdict(lambda: defaultdict(list))
     for _item in data.results:
-        _by_outcome[_item.outcome][_product_tag(_item)].append(_item)
+        _by_outcome[_item.status][_product_tag(_item)].append(_item)
 
     _html_parts = []
     _html_parts.append("""
@@ -288,7 +301,7 @@ else:
 
             for item in items:
                 label, fg, bg, border_bg = _OUTCOME_STYLES.get(
-                    item.outcome, ("?", "#6b7280", "#f9fafb", "#e5e7eb")
+                    item.status, ("?", "#6b7280", "#f9fafb", "#e5e7eb")
                 )
                 raw_title = item.scenario_title or (
                     item.nodeid.split("::")[-1] if "::" in item.nodeid else item.nodeid
@@ -378,7 +391,7 @@ else:
                         if _hp:
                             hints_html = f'<div class="vip-fail-hints">{"".join(_hp)}</div>'
 
-                border = _OUTCOME_COLORS.get(item.outcome, "#d1d5db")
+                border = _OUTCOME_COLORS.get(item.status, "#d1d5db")
                 _html_parts.append(
                     f'<div class="vip-test-card" style="border-left-color:{border}">'
                     f'<div class="vip-test-header">'

--- a/selftests/test_pages.py
+++ b/selftests/test_pages.py
@@ -1,0 +1,86 @@
+"""Tests for versioned Workbench page-object resolution.
+
+Covers ``get_homepage`` (versioned page-object factory) and
+``get_new_session_dialog_close_strategy`` (version-keyed behavior strategy
+dict), both in ``vip_tests.workbench.pages.homepage``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vip.version import ProductVersion
+from vip_tests.workbench.pages.homepage import (
+    Homepage,
+    Homepage_2026_05,
+    _close_dialog_via_cancel_button,
+    _close_dialog_via_escape,
+    get_homepage,
+    get_new_session_dialog_close_strategy,
+)
+
+
+class TestGetHomepage:
+    def test_below_threshold_returns_baseline(self):
+        assert get_homepage("2026.04.9") is Homepage
+
+    def test_well_below_range_returns_baseline(self):
+        assert get_homepage("2020.01.0") is Homepage
+
+    def test_exact_threshold_returns_new_class(self):
+        assert get_homepage("2026.05.0") is Homepage_2026_05
+
+    def test_above_threshold_returns_new_class(self):
+        assert get_homepage("2027.01.0") is Homepage_2026_05
+
+    def test_accepts_product_version_instance(self):
+        assert get_homepage(ProductVersion("2026.05.0")) is Homepage_2026_05
+        assert get_homepage(ProductVersion("2026.04.0")) is Homepage
+
+    def test_none_falls_back_to_baseline(self):
+        assert get_homepage(None) is Homepage
+
+    def test_unparseable_string_falls_back_to_baseline(self):
+        assert get_homepage("not-a-version") is Homepage
+
+    def test_new_class_overrides_only_the_delta(self):
+        # Homepage_2026_05 should be a real subclass, inheriting everything
+        # else unchanged, and only overriding SESSION_DETAILS_DIALOG.
+        assert issubclass(Homepage_2026_05, Homepage)
+        assert Homepage_2026_05.SESSION_DETAILS_DIALOG != Homepage.SESSION_DETAILS_DIALOG
+        assert Homepage_2026_05.POSIT_LOGO == Homepage.POSIT_LOGO
+        assert Homepage_2026_05.NEW_SESSION_BUTTON == Homepage.NEW_SESSION_BUTTON
+
+
+class TestGetNewSessionDialogCloseStrategy:
+    def test_below_threshold_returns_cancel_button_strategy(self):
+        assert get_new_session_dialog_close_strategy("2026.04.9") is _close_dialog_via_cancel_button
+
+    def test_exact_threshold_returns_escape_strategy(self):
+        assert get_new_session_dialog_close_strategy("2026.05.0") is _close_dialog_via_escape
+
+    def test_above_threshold_returns_escape_strategy(self):
+        assert get_new_session_dialog_close_strategy("2027.01.0") is _close_dialog_via_escape
+
+    def test_none_falls_back_to_cancel_button_strategy(self):
+        assert get_new_session_dialog_close_strategy(None) is _close_dialog_via_cancel_button
+
+    def test_unparseable_string_falls_back_to_cancel_button_strategy(self):
+        assert get_new_session_dialog_close_strategy("garbage") is _close_dialog_via_cancel_button
+
+    def test_strategies_are_callables_accepting_a_page(self):
+        import inspect
+
+        for fn in (_close_dialog_via_cancel_button, _close_dialog_via_escape):
+            sig = inspect.signature(fn)
+            params = list(sig.parameters.values())
+            assert len(params) == 1
+            assert params[0].name == "page"
+
+
+@pytest.mark.parametrize("version", ["2026.05.0", "2026.05.1", "2027.01.0"])
+def test_resolution_is_consistent_between_factory_and_strategy(version):
+    # Both tables share the same 2026.05.0 threshold in this codebase today;
+    # confirm they resolve in lockstep for versions at/after it.
+    assert get_homepage(version) is Homepage_2026_05
+    assert get_new_session_dialog_close_strategy(version) is _close_dialog_via_escape

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from vip.plugin import _extract_exception_info, _format_concise_error, _version_tuple
+from vip.plugin import _extract_exception_info, _format_concise_error
 
 
 class TestFormatConciseError:
@@ -154,26 +154,6 @@ class TestExtractExceptionInfo:
         exc_type, exc_message = _extract_exception_info(longrepr)
         assert exc_type == "AssertionError"
         assert "Connect: /metrics returned 403" in exc_message
-
-
-class TestVersionTuple:
-    def test_simple(self):
-        assert _version_tuple("1.2.3") == (1, 2, 3)
-
-    def test_two_part(self):
-        assert _version_tuple("2024.05") == (2024, 5)
-
-    def test_prerelease_suffix(self):
-        assert _version_tuple("1.2.3rc1") == (1, 2, 3)
-
-    def test_single_number(self):
-        assert _version_tuple("42") == (42,)
-
-    def test_comparison(self):
-        assert _version_tuple("2024.05.0") < _version_tuple("2024.06.0")
-        assert _version_tuple("2024.05.0") == _version_tuple("2024.05.0")
-        assert _version_tuple("1.0.0") < _version_tuple("2.0.0")
-        assert _version_tuple("1.9.9") < _version_tuple("1.10.0")
 
 
 class TestPluginIntegration:
@@ -417,9 +397,62 @@ class TestPluginIntegration:
                 assert True
             """
         )
-        # Connect has no version set, so the test runs optimistically.
+        # Connect has no version set. This used to run optimistically (PASS);
+        # the policy changed so an unknown version skips + warns instead of
+        # risking a spurious pass.
         result = selftest_pytester.runpytest("--vip-config=vip.toml", "-v")
-        result.stdout.fnmatch_lines(["*PASSED*"])
+        result.stdout.fnmatch_lines(["*SKIPPED*"])
+        result.stdout.fnmatch_lines(
+            ["*VIP: cannot evaluate min_version(product='connect', version='9999.01.0')*"]
+        )
+
+    def test_version_skip_unparseable_deployed_version(self, selftest_pytester):
+        """An unparseable deployed version also skips + warns, not runs optimistically."""
+        selftest_pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                '[connect]\nurl = "https://example.com"\nversion = "not-a-version"\n'
+            ),
+        )
+        selftest_pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.min_version(product="connect", version="2024.09.0")
+            def test_needs_recent_connect():
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest("--vip-config=vip.toml", "-v")
+        result.stdout.fnmatch_lines(["*SKIPPED*"])
+        result.stdout.fnmatch_lines(
+            ["*VIP: cannot evaluate min_version(product='connect', version='2024.09.0')*"]
+        )
+
+    def test_version_skip_known_below_minimum_is_plain_skip(self, selftest_pytester):
+        """A known deployed version below the minimum is a plain skip, not N/A."""
+        selftest_pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                '[connect]\nurl = "https://example.com"\nversion = "2024.01.0"\n'
+            ),
+        )
+        selftest_pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.min_version(product="connect", version="2024.09.0")
+            def test_needs_recent_connect():
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest("--vip-config=vip.toml", "--vip-verbose", "-v", "-rs")
+        result.stdout.fnmatch_lines(["*SKIPPED*"])
+        result.stdout.fnmatch_lines(["*connect version 2024.01.0 < required 2024.09.0*"])
+        # No N/A warning for this path — the version is known, just too old.
+        assert "cannot evaluate min_version" not in result.stdout.str()
 
     # A skip reason far longer than 80 columns, ending in a unique sentinel so
     # we can tell a full reason from one pytest has ellipsized to "(reason...)".
@@ -573,6 +606,50 @@ class TestPluginIntegration:
         assert "feature_description" in result
         assert result["scenario_title"] is None
         assert result["feature_description"] is None
+
+    def test_json_report_includes_na_version_flag(self, selftest_pytester):
+        """Results JSON flags version-unknown skips with na_version: true."""
+        selftest_pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n[connect]\nurl = "https://example.com"\n'
+            ),
+        )
+        selftest_pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.min_version(product="connect", version="9999.01.0")
+            def test_future_version():
+                assert True
+            """
+        )
+        report_path = selftest_pytester.path / "results.json"
+        selftest_pytester.runpytest(
+            "--vip-config=vip.toml",
+            f"--vip-report={report_path}",
+        )
+        data = json.loads(report_path.read_text())
+        result = data["results"][0]
+        assert result["outcome"] == "skipped"
+        assert result["na_version"] is True
+
+    def test_json_report_na_version_defaults_false(self, selftest_pytester):
+        """Ordinary results (including ordinary skips) report na_version: false."""
+        selftest_pytester.makepyfile(
+            """
+            def test_plain():
+                assert True
+            """
+        )
+        report_path = selftest_pytester.path / "results.json"
+        selftest_pytester.runpytest(
+            "--vip-config=vip.toml",
+            f"--vip-report={report_path}",
+        )
+        data = json.loads(report_path.read_text())
+        result = data["results"][0]
+        assert result["na_version"] is False
 
     def test_interactive_auth_skipped_when_no_auth_products(self, selftest_pytester):
         """--interactive-auth skips the browser flow when no auth-requiring products are enabled.

--- a/selftests/test_reporting.py
+++ b/selftests/test_reporting.py
@@ -223,6 +223,73 @@ class TestProductInfo:
         assert p.version == "2024.09.0"
 
 
+class TestNAVersionStatus:
+    def test_status_defaults_to_outcome(self):
+        r = TestResult(nodeid="a", outcome="passed")
+        assert r.status == "passed"
+
+    def test_na_version_field_defaults_false(self):
+        r = TestResult(nodeid="a", outcome="skipped")
+        assert r.na_version is False
+        assert r.status == "skipped"
+
+    def test_status_is_na_version_when_flagged_and_skipped(self):
+        r = TestResult(nodeid="a", outcome="skipped", na_version=True)
+        assert r.status == "na_version"
+
+    def test_na_version_flag_ignored_unless_outcome_is_skipped(self):
+        # na_version should never be set on a non-skip in practice, but the
+        # status property must not misreport a passed/failed result as N/A.
+        r = TestResult(nodeid="a", outcome="passed", na_version=True)
+        assert r.status == "passed"
+
+    def test_load_results_parses_na_version(self, tmp_path):
+        import json
+
+        data = {
+            "deployment_name": "Test",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "exit_status": 0,
+            "products": {},
+            "results": [
+                {
+                    "nodeid": "tests/connect/test_a.py::test_needs_recent",
+                    "outcome": "skipped",
+                    "duration": 0.0,
+                    "markers": ["connect"],
+                    "na_version": True,
+                },
+                {
+                    "nodeid": "tests/connect/test_b.py::test_unrelated_skip",
+                    "outcome": "skipped",
+                    "duration": 0.0,
+                    "markers": ["connect"],
+                },
+            ],
+        }
+        p = tmp_path / "results.json"
+        p.write_text(json.dumps(data))
+        rd = load_results(p)
+        assert rd.results[0].na_version is True
+        assert rd.results[0].status == "na_version"
+        assert rd.results[1].na_version is False
+        assert rd.results[1].status == "skipped"
+
+    def test_na_version_still_counts_toward_skipped_total(self):
+        # Documented decision: na_version results are a distinct *status* for
+        # display purposes, but they don't get their own summary count --
+        # they still count toward ReportData.skipped since they are, at the
+        # pytest outcome level, skips.
+        rd = ReportData(
+            results=[
+                TestResult(nodeid="a", outcome="skipped"),
+                TestResult(nodeid="b", outcome="skipped", na_version=True),
+            ]
+        )
+        assert rd.skipped == 2
+        assert rd.total == 2
+
+
 class TestConciseError:
     def test_concise_error_field_default_none(self):
         r = TestResult(nodeid="a", outcome="passed")

--- a/selftests/test_version.py
+++ b/selftests/test_version.py
@@ -1,0 +1,132 @@
+"""Tests for vip.version.ProductVersion."""
+
+from __future__ import annotations
+
+import pytest
+
+from vip.version import ProductVersion
+
+
+class TestParsing:
+    def test_bare_version(self):
+        v = ProductVersion("2026.06.0")
+        assert (v.year, v.month, v.patch) == (2026, 6, 0)
+        assert v.pre_kind is None
+        assert v.pre_extra is None
+        assert v.build is None
+
+    def test_dev_suffix(self):
+        v = ProductVersion("2026.06.0-dev")
+        assert v.pre_kind == "dev"
+        assert v.pre_extra is None
+
+    def test_daily_suffix(self):
+        v = ProductVersion("2026.06.0-daily.20260615")
+        assert v.pre_kind == "daily"
+        assert v.pre_extra == "20260615"
+
+    def test_preview_suffix(self):
+        v = ProductVersion("2026.06.0-preview")
+        assert v.pre_kind == "preview"
+        assert v.pre_extra is None
+
+    def test_build_suffix(self):
+        v = ProductVersion("2026.06.0+123")
+        assert v.pre_kind is None
+        assert v.build == "123"
+
+    def test_dev_and_build_combo(self):
+        v = ProductVersion("2026.06.0-dev+123")
+        assert v.pre_kind == "dev"
+        assert v.pre_extra is None
+        assert v.build == "123"
+
+    def test_daily_and_build_combo(self):
+        v = ProductVersion("2026.06.0-daily.20260615+abc")
+        assert v.pre_kind == "daily"
+        assert v.pre_extra == "20260615"
+        assert v.build == "abc"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "not-a-version",
+            "2026.06",
+            "2026.06.0.1",
+            "2026.aa.0",
+            "vX.Y.Z",
+            "2026.06.0-rc1",  # unsupported pre-release kind
+            "2026-06-0",
+        ],
+    )
+    def test_malformed_raises(self, raw):
+        with pytest.raises(ValueError, match="Cannot parse"):
+            ProductVersion(raw)
+
+
+class TestComparison:
+    def test_equal_versions(self):
+        assert ProductVersion("2026.06.0") == ProductVersion("2026.06.0")
+
+    def test_not_equal_different_patch(self):
+        assert ProductVersion("2026.06.0") != ProductVersion("2026.06.1")
+
+    def test_year_month_patch_ordering(self):
+        assert ProductVersion("2025.12.9") < ProductVersion("2026.01.0")
+        assert ProductVersion("2026.05.0") < ProductVersion("2026.06.0")
+        assert ProductVersion("2026.06.0") < ProductVersion("2026.06.1")
+
+    def test_prerelease_sorts_before_release(self):
+        release = ProductVersion("2026.06.0")
+        for suffix in ("-dev", "-daily.20260615", "-preview"):
+            pre = ProductVersion(f"2026.06.0{suffix}")
+            assert pre < release, f"{pre} should sort before {release}"
+            assert pre <= release
+            assert release > pre
+            assert release >= pre
+
+    def test_prerelease_kind_ordering(self):
+        dev = ProductVersion("2026.06.0-dev")
+        daily = ProductVersion("2026.06.0-daily.20260615")
+        preview = ProductVersion("2026.06.0-preview")
+        assert dev < daily < preview
+
+    def test_build_metadata_does_not_affect_ordering(self):
+        assert ProductVersion("2026.06.0+123") == ProductVersion("2026.06.0+456")
+        assert ProductVersion("2026.06.0+123") == ProductVersion("2026.06.0")
+
+    def test_le_ge_operators(self):
+        v1 = ProductVersion("2026.06.0")
+        v2 = ProductVersion("2026.06.1")
+        assert v1 <= v1
+        assert v1 <= v2
+        assert v2 >= v1
+        assert v2 >= v2
+
+    def test_comparison_with_non_product_version_not_implemented(self):
+        v = ProductVersion("2026.06.0")
+        assert (v == "2026.06.0") is False
+        with pytest.raises(TypeError):
+            v < "2026.06.0"  # noqa: B015
+
+
+class TestHashability:
+    def test_equal_versions_hash_equal(self):
+        assert hash(ProductVersion("2026.06.0")) == hash(ProductVersion("2026.06.0"))
+
+    def test_usable_as_dict_key(self):
+        d = {ProductVersion("2026.06.0"): "shadcn"}
+        assert d[ProductVersion("2026.06.0")] == "shadcn"
+
+    def test_usable_in_set(self):
+        s = {ProductVersion("2026.06.0"), ProductVersion("2026.06.0"), ProductVersion("2026.06.1")}
+        assert len(s) == 2
+
+
+class TestStrRepr:
+    def test_str_preserves_original(self):
+        assert str(ProductVersion("2026.06.0-dev+123")) == "2026.06.0-dev+123"
+
+    def test_repr_is_informative(self):
+        assert repr(ProductVersion("2026.06.0")) == "ProductVersion('2026.06.0')"

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -31,6 +31,7 @@ from typing import Any
 import pytest
 
 from vip.config import VIPConfig, load_config
+from vip.version import ProductVersion
 
 # ---------------------------------------------------------------------------
 # Stash keys
@@ -41,6 +42,7 @@ _ext_dirs_key = pytest.StashKey[list[str]]()
 _results_key = pytest.StashKey[list[dict[str, Any]]]()
 _auth_session_key = pytest.StashKey[Any]()
 _auth_mode_key = pytest.StashKey[str]()
+_version_na_key = pytest.StashKey[bool]()
 
 # Module-level reference to the active pytest.Config, set in pytest_configure.
 # Safe because pytester runs in a subprocess (fresh import each time).
@@ -565,6 +567,15 @@ def require_connect_api_key(vip_cfg: VIPConfig) -> None:
 
 
 def _maybe_skip_for_version(item: pytest.Item, cfg: VIPConfig) -> None:
+    """Skip *item* when its ``min_version`` marker requirement is not met.
+
+    When the deployed or required version cannot be parsed as a
+    ``ProductVersion`` (including the "version unknown" case, ``pc.version
+    is None``), the test is skipped and flagged as N/A-by-version rather
+    than run optimistically or skipped indistinguishably from an ordinary
+    skip. This surfaces version-detection gaps in the report instead of
+    hiding them behind a possibly-spurious pass or a generic "skipped".
+    """
     marker = item.get_closest_marker("min_version")
     if marker is None:
         return
@@ -580,18 +591,46 @@ def _maybe_skip_for_version(item: pytest.Item, cfg: VIPConfig) -> None:
         return
 
     if pc.version is None:
-        # Version unknown - run the test optimistically.
+        _skip_version_unknown(item, product, version, reason="version unknown")
         return
 
-    if _version_tuple(pc.version) < _version_tuple(version):
+    try:
+        deployed = ProductVersion(pc.version)
+    except ValueError:
+        _skip_version_unknown(
+            item, product, version, reason=f"deployed version {pc.version!r} is unparseable"
+        )
+        return
+
+    try:
+        required = ProductVersion(version)
+    except ValueError:
+        _skip_version_unknown(
+            item, product, version, reason=f"required version {version!r} is unparseable"
+        )
+        return
+
+    if deployed < required:
         item.add_marker(
             pytest.mark.skip(reason=f"{product} version {pc.version} < required {version}")
         )
 
 
-def _version_tuple(v: str) -> tuple[int, ...]:
-    """Parse a dotted version string into a comparable tuple."""
-    return tuple(int(m.group()) if (m := re.match(r"\d+", seg)) else 0 for seg in v.split("."))
+def _skip_version_unknown(item: pytest.Item, product: str, version: str, *, reason: str) -> None:
+    """Skip *item* and flag it as N/A-by-version, warning about the gap."""
+    item.stash[_version_na_key] = True
+    item.add_marker(
+        pytest.mark.skip(
+            reason=f"VIP: version unknown for {product} — cannot evaluate "
+            f"min_version(product={product!r}, version={version!r}) ({reason})"
+        )
+    )
+    warnings.warn(
+        f"VIP: cannot evaluate min_version(product={product!r}, version={version!r}) "
+        f"for {item.nodeid} — {reason}. Skipping and marking N/A instead of running "
+        "optimistically.",
+        stacklevel=1,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -787,13 +826,16 @@ def pytest_runtest_makereport(item: pytest.Item, call):  # noqa: ARG001
 
         item_stash = getattr(item, "stash", None)
         scenario_meta: dict[str, str | None] = {}
+        na_version = False
         if item_stash is not None:
             scenario_meta = item_stash.get(_scenario_stash_key, {})
+            na_version = item_stash.get(_version_na_key, False)
 
         # These attributes survive xdist worker→controller serialization.
         report.vip_markers = markers  # type: ignore[attr-defined]
         report.vip_scenario_title = scenario_meta.get("scenario_title")  # type: ignore[attr-defined]
         report.vip_feature_description = scenario_meta.get("feature_description")  # type: ignore[attr-defined]
+        report.vip_na_version = na_version  # type: ignore[attr-defined]
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -840,6 +882,7 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
                     "markers": list(getattr(report, "vip_markers", ())),
                     "scenario_title": getattr(report, "vip_scenario_title", None),
                     "feature_description": getattr(report, "vip_feature_description", None),
+                    "na_version": getattr(report, "vip_na_version", False),
                 }
             )
 

--- a/src/vip/reporting.py
+++ b/src/vip/reporting.py
@@ -23,6 +23,7 @@ class TestResult:
     markers: list[str] = field(default_factory=list)
     scenario_title: str | None = None
     feature_description: str | None = None
+    na_version: bool = False
 
     @property
     def category(self) -> str:
@@ -32,6 +33,21 @@ class TestResult:
         if len(parts) >= 2:
             return parts[1]
         return "unknown"
+
+    @property
+    def status(self) -> str:
+        """Report status, distinguishing N/A-by-version from ordinary skips.
+
+        Returns ``"na_version"`` when the test was skipped because a
+        product's version could not be determined (see
+        ``plugin._skip_version_unknown``), otherwise returns ``outcome``
+        unchanged. Quarto templates key their styling dicts on this value
+        instead of raw ``outcome`` so version gaps render distinctly from
+        both passes/failures and ordinary (unconfigured-feature) skips.
+        """
+        if self.na_version and self.outcome == "skipped":
+            return "na_version"
+        return self.outcome
 
 
 @dataclass
@@ -67,6 +83,10 @@ class ReportData:
 
     @property
     def skipped(self) -> int:
+        # N/A-by-version results are still pytest "skipped" outcomes, so they
+        # count toward the top-line skipped total; they get their own
+        # section/badge in the report via TestResult.status, but the summary
+        # count is not split out separately.
         return sum(1 for r in self.results if r.outcome == "skipped")
 
     @property
@@ -109,6 +129,7 @@ def load_results(path: str | Path) -> ReportData:
             markers=r.get("markers", []),
             scenario_title=r.get("scenario_title"),
             feature_description=r.get("feature_description"),
+            na_version=r.get("na_version", False),
         )
         for r in raw.get("results", [])
     ]

--- a/src/vip/version.py
+++ b/src/vip/version.py
@@ -1,0 +1,107 @@
+"""Posit calendar-version parsing and comparison.
+
+Posit Team products (Connect, Workbench, Package Manager) use a calendar
+versioning scheme: ``YYYY.MM.patch``, optionally followed by a pre-release
+suffix (``-dev``, ``-daily.<date>``, ``-preview``) and/or a build metadata
+suffix (``+build``). Examples: ``2026.06.0``, ``2026.06.0-dev+123``,
+``2026.06.0-daily.20260615``, ``2026.06.0-preview``.
+
+This replaces the old ``plugin._version_tuple`` helper, which took the first
+run of digits per dot-separated segment and ignored suffixes entirely --
+fragile on real Posit version strings and unable to express "pre-release
+sorts before release".
+"""
+
+from __future__ import annotations
+
+import re
+from functools import total_ordering
+
+# Pre-release kinds, ordered from "earliest in the release cycle" to "latest
+# before the final release". There's no upstream spec pinning this down, so
+# the ordering here is a judgment call: a "dev" build is the least finished
+# (arbitrary point during development), "daily" is a scheduled nightly build
+# of `main` (further along, but still unstable), and "preview" is a
+# release-candidate-like build cut shortly before the final release. All
+# three sort before the plain (final) release of the same numeric version.
+_PRERELEASE_ORDER = {"dev": 0, "daily": 1, "preview": 2}
+
+# Final release has no suffix; it must sort after every pre-release kind.
+_FINAL_RANK = len(_PRERELEASE_ORDER)
+
+_VERSION_RE = re.compile(
+    r"""
+    ^
+    (?P<year>\d+)\.(?P<month>\d+)\.(?P<patch>\d+)
+    (?:-(?P<pre_kind>dev|daily|preview)(?:[.-](?P<pre_extra>[0-9A-Za-z.-]+))?)?
+    (?:\+(?P<build>[0-9A-Za-z.-]+))?
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+@total_ordering
+class ProductVersion:
+    """A parsed, comparable Posit calendar version.
+
+    Comparison key is ``(year, month, patch, prerelease_rank, prerelease_extra)``.
+    Build metadata (``+build``) does not affect ordering (matches semver
+    convention: build metadata is informational only), but is preserved for
+    display via ``__str__``/``__repr__``.
+
+    Raises ``ValueError`` for any string that doesn't match the
+    ``YYYY.MM.patch[-dev|-daily[.X]|-preview][+build]`` shape.
+    """
+
+    __slots__ = ("_raw", "year", "month", "patch", "pre_kind", "pre_extra", "build")
+
+    def __init__(self, raw: str) -> None:
+        match = _VERSION_RE.match(raw.strip())
+        if not match:
+            raise ValueError(
+                f"Cannot parse {raw!r} as a Posit calendar version "
+                "(expected YYYY.MM.patch[-dev|-daily|-preview][+build])"
+            )
+        self._raw = raw
+        self.year = int(match.group("year"))
+        self.month = int(match.group("month"))
+        self.patch = int(match.group("patch"))
+        self.pre_kind: str | None = match.group("pre_kind")
+        self.pre_extra: str | None = match.group("pre_extra")
+        self.build: str | None = match.group("build")
+
+    @property
+    def _prerelease_rank(self) -> int:
+        """Sort rank among pre-release kinds; final releases rank highest."""
+        if self.pre_kind is None:
+            return _FINAL_RANK
+        return _PRERELEASE_ORDER[self.pre_kind]
+
+    def _sort_key(self) -> tuple[int, int, int, int, str]:
+        return (
+            self.year,
+            self.month,
+            self.patch,
+            self._prerelease_rank,
+            self.pre_extra or "",
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ProductVersion):
+            return NotImplemented
+        return self._sort_key() == other._sort_key()
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, ProductVersion):
+            return NotImplemented
+        return self._sort_key() < other._sort_key()
+
+    def __hash__(self) -> int:
+        return hash(self._sort_key())
+
+    def __str__(self) -> str:
+        return self._raw
+
+    def __repr__(self) -> str:
+        return f"ProductVersion({self._raw!r})"

--- a/src/vip_tests/workbench/pages/__init__.py
+++ b/src/vip_tests/workbench/pages/__init__.py
@@ -6,7 +6,13 @@ for a specific page or component.
 """
 
 from .console_pane import ConsolePaneSelectors
-from .homepage import Homepage, NewSessionDialog
+from .homepage import (
+    Homepage,
+    Homepage_2026_05,
+    NewSessionDialog,
+    get_homepage,
+    get_new_session_dialog_close_strategy,
+)
 from .ide_base import IDEBase
 from .jupyterlab_session import JupyterLabSession
 from .login import LoginPage
@@ -17,6 +23,7 @@ from .vscode_session import VSCodeSession
 __all__ = [
     "ConsolePaneSelectors",
     "Homepage",
+    "Homepage_2026_05",
     "IDEBase",
     "JupyterLabSession",
     "LoginPage",
@@ -24,4 +31,6 @@ __all__ = [
     "PositronSession",
     "RStudioSession",
     "VSCodeSession",
+    "get_homepage",
+    "get_new_session_dialog_close_strategy",
 ]

--- a/src/vip_tests/workbench/pages/homepage.py
+++ b/src/vip_tests/workbench/pages/homepage.py
@@ -3,6 +3,17 @@
 Mirrors: rstudio-pro/e2e/pages/homepage.page.ts
 """
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from playwright.sync_api import Page
+
+from vip.version import ProductVersion
+
+_T = TypeVar("_T")
+
 
 class NewSessionDialog:
     """Selectors for the new session dialog."""
@@ -200,3 +211,118 @@ class Homepage:
             f"{row} button[aria-label='{status}'], "
             f"{row} button:text-is('{status}')"
         )
+
+
+class Homepage_2026_05(Homepage):  # noqa: N801 - version-embedded name matches design convention
+    """Homepage selectors for the 2026.05 shadcn redesign onward.
+
+    ``SESSION_DETAILS_DIALOG`` is the one confirmed selector-only delta in
+    this file: baseline ``Homepage`` still targets the legacy Bootstrap-style
+    ``[class*='modal-dialog']`` container, which does not match the shadcn
+    ``data-slot``-based dialog markup shipped from 2026.05 onward (see the
+    workaround note in ``test_sessions.py::resume_suspended_session``, which
+    currently targets the stable "Launch" button text instead of the
+    container for exactly this reason). Every other selector already reads
+    correctly on both old and new markup (either unchanged, or already
+    unioned like ``QUIT_BUTTON`` / ``session_row_status``), so nothing else
+    needs to be overridden here.
+    """
+
+    SESSION_DETAILS_DIALOG = "[data-slot='dialog-content']"
+
+
+# Resolution table for get_homepage(): (minimum version, page-object class),
+# sorted ascending by threshold. The class for the highest threshold that is
+# <= the detected version wins; versions below the lowest threshold (or an
+# unparseable/None version) fall back to the oldest class. Single-sided
+# thresholds only -- no version ranges/max_version (see design doc scope cut).
+_HOMEPAGE_VERSIONS: list[tuple[ProductVersion, type[Homepage]]] = [
+    (ProductVersion("2026.05.0"), Homepage_2026_05),
+]
+
+
+def _resolve_by_version(
+    version: ProductVersion | str | None,
+    table: list[tuple[ProductVersion, _T]],
+    oldest: _T,
+) -> _T:
+    """Return the table entry for the highest threshold <= *version*.
+
+    Shared resolution logic for both the page-object factory
+    (``get_homepage``) and the behavior-strategy lookup
+    (``get_new_session_dialog_close_strategy``): both are UI-resolution
+    concerns rather than test-gating, so an unparseable or missing version
+    falls back to *oldest* instead of raising (unlike the pytest marker path
+    in ``plugin.py``, there is no "skip" concept here).
+    """
+    if version is None:
+        return oldest
+    if isinstance(version, str):
+        try:
+            version = ProductVersion(version)
+        except ValueError:
+            return oldest
+
+    resolved = oldest
+    for threshold, value in table:
+        if version >= threshold:
+            resolved = value
+        else:
+            break
+    return resolved
+
+
+def get_homepage(version: ProductVersion | str | None) -> type[Homepage]:
+    """Return the ``Homepage`` subclass matching the deployed Workbench version.
+
+    Accepts ``None`` or an unparseable string and falls back to the oldest
+    known class (``Homepage``) -- page-object selection is a UI concern, not
+    test gating, so there's no skip path here.
+    """
+    return _resolve_by_version(version, _HOMEPAGE_VERSIONS, Homepage)
+
+
+# ---------------------------------------------------------------------------
+# New Session dialog close behavior (Escape vs. Cancel button)
+# ---------------------------------------------------------------------------
+#
+# Unlike SESSION_DETAILS_DIALOG above, the 2026.05 shadcn redesign changed how
+# the New Session dialog is dismissed: the legacy `#modalCancelBtn` (see
+# `NewSessionDialog.CANCEL_BUTTON`, still used by existing step files) does
+# not exist in the new dialog at all -- pressing Escape closes it instead.
+# That's a BEHAVIOR difference, not a selector difference, so it can't be
+# expressed as a page-object override; it needs a strategy dict keyed by
+# version, mirroring idp.py's `_IDP_STRATEGIES` but keyed by version
+# threshold instead of a flat IdP name.
+#
+# These strategies are not wired into any step file yet (issue #409's job)
+# -- this only builds the resolution mechanism and its own selftest.
+
+
+def _close_dialog_via_cancel_button(page: Page) -> None:
+    """Dismiss the New Session dialog via the legacy Cancel button (pre-2026.05)."""
+    page.locator(NewSessionDialog.CANCEL_BUTTON).click()
+
+
+def _close_dialog_via_escape(page: Page) -> None:
+    """Dismiss the New Session dialog by pressing Escape (2026.05 shadcn onward)."""
+    page.keyboard.press("Escape")
+
+
+_NEW_SESSION_DIALOG_CLOSE_STRATEGIES: list[tuple[ProductVersion, Callable[[Page], None]]] = [
+    (ProductVersion("2026.05.0"), _close_dialog_via_escape),
+]
+
+
+def get_new_session_dialog_close_strategy(
+    version: ProductVersion | str | None,
+) -> Callable[[Page], None]:
+    """Return the function that dismisses the New Session dialog for *version*.
+
+    Same fallback policy as ``get_homepage``: ``None`` or an unparseable
+    string resolves to the oldest known strategy (the legacy Cancel button)
+    rather than raising.
+    """
+    return _resolve_by_version(
+        version, _NEW_SESSION_DIALOG_CLOSE_STRATEGIES, _close_dialog_via_cancel_button
+    )

--- a/thoughts/shared/plans/2026-06-30-issue-410-better-version-gating-design.md
+++ b/thoughts/shared/plans/2026-06-30-issue-410-better-version-gating-design.md
@@ -1,0 +1,83 @@
+# Design — #410: Better version gating
+
+**Status:** Approved design (brainstorming) — ready for implementation plan
+**Date:** 2026-06-30
+**Issue:** posit-dev/vip#410
+**Dispatch order:** AFTER #411 merges (parallel with #409)
+
+## Problem
+
+Version gating today is a single marker `@pytest.mark.min_version(product=, version=)`
+handled in `src/vip/plugin.py:_maybe_skip_for_version`. Limitations:
+- Minimum only — no behavior switching, no ranges.
+- Runs **optimistically** when the version is unknown (`pc.version is None` → test runs),
+  causing spurious failures.
+- Naive `_version_tuple` parser (first `\d+` per dotted segment) — fragile on Posit
+  calendar versions with suffixes (`2026.06.0-dev+123`, dailies, previews).
+- Can only **skip**, never switch behavior. Gates at whole-test level, so it cannot express
+  "click selector A on 2026.05+, selector B before" (the Workbench New Session dialog
+  redesign case).
+
+## Scope (from design chat)
+**In:** behavior/selector switching per version · robust version parsing ·
+unknown-version handling · "N/A" report status.
+**Out (deprioritized):** `max_version` / version ranges.
+
+## Key insight
+VIP **already** separates selectors from tests: `src/vip_tests/workbench/pages/` holds
+page-object selector classes (`Homepage`, `LoginPage`, `ConsolePaneSelectors`,
+`RStudioSession`, ...) as flat class constants (they even mirror upstream e2e TS page
+files). What is missing is a **version dimension** — the constants are static.
+
+## Mechanism — versioned page-object classes via cumulative inheritance
+
+Chosen over resolver-methods and a data registry. Decisive factor: with #409's Workbench
+version matrix, a fixture picks the page object **once** (`get_homepage(version)`) and every
+step downstream uses it — no `version` argument threaded through dozens of step defs.
+
+UI changes are cumulative and forward, so a linear inheritance chain models product
+evolution and each subclass holds **only the delta**:
+
+```python
+class Homepage:                       # oldest supported — full selector set
+    POSIT_LOGO = "#posit-logo"
+    NEW_SESSION_BUTTON = "#newSessionBtn"
+
+class Homepage_2026_05(Homepage):     # shadcn redesign — override only what changed
+    NEW_SESSION_BUTTON = "button:text-is('New Session')"
+```
+
+- A `get_<page>(version)` factory maps a detected version to the right class.
+- No drift: each selector defined exactly once per version it changes in.
+- Support window is **current + 1–2 back (2–3 live)**, so inheritance depth stays ~2–3.
+
+### Behavior flows (not just selectors)
+For flows that change (Escape vs `#modalCancelBtn`), use an `idp.py`-style **strategy dict
+keyed by version range** (mirrors `_IDP_STRATEGIES`), resolved alongside the page object.
+
+## Robust version parser
+Replace `plugin.py:_version_tuple` with a real Posit calendar-version type:
+`YYYY.MM.patch` plus `-dev` / `-daily` / `-preview` / `+build` suffixes, with correct
+comparison and per-product scheme tolerance. Likely a small `src/vip/version.py`
+(`ProductVersion`) used by both the gate marker and the page-object factory.
+
+## Unknown-version policy
+When a product version cannot be detected: **skip + mark N/A + emit a warning**
+(consistent with the chosen N/A report status; safest — no spurious failures, gaps visible).
+
+## Report status
+Add a distinct **"N/A (version)"** status in `src/vip/reporting.py` and the Quarto
+templates, separate from "skipped (unconfigured)", so version gaps are visible in reports.
+
+## Dependencies
+- **#411 first** (code-surface churn). **#409 Child B** consumes the versioned page objects.
+
+## Acceptance criteria
+- Versioned page-object classes + `get_<page>(version)` factory in `pages/`; volatile
+  selectors version-resolved, stable ones inherited once.
+- Behavior strategy dict keyed by version range for flow differences.
+- `ProductVersion` parser handling calendar versions + suffixes; replaces `_version_tuple`.
+- Unknown version → skip + N/A + warning.
+- "N/A (version)" status distinct in report data model + Quarto output.
+- Selftests cover parser edge cases, factory selection, and unknown-version handling.
+- ruff + mypy clean; CLAUDE.md / `docs/test-architecture.md` updated for the version dimension.

--- a/validation_docs/demo-version-gating.md
+++ b/validation_docs/demo-version-gating.md
@@ -1,0 +1,149 @@
+# Feature: robust version gating (#410)
+
+*2026-07-01T22:55:10Z by Showboat 0.6.1*
+<!-- showboat-id: 8caba893-f614-4413-a0a3-d9ba1b4e8842 -->
+
+Issue #410 replaces the old naive `_version_tuple` marker gate with a real Posit calendar-version parser (`vip.version.ProductVersion`), adds an explicit unknown-version policy (skip + N/A + warn instead of an optimistic pass), a distinct 'N/A (version)' report status, and versioned page-object classes for UI selectors/behavior that change across Workbench releases.
+
+## 1. `ProductVersion` parses and compares Posit calendar versions
+
+Handles `YYYY.MM.patch` plus `-dev`/`-daily`/`-preview` pre-release suffixes and `+build` metadata, with pre-releases sorting before the final release of the same numeric version.
+
+```bash
+uv run python -c "
+from vip.version import ProductVersion as V
+
+print('2026.06.0-dev+123      <', '2026.06.0-daily.20260615 :', V('2026.06.0-dev+123') < V('2026.06.0-daily.20260615'))
+print('2026.06.0-preview      <', '2026.06.0                :', V('2026.06.0-preview') < V('2026.06.0'))
+print('2026.05.9              <', '2026.06.0                :', V('2026.05.9') < V('2026.06.0'))
+print('2026.06.0+build1      ==', '2026.06.0+build2         :', V('2026.06.0+build1') == V('2026.06.0+build2'))
+
+try:
+    V('not-a-version')
+except ValueError as exc:
+    print('unparseable input raises ValueError:', exc)
+"
+```
+
+```output
+2026.06.0-dev+123      < 2026.06.0-daily.20260615 : True
+2026.06.0-preview      < 2026.06.0                : True
+2026.05.9              < 2026.06.0                : True
+2026.06.0+build1      == 2026.06.0+build2         : True
+unparseable input raises ValueError: Cannot parse 'not-a-version' as a Posit calendar version (expected YYYY.MM.patch[-dev|-daily|-preview][+build])
+```
+
+## 2. Unknown version now skips + warns instead of running optimistically
+
+Previously, `pc.version is None` meant a `min_version`-marked test ran optimistically (silent spurious-pass risk). Now it skips, is flagged N/A for the report, and emits a warning naming the gap.
+
+```bash
+uv run pytest selftests/test_plugin.py -k 'version_skip' -v 2>&1 | grep -E 'PASSED|FAILED' | sed -E 's/\[[[:space:]]*[0-9]+%\]//' | sort
+uv run pytest selftests/test_plugin.py -k 'version_skip' -q 2>&1 | grep -E 'passed|failed' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+selftests/test_plugin.py::TestPluginIntegration::test_version_skip PASSED 
+selftests/test_plugin.py::TestPluginIntegration::test_version_skip_known_below_minimum_is_plain_skip PASSED 
+selftests/test_plugin.py::TestPluginIntegration::test_version_skip_unparseable_deployed_version PASSED 
+3 passed
+```
+
+## 3. Versioned page objects: cumulative inheritance + a `get_<page>(version)` factory
+
+`Homepage_2026_05` overrides only the one selector that changed (the shadcn dialog container). A separate version-threshold strategy dict handles the New Session dialog's close *behavior* change (Escape vs. the legacy Cancel button), which isn't expressible as a selector override.
+
+```bash
+uv run python -c "
+from vip_tests.workbench.pages import get_homepage, get_new_session_dialog_close_strategy, Homepage, Homepage_2026_05
+
+print('get_homepage(\"2026.04.0\") ->', get_homepage('2026.04.0').__name__)
+print('get_homepage(\"2026.05.0\") ->', get_homepage('2026.05.0').__name__)
+print('get_homepage(\"2026.06.1\") ->', get_homepage('2026.06.1').__name__)
+print('get_homepage(None)          ->', get_homepage(None).__name__)
+
+print()
+print('SESSION_DETAILS_DIALOG (pre-2026.05):', Homepage.SESSION_DETAILS_DIALOG)
+print('SESSION_DETAILS_DIALOG (2026.05+)   :', Homepage_2026_05.SESSION_DETAILS_DIALOG)
+
+print()
+print('close strategy pre-2026.05 ->', get_new_session_dialog_close_strategy('2026.04.0').__name__)
+print('close strategy 2026.05+    ->', get_new_session_dialog_close_strategy('2026.05.0').__name__)
+"
+```
+
+```output
+get_homepage("2026.04.0") -> Homepage
+get_homepage("2026.05.0") -> Homepage_2026_05
+get_homepage("2026.06.1") -> Homepage_2026_05
+get_homepage(None)          -> Homepage
+
+SESSION_DETAILS_DIALOG (pre-2026.05): [class*='modal-dialog']
+SESSION_DETAILS_DIALOG (2026.05+)   : [data-slot='dialog-content']
+
+close strategy pre-2026.05 -> _close_dialog_via_cancel_button
+close strategy 2026.05+    -> _close_dialog_via_escape
+```
+
+## 4. Distinct 'N/A (version)' report status
+
+`TestResult.status` returns `\"na_version\"` when a test was skipped due to an undetermined version, separate from an ordinary `\"skipped\"` (e.g. an unconfigured feature). The Quarto templates key their styling off `.status`, so version gaps get their own amber badge instead of blending into the grey 'SKIP' bucket.
+
+```bash
+uv run python -c "
+from vip.reporting import TestResult
+
+ordinary_skip = TestResult(nodeid='t::a', outcome='skipped', na_version=False)
+na_skip = TestResult(nodeid='t::b', outcome='skipped', na_version=True)
+passed = TestResult(nodeid='t::c', outcome='passed', na_version=True)  # na_version only matters when actually skipped
+
+print('ordinary skip .status ->', ordinary_skip.status)
+print('N/A-by-version .status ->', na_skip.status)
+print('passed (na_version flag ignored) .status ->', passed.status)
+"
+```
+
+```output
+ordinary skip .status -> skipped
+N/A-by-version .status -> na_version
+passed (na_version flag ignored) .status -> passed
+```
+
+## 5. Full selftest coverage for the new module and page-object factory
+
+```bash
+uv run pytest selftests/test_version.py selftests/test_pages.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+45 passed
+```
+
+## 6. Full selftest suite + lint/format/type checks
+
+```bash
+uv run pytest selftests/ -q --ignore=selftests/test_load_engine.py 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+855 passed, 22 warnings
+```
+
+```bash
+uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+147 files already formatted
+```
+
+`mypy` type checking on `src/vip/`
+
+```bash
+uv run mypy src/vip/ 2>&1 | tail -1
+```
+
+```output
+Success: no issues found in 28 source files
+```


### PR DESCRIPTION
## Summary

- Replace the naive `_version_tuple` marker gate with `vip.version.ProductVersion`, a real parser/comparator for Posit's calendar versioning scheme (`YYYY.MM.patch` plus `-dev`/`-daily`/`-preview`/`+build` suffixes).
- Change the unknown-version policy: a `min_version`-marked test with an undetermined or unparseable product version now skips + warns instead of running optimistically (previously a silent spurious-pass risk).
- Add a distinct **"N/A (version)"** report status (`TestResult.status`) so version gaps are visible in the Quarto report instead of blending into ordinary "skipped".
- Add versioned page-object classes via cumulative inheritance (`Homepage_2026_05(Homepage)`) plus a `get_homepage(version)` factory, and a version-threshold behavior-strategy dict (`get_new_session_dialog_close_strategy`, mirroring `vip.idp`'s IdP strategy dict) for the New Session dialog's Escape-vs-Cancel-button close behavior introduced in the 2026.05 shadcn redesign.

### Key decisions
- Pre-release ordering: `dev < daily < preview < final release` of the same numeric version — not pinned down upstream, documented as a judgment call in `version.py`. Build metadata (`+build`) does not affect ordering.
- The page-object factory and behavior-strategy lookup share a `_resolve_by_version` helper and fall back to the *oldest* known class/strategy on an unknown/unparseable version — unlike the pytest marker path, this is a UI-resolution concern with no "skip" available to it.
- Nothing is wired into `test_runtime_versions.py` or other step files yet — per the design doc's dependency order, that's issue #409's job. This PR only builds and unit-tests the mechanisms.
- `report/results.json.example` was left unchanged — it's a minimal top-level shape example that never demonstrated per-result fields before this change either.

Design doc: `thoughts/shared/plans/2026-06-30-issue-410-better-version-gating-design.md`

Closes #410

## Test plan
- [x] `uv run ruff check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run ruff format --check src/ src/vip_tests/ selftests/ examples/`
- [x] `uv run mypy src/vip/`
- [x] `uv run pytest selftests/ -q --ignore=selftests/test_load_engine.py` (855 passed)
- [x] New selftests: `selftests/test_version.py` (parser edge cases + comparisons), `selftests/test_pages.py` (factory/strategy selection by version, including unknown-version fallback)
- [x] Updated `selftests/test_plugin.py` (unknown/unparseable version → skip + N/A, not optimistic pass) and `selftests/test_reporting.py` (new N/A status)

## Demo

# Feature: robust version gating (#410)

*2026-07-01T22:55:10Z by Showboat 0.6.1*
<!-- showboat-id: 8caba893-f614-4413-a0a3-d9ba1b4e8842 -->

Issue #410 replaces the old naive `_version_tuple` marker gate with a real Posit calendar-version parser (`vip.version.ProductVersion`), adds an explicit unknown-version policy (skip + N/A + warn instead of an optimistic pass), a distinct 'N/A (version)' report status, and versioned page-object classes for UI selectors/behavior that change across Workbench releases.

## 1. `ProductVersion` parses and compares Posit calendar versions

Handles `YYYY.MM.patch` plus `-dev`/`-daily`/`-preview` pre-release suffixes and `+build` metadata, with pre-releases sorting before the final release of the same numeric version.

```bash
uv run python -c "
from vip.version import ProductVersion as V

print('2026.06.0-dev+123      <', '2026.06.0-daily.20260615 :', V('2026.06.0-dev+123') < V('2026.06.0-daily.20260615'))
print('2026.06.0-preview      <', '2026.06.0                :', V('2026.06.0-preview') < V('2026.06.0'))
print('2026.05.9              <', '2026.06.0                :', V('2026.05.9') < V('2026.06.0'))
print('2026.06.0+build1      ==', '2026.06.0+build2         :', V('2026.06.0+build1') == V('2026.06.0+build2'))

try:
    V('not-a-version')
except ValueError as exc:
    print('unparseable input raises ValueError:', exc)
"
```

```output
2026.06.0-dev+123      < 2026.06.0-daily.20260615 : True
2026.06.0-preview      < 2026.06.0                : True
2026.05.9              < 2026.06.0                : True
2026.06.0+build1      == 2026.06.0+build2         : True
unparseable input raises ValueError: Cannot parse 'not-a-version' as a Posit calendar version (expected YYYY.MM.patch[-dev|-daily|-preview][+build])
```

## 2. Unknown version now skips + warns instead of running optimistically

Previously, `pc.version is None` meant a `min_version`-marked test ran optimistically (silent spurious-pass risk). Now it skips, is flagged N/A for the report, and emits a warning naming the gap.

```bash
uv run pytest selftests/test_plugin.py -k 'version_skip' -v 2>&1 | grep -E 'PASSED|FAILED' | sed -E 's/\[[[:space:]]*[0-9]+%\]//' | sort
uv run pytest selftests/test_plugin.py -k 'version_skip' -q 2>&1 | grep -E 'passed|failed' | sed 's/ in [0-9.]*s//'
```

```output
selftests/test_plugin.py::TestPluginIntegration::test_version_skip PASSED 
selftests/test_plugin.py::TestPluginIntegration::test_version_skip_known_below_minimum_is_plain_skip PASSED 
selftests/test_plugin.py::TestPluginIntegration::test_version_skip_unparseable_deployed_version PASSED 
3 passed
```

## 3. Versioned page objects: cumulative inheritance + a `get_<page>(version)` factory

`Homepage_2026_05` overrides only the one selector that changed (the shadcn dialog container). A separate version-threshold strategy dict handles the New Session dialog's close *behavior* change (Escape vs. the legacy Cancel button), which isn't expressible as a selector override.

```bash
uv run python -c "
from vip_tests.workbench.pages import get_homepage, get_new_session_dialog_close_strategy, Homepage, Homepage_2026_05

print('get_homepage(\"2026.04.0\") ->', get_homepage('2026.04.0').__name__)
print('get_homepage(\"2026.05.0\") ->', get_homepage('2026.05.0').__name__)
print('get_homepage(\"2026.06.1\") ->', get_homepage('2026.06.1').__name__)
print('get_homepage(None)          ->', get_homepage(None).__name__)

print()
print('SESSION_DETAILS_DIALOG (pre-2026.05):', Homepage.SESSION_DETAILS_DIALOG)
print('SESSION_DETAILS_DIALOG (2026.05+)   :', Homepage_2026_05.SESSION_DETAILS_DIALOG)

print()
print('close strategy pre-2026.05 ->', get_new_session_dialog_close_strategy('2026.04.0').__name__)
print('close strategy 2026.05+    ->', get_new_session_dialog_close_strategy('2026.05.0').__name__)
"
```

```output
get_homepage("2026.04.0") -> Homepage
get_homepage("2026.05.0") -> Homepage_2026_05
get_homepage("2026.06.1") -> Homepage_2026_05
get_homepage(None)          -> Homepage

SESSION_DETAILS_DIALOG (pre-2026.05): [class*='modal-dialog']
SESSION_DETAILS_DIALOG (2026.05+)   : [data-slot='dialog-content']

close strategy pre-2026.05 -> _close_dialog_via_cancel_button
close strategy 2026.05+    -> _close_dialog_via_escape
```

## 4. Distinct 'N/A (version)' report status

`TestResult.status` returns `"na_version"` when a test was skipped due to an undetermined version, separate from an ordinary `"skipped"` (e.g. an unconfigured feature). The Quarto templates key their styling off `.status`, so version gaps get their own amber badge instead of blending into the grey 'SKIP' bucket.

```bash
uv run python -c "
from vip.reporting import TestResult

ordinary_skip = TestResult(nodeid='t::a', outcome='skipped', na_version=False)
na_skip = TestResult(nodeid='t::b', outcome='skipped', na_version=True)
passed = TestResult(nodeid='t::c', outcome='passed', na_version=True)  # na_version only matters when actually skipped

print('ordinary skip .status ->', ordinary_skip.status)
print('N/A-by-version .status ->', na_skip.status)
print('passed (na_version flag ignored) .status ->', passed.status)
"
```

```output
ordinary skip .status -> skipped
N/A-by-version .status -> na_version
passed (na_version flag ignored) .status -> passed
```

## 5. Full selftest coverage for the new module and page-object factory

```bash
uv run pytest selftests/test_version.py selftests/test_pages.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
45 passed
```

## 6. Full selftest suite + lint/format/type checks

```bash
uv run pytest selftests/ -q --ignore=selftests/test_load_engine.py 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
855 passed, 22 warnings
```

```bash
uv run ruff check src/ src/vip_tests/ selftests/ examples/ && uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
147 files already formatted
```

`mypy` type checking on `src/vip/`

```bash
uv run mypy src/vip/ 2>&1 | tail -1
```

```output
Success: no issues found in 28 source files
```
