### PR TITLE
build: pin uv version for deterministic uv.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/playwright/python:v1.60.0-noble
 
 # Install uv for fast Python package management
-COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/docker/opensuse-leap/Dockerfile
+++ b/docker/opensuse-leap/Dockerfile
@@ -8,7 +8,7 @@ RUN zypper -n install \
     && zypper clean --all
 
 # Install uv (matches version pinned in vip's main Dockerfiles)
-COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 COPY . .

--- a/docker/rhel10/Dockerfile
+++ b/docker/rhel10/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf install -y \
     && dnf clean all
 
 # Install uv (matches version pinned in vip's main Dockerfile)
-COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 COPY . .

--- a/docker/rhel9/Dockerfile
+++ b/docker/rhel9/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf install -y \
     && dnf clean all
 
 # Install uv (matches version pinned in vip's main Dockerfile)
-COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 COPY . .

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,9 +56,9 @@ version is pinned so relocking always produces the same output:
   on any relock. If uv refuses to run, upgrade it (`uv self update`, or
   `brew upgrade uv`).
 - `just relock` regenerates the lockfile with an **exact** pinned uv version
-  (`UV_VERSION` in the `justfile`), fetched via `uvx` so it doesn't matter which
-  uv you have installed. Always relock with this recipe rather than a bare
-  `uv lock`:
+  (`UV_VERSION` in the `justfile`), fetched via `uvx` — so the output is
+  identical even when your local uv is a different version. Always relock with
+  this recipe rather than a bare `uv lock`:
 
   ```bash
   just relock
@@ -73,7 +73,7 @@ Never hand-edit conflict markers in `uv.lock`. Take either side wholesale, then
 regenerate deterministically:
 
 ```bash
