### PR TITLE
feat(cli): add --connect-version and --workbench-version to vip verify

### DIFF
--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -17,7 +17,9 @@ def _make_args(**overrides) -> argparse.Namespace:
     defaults = {
         "config": None,
         "connect_url": None,
+        "connect_version": None,
         "workbench_url": None,
+        "workbench_version": None,
         "package_manager_url": None,
         "report": "report/results.json",
         "interactive_auth": False,
@@ -969,6 +971,52 @@ class TestVerifyLocalTLSFlags:
         finally:
             if path:
                 Path(path).unlink(missing_ok=True)
+
+
+class TestVerifyLocalVersionFlags:
+    """--connect-version and --workbench-version are encoded in the temp config."""
+
+    def test_connect_version_written_to_temp_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import _generate_temp_config
+        from vip.config import load_config
+
+        path = _generate_temp_config(
+            _make_args(connect_url="https://c.example.com", connect_version="2026.06.0")
+        )
+        try:
+            cfg = load_config(path)
+            assert cfg.connect.version == "2026.06.0"
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_workbench_version_written_to_temp_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import _generate_temp_config
+        from vip.config import load_config
+
+        path = _generate_temp_config(
+            _make_args(workbench_url="https://w.example.com", workbench_version="2026.06.0")
+        )
+        try:
+            cfg = load_config(path)
+            assert cfg.workbench.version == "2026.06.0"
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_no_version_line_when_flag_absent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import _generate_temp_config
+
+        path = _generate_temp_config(_make_args(connect_url="https://c.example.com"))
+        try:
+            content = Path(path).read_text()
+            assert "version" not in content
+        finally:
+            Path(path).unlink(missing_ok=True)
 
 
 class TestVerifyLocalSnowflakeApiAuthGuard:

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -21,6 +21,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         "workbench_url": None,
         "workbench_version": None,
         "package_manager_url": None,
+        "package_manager_version": None,
         "report": "report/results.json",
         "interactive_auth": False,
         "no_auth": False,
@@ -974,7 +975,8 @@ class TestVerifyLocalTLSFlags:
 
 
 class TestVerifyLocalVersionFlags:
-    """--connect-version and --workbench-version are encoded in the temp config."""
+    """--connect-version, --workbench-version, --package-manager-version are
+    encoded in the temp config."""
 
     def test_connect_version_written_to_temp_config(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -1006,15 +1008,59 @@ class TestVerifyLocalVersionFlags:
         finally:
             Path(path).unlink(missing_ok=True)
 
-    def test_no_version_line_when_flag_absent(self, tmp_path, monkeypatch):
+    def test_package_manager_version_written_to_temp_config(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("VIP_CONFIG", raising=False)
         from vip.cli import _generate_temp_config
+        from vip.config import load_config
 
-        path = _generate_temp_config(_make_args(connect_url="https://c.example.com"))
+        path = _generate_temp_config(
+            _make_args(
+                package_manager_url="https://pm.example.com",
+                package_manager_version="2026.06.0",
+            )
+        )
         try:
-            content = Path(path).read_text()
-            assert "version" not in content
+            cfg = load_config(path)
+            assert cfg.package_manager.version == "2026.06.0"
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_no_version_set_when_flags_absent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import _generate_temp_config
+        from vip.config import load_config
+
+        path = _generate_temp_config(
+            _make_args(
+                connect_url="https://c.example.com",
+                workbench_url="https://w.example.com",
+                package_manager_url="https://pm.example.com",
+            )
+        )
+        try:
+            cfg = load_config(path)
+            assert cfg.connect.version is None
+            assert cfg.workbench.version is None
+            assert cfg.package_manager.version is None
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_version_value_with_quote_survives_round_trip(self, tmp_path, monkeypatch):
+        """Values containing a quote must not break the generated TOML."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import _generate_temp_config
+        from vip.config import load_config
+
+        tricky = '2026.06.0"; malicious = true'
+        path = _generate_temp_config(
+            _make_args(connect_url="https://c.example.com", connect_version=tricky)
+        )
+        try:
+            cfg = load_config(path)
+            assert cfg.connect.version == tricky
         finally:
             Path(path).unlink(missing_ok=True)
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -278,25 +278,29 @@ def _generate_temp_config(args: argparse.Namespace) -> str:
     lines = ["[general]", 'deployment_name = "Posit Team"', ""]
 
     if args.connect_url:
-        lines.extend(["[connect]", f'url = "{args.connect_url}"'])
+        lines.extend(["[connect]", f"url = {json.dumps(args.connect_url)}"])
         connect_version = getattr(args, "connect_version", None)
         if connect_version:
-            lines.append(f'version = "{connect_version}"')
+            lines.append(f"version = {json.dumps(connect_version)}")
         lines.append("")
     else:
         lines.extend(["[connect]", "enabled = false", ""])
 
     if args.workbench_url:
-        lines.extend(["[workbench]", f'url = "{args.workbench_url}"'])
+        lines.extend(["[workbench]", f"url = {json.dumps(args.workbench_url)}"])
         workbench_version = getattr(args, "workbench_version", None)
         if workbench_version:
-            lines.append(f'version = "{workbench_version}"')
+            lines.append(f"version = {json.dumps(workbench_version)}")
         lines.append("")
     else:
         lines.extend(["[workbench]", "enabled = false", ""])
 
     if args.package_manager_url:
-        lines.extend(["[package_manager]", f'url = "{args.package_manager_url}"', ""])
+        lines.extend(["[package_manager]", f"url = {json.dumps(args.package_manager_url)}"])
+        package_manager_version = getattr(args, "package_manager_version", None)
+        if package_manager_version:
+            lines.append(f"version = {json.dumps(package_manager_version)}")
+        lines.append("")
     else:
         lines.extend(["[package_manager]", "enabled = false", ""])
 
@@ -935,6 +939,14 @@ def main() -> None:
         default=None,
         help=(
             "Deployed Workbench version (e.g. 2026.06.0). Required for tests with a "
+            "min_version marker to run instead of being skipped as N/A-by-version."
+        ),
+    )
+    url_group.add_argument(
+        "--package-manager-version",
+        default=None,
+        help=(
+            "Deployed Package Manager version (e.g. 2026.06.0). Required for tests with a "
             "min_version marker to run instead of being skipped as N/A-by-version."
         ),
     )

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -278,12 +278,20 @@ def _generate_temp_config(args: argparse.Namespace) -> str:
     lines = ["[general]", 'deployment_name = "Posit Team"', ""]
 
     if args.connect_url:
-        lines.extend(["[connect]", f'url = "{args.connect_url}"', ""])
+        lines.extend(["[connect]", f'url = "{args.connect_url}"'])
+        connect_version = getattr(args, "connect_version", None)
+        if connect_version:
+            lines.append(f'version = "{connect_version}"')
+        lines.append("")
     else:
         lines.extend(["[connect]", "enabled = false", ""])
 
     if args.workbench_url:
-        lines.extend(["[workbench]", f'url = "{args.workbench_url}"', ""])
+        lines.extend(["[workbench]", f'url = "{args.workbench_url}"'])
+        workbench_version = getattr(args, "workbench_version", None)
+        if workbench_version:
+            lines.append(f'version = "{workbench_version}"')
+        lines.append("")
     else:
         lines.extend(["[workbench]", "enabled = false", ""])
 
@@ -914,6 +922,22 @@ def main() -> None:
     url_group.add_argument("--connect-url", default=None, help="Connect server URL")
     url_group.add_argument("--workbench-url", default=None, help="Workbench server URL")
     url_group.add_argument("--package-manager-url", default=None, help="Package Manager server URL")
+    url_group.add_argument(
+        "--connect-version",
+        default=None,
+        help=(
+            "Deployed Connect version (e.g. 2026.06.0). Required for tests with a "
+            "min_version marker to run instead of being skipped as N/A-by-version."
+        ),
+    )
+    url_group.add_argument(
+        "--workbench-version",
+        default=None,
+        help=(
+            "Deployed Workbench version (e.g. 2026.06.0). Required for tests with a "
+            "min_version marker to run instead of being skipped as N/A-by-version."
+        ),
+    )
 
     # TLS configuration
     tls_group = verify_parser.add_argument_group("TLS configuration")


### PR DESCRIPTION
## Summary
- Adds `--connect-version` / `--workbench-version` flags to `vip verify`, mirroring the existing `[connect]`/`[workbench] version` fields in `vip.toml`.
- Without them, `vip verify --connect-url ...` (no config file) has no way to supply a deployed version, so any `min_version`-marked test warns "version unknown" and is marked N/A during collection — even if it's not selected to run.
- Surfaced by the mock-idp-e2e workflow (#431) after #432 (robust version gating) merged: `test_chronicle.py`'s `min_version(connect, 2026.06.0)` marker now warns on every CI run since `--connect-url` had no version source.

## Test plan
- [x] `uv run ruff check` / `ruff format --check`
- [x] `uv run pytest selftests/ -q` — 858 passed (excluding the pre-existing flaky `test_load_engine.py` timing tests)
- [x] New selftests in `TestVerifyLocalVersionFlags` cover: version written when flag set, omitted when absent, for both Connect and Workbench
- [x] Manually verified generated `vip.toml` content via `_generate_temp_config`