### PR TITLE
ci: skip example-report on dependabot PRs (no secret access)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,12 @@ permissions:
 
 jobs:
   example-report:
-    if: github.event.action != 'closed'
+    # Dependabot PRs run without access to repository secrets, so the
+    # license-gated product startup inside example-report can never succeed
+    # there. Skip it on Dependabot PRs instead of failing them with a
+    # spurious License Error. (The preview job below needs this one, so it
+    # skips too.)
+    if: github.event.action != 'closed' && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/example-report.yml
     secrets: inherit
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,7 +15,7 @@ rules:
     #   - website-preview.yml  -- rossjrw/pr-preview-action pushes to gh-pages
     ignore:
       - release.yml:18:9
-      - preview.yml:33:9
-      - preview.yml:53:9
+      - preview.yml:38:9
+      - preview.yml:58:9
       - website-preview.yml:36:9
       - website-preview.yml:100:9


### PR DESCRIPTION
Dependabot PRs run without access to repository secrets, so the license-gated product startup inside `example-report` (Connect/Workbench/PM) can never succeed on them — it fails with a spurious "License Error", which is what reddened the recent Dependabot PRs (e.g. #428).

Skip the `example-report` job (and its dependent `preview` job, via `needs:`) on Dependabot PRs. Non-Dependabot PRs are unaffected.

Part of the #425 robust-CI/CD effort.

## Note
This does NOT address the separate `Agentic Workflow Lockfile Guard` failure on Dependabot *actions* PRs (#429) — that one has no safe one-line fix (the gh-aw `.lock.yml` files pin nearly every shared action, so neither a dependabot ignore-list nor a guard exemption is safe). Tracking that separately.

## Verification
- `preview.yml` parses as valid YAML.
- `zizmor==1.24.1` adds no new findings (pre-existing `secrets: inherit` findings unchanged).