-git checkout --theirs uv.lock   # or --ours; the starting point doesn't matter
+git checkout --theirs -- uv.lock   # or --ours; the starting point doesn't matter
 just relock                     # re-resolves from pyproject.toml with the pinned uv
 git add uv.lock
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,6 +44,43 @@ uv run ruff format src/ src/vip_tests/       # reformat
 uv run mypy src/
 ```
 
+## The lockfile
+
+`uv.lock` is committed and must stay reproducible across machines. The uv
+version is pinned so relocking always produces the same output:
+
+- `pyproject.toml`'s `[tool.uv] required-version = ">=0.11"` rejects any uv
+  older than 0.11 for **every** uv command in this repo. Older uv (e.g. the
+  0.6.x still shipped by some package managers) strips the `upload-time` wheel
+  annotations and writes an older lockfile revision, which churns ~2000 lines
+  on any relock. If uv refuses to run, upgrade it (`uv self update`, or
+  `brew upgrade uv`).
+- `just relock` regenerates the lockfile with an **exact** pinned uv version
+  (`UV_VERSION` in the `justfile`), fetched via `uvx` so it doesn't matter which
+  uv you have installed. Always relock with this recipe rather than a bare
+  `uv lock`:
+
+  ```bash
+  just relock
+  ```
+
+  When bumping the pin, change both `UV_VERSION` in the `justfile` and the
+  `required-version` floor in `pyproject.toml` together.
+
+### Resolving a uv.lock merge conflict
+
+Never hand-edit conflict markers in `uv.lock`. Take either side wholesale, then
+regenerate deterministically:
+
+```bash
+git checkout --theirs uv.lock   # or --ours; the starting point doesn't matter
+just relock                     # re-resolves from pyproject.toml with the pinned uv
+git add uv.lock
+```
+
+Because the uv version is pinned, the regenerated lockfile is identical to what
+CI and other contributors produce, so the conflict resolves cleanly.
+
 ## Design principles
 
 - **Non-destructive** — tests create, verify, and clean up their own content.

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 # VIP - Verified Installation of Posit
 
+# Exact uv version used to regenerate uv.lock. Must satisfy the
+# `required-version` floor in pyproject.toml's [tool.uv]. Bump both together.
+UV_VERSION := "0.11.28"
+
 # List available recipes
 default:
     @just --list
@@ -11,6 +15,14 @@ setup:
 
 # Same as `setup` — kept for muscle memory; vip install handles RHEL detection.
 setup-rhel: setup
+
+# Regenerate uv.lock with the pinned uv version (see UV_VERSION above).
+# Use this instead of a bare `uv lock` so the lockfile is byte-reproducible
+# regardless of the uv installed locally — `uvx` fetches the exact pin. This is
+# also how you resolve a uv.lock merge conflict: take either side, then relock.
+#   git checkout --theirs uv.lock && just relock
+relock:
+    uvx --from uv=={{ UV_VERSION }} uv lock
 
 # Run ruff linter
 lint:

--- a/justfile
+++ b/justfile
@@ -17,10 +17,11 @@ setup:
 setup-rhel: setup
 
 # Regenerate uv.lock with the pinned uv version (see UV_VERSION above).
-# Use this instead of a bare `uv lock` so the lockfile is byte-reproducible
-# regardless of the uv installed locally — `uvx` fetches the exact pin. This is
-# also how you resolve a uv.lock merge conflict: take either side, then relock.
-#   git checkout --theirs uv.lock && just relock
+# Use this instead of a bare `uv lock`: `uvx` fetches the exact pinned uv, so
+# the lockfile is byte-reproducible even when your local uv is a different
+# version. This is also how you resolve a uv.lock merge conflict — take either
+# side, then relock:
+#   git checkout --theirs -- uv.lock && just relock
 relock:
     uvx --from uv=={{ UV_VERSION }} uv lock
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,14 @@ vip = "vip.plugin"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.uv]
+# Pin the uv version used in this repo so `uv.lock` is reproducible across
+# machines. Older uv (< 0.11) strips the `upload-time` wheel annotations and
+# uses an older lockfile revision, which churns ~2000 lines on any relock. The
+# floor rejects those versions for every uv command; `just relock` pins an exact
+# version on top of it. See docs/development.md ("The lockfile").
+required-version = ">=0.11"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/vip", "src/vip_tests"]
 

--- a/validation_docs/demo-deterministic-lockfile.md
+++ b/validation_docs/demo-deterministic-lockfile.md
@@ -1,0 +1,74 @@
+# Feature: deterministic uv.lock handling (#425 part 2)
+
+*2026-07-08T16:21:01Z by Showboat 0.6.1*
+<!-- showboat-id: 6c558e25-212d-40cf-88f3-48535733826c -->
+
+Local uv 0.6.3 strips the `upload-time` wheel annotations and writes an older lockfile revision, churning ~2000 lines on any relock and driving constant merge conflicts. This change pins the uv version used for locking so `uv.lock` is byte-reproducible everywhere: a `required-version` floor in pyproject.toml, a pinned `just relock` recipe, and contributor docs for deterministic conflict resolution.
+
+```bash
+sed -n '/^\[tool.uv\]/,/^$/p' pyproject.toml
+```
+
+```output
+[tool.uv]
+# Pin the uv version used in this repo so `uv.lock` is reproducible across
+# machines. Older uv (< 0.11) strips the `upload-time` wheel annotations and
+# uses an older lockfile revision, which churns ~2000 lines on any relock. The
+# floor rejects those versions for every uv command; `just relock` pins an exact
+# version on top of it. See docs/development.md ("The lockfile").
+required-version = ">=0.11"
+
+```
+
+```bash
+grep -A1 '^UV_VERSION' justfile; echo; grep -A7 '^# Regenerate uv.lock' justfile
+```
+
+```output
+UV_VERSION := "0.11.28"
+
+
+# Regenerate uv.lock with the pinned uv version (see UV_VERSION above).
+# Use this instead of a bare `uv lock` so the lockfile is byte-reproducible
+# regardless of the uv installed locally — `uvx` fetches the exact pin. This is
+# also how you resolve a uv.lock merge conflict: take either side, then relock.
+#   git checkout --theirs uv.lock && just relock
+relock:
+    uvx --from uv=={{ UV_VERSION }} uv lock
+
+```
+
+**Proof 1 — determinism.** Regenerating with the pinned uv leaves the committed `uv.lock` byte-identical (no churn), so a fresh relock never fights the lockfile:
+
+```bash
+just relock >/dev/null 2>&1; if [ -z "$(git status --porcelain uv.lock)" ]; then echo "just relock -> uv.lock unchanged (byte-identical to committed)"; else echo "CHANGED:"; git --no-pager diff --stat uv.lock; fi
+```
+
+```output
+just relock -> uv.lock unchanged (byte-identical to committed)
+```
+
+**Proof 2 — the floor guards against a stray relock.** `uv lock --check` confirms the committed lockfile matches the pinned uv's output, and `required-version` refuses any uv below 0.11 for every command in the repo:
+
+```bash
+uvx --from uv==0.11.28 uv lock --check >/dev/null 2>&1 && echo "uv lock --check: committed uv.lock matches pinned-uv (0.11.28) output"
+```
+
+```output
+uv lock --check: committed uv.lock matches pinned-uv (0.11.28) output
+```
+
+**Lint and format** stay green (this change touches config, the justfile, and docs — no Python):
+
+```bash
+env -u VIRTUAL_ENV just check 2>&1 | sed "s/ in [0-9.]*s//"
+```
+
+```output
+uv run ruff check src/ selftests/ examples/ docker/
+All checks passed!
+uv run ruff format --check src/ selftests/ examples/ docker/
+149 files already formatted
+```
+
+**Docs.** `docs/development.md` gains a "The lockfile" section explaining the pin, the `just relock` recipe, and deterministic merge-conflict resolution (`git checkout --theirs uv.lock && just relock` — take either side, then regenerate).

--- a/validation_docs/demo-deterministic-lockfile.md
+++ b/validation_docs/demo-deterministic-lockfile.md
@@ -1,7 +1,7 @@
 # Feature: deterministic uv.lock handling (#425 part 2)
 
-*2026-07-08T16:21:01Z by Showboat 0.6.1*
-<!-- showboat-id: 6c558e25-212d-40cf-88f3-48535733826c -->
+*2026-07-08T16:57:07Z by Showboat 0.6.1*
+<!-- showboat-id: e0f4674a-03c3-4116-9850-5184ea0c45dd -->
 
 Local uv 0.6.3 strips the `upload-time` wheel annotations and writes an older lockfile revision, churning ~2000 lines on any relock and driving constant merge conflicts. This change pins the uv version used for locking so `uv.lock` is byte-reproducible everywhere: a `required-version` floor in pyproject.toml, a pinned `just relock` recipe, and contributor docs for deterministic conflict resolution.
 
@@ -29,13 +29,13 @@ UV_VERSION := "0.11.28"
 
 
 # Regenerate uv.lock with the pinned uv version (see UV_VERSION above).
-# Use this instead of a bare `uv lock` so the lockfile is byte-reproducible
-# regardless of the uv installed locally — `uvx` fetches the exact pin. This is
-# also how you resolve a uv.lock merge conflict: take either side, then relock.
-#   git checkout --theirs uv.lock && just relock
+# Use this instead of a bare `uv lock`: `uvx` fetches the exact pinned uv, so
+# the lockfile is byte-reproducible even when your local uv is a different
+# version. This is also how you resolve a uv.lock merge conflict — take either
+# side, then relock:
+#   git checkout --theirs -- uv.lock && just relock
 relock:
     uvx --from uv=={{ UV_VERSION }} uv lock
-
 ```
 
 **Proof 1 — determinism.** Regenerating with the pinned uv leaves the committed `uv.lock` byte-identical (no churn), so a fresh relock never fights the lockfile:
@@ -71,4 +71,4 @@ uv run ruff format --check src/ selftests/ examples/ docker/
 149 files already formatted
 ```
 
-**Docs.** `docs/development.md` gains a "The lockfile" section explaining the pin, the `just relock` recipe, and deterministic merge-conflict resolution (`git checkout --theirs uv.lock && just relock` — take either side, then regenerate).
+**Docs.** `docs/development.md` gains a "The lockfile" section explaining the pin, the `just relock` recipe, and deterministic merge-conflict resolution (`git checkout --theirs -- uv.lock && just relock` — take either side, then regenerate).


### PR DESCRIPTION
## Summary

Part 2 of #425 (Child E of the robust CI/CD epic #409). Part 1 (#426) scoped the
dependency audit; this handles **deterministic lockfile handling**.

Old uv (< 0.11, e.g. the 0.6.3 Homebrew still ships) strips `upload-time` wheel
annotations and writes an older lockfile revision — churning ~2000 lines on any
relock and driving constant `uv.lock` merge conflicts. This pins the uv version
used for locking so the lockfile is byte-reproducible everywhere.

## Changes

- **`pyproject.toml`** — `[tool.uv] required-version = ">=0.11"`. Rejects the
  churn-causing versions for *every* uv command in the repo (a stray `uv lock`
  on old uv now errors instead of silently re-churning).
- **`justfile`** — `just relock` recipe pinned to an exact uv (`UV_VERSION =
  0.11.28`) via `uvx --from uv==<ver>`, so it produces identical output
  regardless of the locally installed uv. Doubles as the merge-conflict fix.
- **`docs/development.md`** — new "The lockfile" section: the pin, `just relock`,
  and deterministic conflict resolution (`git checkout --theirs uv.lock && just relock`).
- **Dockerfiles** (`Dockerfile`, `docker/{rhel9,rhel10,opensuse-leap}/Dockerfile`) —
  bump the `ghcr.io/astral-sh/uv` image pin from `0.6.3` to `0.11.28` so the container
  builds satisfy the new floor at `uv sync --frozen`. (The floor surfaced that the
  images were still on the churn-causing 0.6.3.)

Out of scope (tracked elsewhere): the scoped/scheduled audit (part 1, merged),
#399's release-time pins, CI `setup-uv` pinning (CI only reads the lock).

## Note on blast radius

`required-version` blocks uv older than 0.11 for all uv commands in this repo —
contributors on ancient uv must upgrade (`uv self update` / `brew upgrade uv`).
This is the intended nudge; CI already uses a modern uv.

## Verification

- `uv lock --check` passes with the pinned uv; committed `uv.lock` unchanged.
- `just relock` is a no-op on the committed lock (determinism).
- ruff check + format, mypy (`src/vip/`) clean; selftests 883 passed (only the
  documented `test_load_engine` timing flakes).

## Demo

# Feature: deterministic uv.lock handling (#425 part 2)

*2026-07-08T16:21:01Z by Showboat 0.6.1*
<!-- showboat-id: 6c558e25-212d-40cf-88f3-48535733826c -->

Local uv 0.6.3 strips the `upload-time` wheel annotations and writes an older lockfile revision, churning ~2000 lines on any relock and driving constant merge conflicts. This change pins the uv version used for locking so `uv.lock` is byte-reproducible everywhere: a `required-version` floor in pyproject.toml, a pinned `just relock` recipe, and contributor docs for deterministic conflict resolution.

```bash
sed -n '/^\[tool.uv\]/,/^$/p' pyproject.toml
```

```output
[tool.uv]
# Pin the uv version used in this repo so `uv.lock` is reproducible across
# machines. Older uv (< 0.11) strips the `upload-time` wheel annotations and
# uses an older lockfile revision, which churns ~2000 lines on any relock. The
# floor rejects those versions for every uv command; `just relock` pins an exact
# version on top of it. See docs/development.md ("The lockfile").
required-version = ">=0.11"

```

```bash
grep -A1 '^UV_VERSION' justfile; echo; grep -A7 '^# Regenerate uv.lock' justfile
```

```output
UV_VERSION := "0.11.28"


# Regenerate uv.lock with the pinned uv version (see UV_VERSION above).
# Use this instead of a bare `uv lock` so the lockfile is byte-reproducible
# regardless of the uv installed locally — `uvx` fetches the exact pin. This is
# also how you resolve a uv.lock merge conflict: take either side, then relock.
#   git checkout --theirs uv.lock && just relock
relock:
    uvx --from uv=={{ UV_VERSION }} uv lock

```

**Proof 1 — determinism.** Regenerating with the pinned uv leaves the committed `uv.lock` byte-identical (no churn), so a fresh relock never fights the lockfile:

```bash
just relock >/dev/null 2>&1; if [ -z "$(git status --porcelain uv.lock)" ]; then echo "just relock -> uv.lock unchanged (byte-identical to committed)"; else echo "CHANGED:"; git --no-pager diff --stat uv.lock; fi
```

```output
just relock -> uv.lock unchanged (byte-identical to committed)
```

**Proof 2 — the floor guards against a stray relock.** `uv lock --check` confirms the committed lockfile matches the pinned uv's output, and `required-version` refuses any uv below 0.11 for every command in the repo:

```bash
uvx --from uv==0.11.28 uv lock --check >/dev/null 2>&1 && echo "uv lock --check: committed uv.lock matches pinned-uv (0.11.28) output"
```

```output
uv lock --check: committed uv.lock matches pinned-uv (0.11.28) output
```

**Lint and format** stay green (this change touches config, the justfile, and docs — no Python):

```bash
env -u VIRTUAL_ENV just check 2>&1 | sed "s/ in [0-9.]*s//"
```

```output
uv run ruff check src/ selftests/ examples/ docker/
All checks passed!
uv run ruff format --check src/ selftests/ examples/ docker/
149 files already formatted
```

**Docs.** `docs/development.md` gains a "The lockfile" section explaining the pin, the `just relock` recipe, and deterministic merge-conflict resolution (`git checkout --theirs uv.lock && just relock` — take either side, then regenerate).
