### PR TITLE
fix(workbench): remove stale clone dir before git-ops clone

### DIFF
--- a/selftests/test_workbench_git_ops.py
+++ b/selftests/test_workbench_git_ops.py
@@ -1,0 +1,59 @@
+"""Selftests for the Workbench git-ops clone command construction.
+
+Covers ``_do_clone`` in ``vip_tests.workbench.test_git_ops``: verifies the
+shell command it builds removes any pre-existing clone directory before
+running ``git clone``, so repeat runs against long-lived QA VMs don't fail
+with "destination path already exists". No live Workbench deployment or
+Playwright browser required -- ``terminal_run`` is monkeypatched to capture
+the command string instead of executing it.
+"""
+
+from __future__ import annotations
+
+from vip_tests.workbench import test_git_ops as git_ops
+
+
+class _FakeGitCfg:
+    def __init__(self, clone_url: str, token: str = ""):
+        self.clone_url = clone_url
+        self.token = token
+
+
+def test_do_clone_removes_existing_dir_before_cloning(monkeypatch):
+    captured: dict = {}
+
+    def fake_terminal_run(page, cmd, timeout=30_000, *, readback_lang="r"):
+        captured["cmd"] = cmd
+        return ""
+
+    monkeypatch.setattr(git_ops, "terminal_run", fake_terminal_run)
+
+    git_cfg = _FakeGitCfg("https://github.com/example/jumpstart_examples.git")
+    git_session_ctx: dict = {}
+
+    clone_dir = git_ops._do_clone(object(), git_session_ctx, git_cfg, readback_lang="r")
+
+    assert clone_dir == "/tmp/jumpstart_examples"
+    assert git_session_ctx["clone_dir"] == clone_dir
+    rm_index = captured["cmd"].find("rm -rf /tmp/jumpstart_examples")
+    clone_index = captured["cmd"].find("git clone")
+    assert rm_index != -1, f"expected rm -rf of clone dir in command: {captured['cmd']!r}"
+    assert rm_index < clone_index, "rm -rf must run before git clone"
+
+
+def test_do_clone_uses_custom_workdir(monkeypatch):
+    captured: dict = {}
+
+    def fake_terminal_run(page, cmd, timeout=30_000, *, readback_lang="r"):
+        captured["cmd"] = cmd
+        return ""
+
+    monkeypatch.setattr(git_ops, "terminal_run", fake_terminal_run)
+
+    git_cfg = _FakeGitCfg("https://github.com/example/other-repo.git")
+    clone_dir = git_ops._do_clone(
+        object(), {}, git_cfg, readback_lang="python", workdir="/home/vip"
+    )
+
+    assert clone_dir == "/home/vip/other-repo"
+    assert "rm -rf /home/vip/other-repo" in captured["cmd"]

--- a/src/vip_tests/workbench/test_git_ops.py
+++ b/src/vip_tests/workbench/test_git_ops.py
@@ -384,7 +384,8 @@ def _do_clone(
 
     terminal_run(
         page,
-        f"cd {shlex.quote(workdir)} && GIT_TERMINAL_PROMPT=0 git clone {shlex.quote(auth_url)}",
+        f"rm -rf {shlex.quote(clone_dir)} && cd {shlex.quote(workdir)} && "
+        f"GIT_TERMINAL_PROMPT=0 git clone {shlex.quote(auth_url)}",
         timeout=_TIMEOUT_GIT_NETWORK,
         readback_lang=readback_lang,
     )

--- a/validation_docs/demo-git-clone-cleanup.md
+++ b/validation_docs/demo-git-clone-cleanup.md
@@ -1,0 +1,71 @@
+# Fix: Workbench git-ops clone reuses stale directory (#438)
+
+*2026-07-08T15:46:55Z by Showboat 0.6.1*
+<!-- showboat-id: 74ec94bb-ee79-49c2-9bfa-0b395cf9760d -->
+
+Every Workbench git-ops clone scenario clones into the fixed path /tmp/jumpstart_examples,
+and nothing ever removes it. On long-lived QA VMs (Workbench scenarios run serially against
+one VM), a leftover clone directory from a prior IDE scenario or a previous day's run makes
+git clone fail with "destination path already exists and is not an empty directory".
+
+Fix: _do_clone (src/vip_tests/workbench/test_git_ops.py) now removes any pre-existing
+destination directory before cloning, so each clone scenario is self-contained regardless
+of what a prior run left behind. New selftests in selftests/test_workbench_git_ops.py pin
+down the command construction by monkeypatching terminal_run and asserting the built
+shell command runs "rm -rf <clone_dir>" before "git clone".
+
+```bash
+uv run pytest selftests/test_workbench_git_ops.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+2 passed
+```
+
+```bash
+uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+890 passed, 26 warnings
+```
+
+```bash
+just check
+```
+
+```output
+uv run ruff check src/ selftests/ examples/ docker/
+All checks passed!
+uv run ruff format --check src/ selftests/ examples/ docker/
+150 files already formatted
+```
+
+```bash
+sed -n '372,393p' src/vip_tests/workbench/test_git_ops.py
+```
+
+```output
+def _do_clone(
+    page: Page,
+    git_session_ctx: dict,
+    git_cfg,
+    readback_lang: str,
+    *,
+    workdir: str = "/tmp",
+) -> str:
+    """Run ``git clone`` in the IDE terminal and return the cloned directory path."""
+    auth_url = _inject_token_into_url(git_cfg.clone_url, git_cfg.token)
+    repo_dir = _repo_dir_from_url(git_cfg.clone_url)
+    clone_dir = f"{workdir}/{repo_dir}"
+
+    terminal_run(
+        page,
+        f"rm -rf {shlex.quote(clone_dir)} && cd {shlex.quote(workdir)} && "
+        f"GIT_TERMINAL_PROMPT=0 git clone {shlex.quote(auth_url)}",
+        timeout=_TIMEOUT_GIT_NETWORK,
+        readback_lang=readback_lang,
+    )
+    git_session_ctx["clone_dir"] = clone_dir
+    return clone_dir
+```


### PR DESCRIPTION
## Summary
- Every Workbench git-ops "Clone a Git repository in `<IDE>` terminal" scenario clones into the fixed path `/tmp/jumpstart_examples`, and nothing removes it afterward. On long-lived Workbench QA VMs (not redeployed per `vip verify` run), a leftover clone directory from a prior IDE scenario or a previous day's run makes `git clone` fail with `fatal: destination path 'jumpstart_examples' already exists and is not an empty directory`.
- `_do_clone` now removes any pre-existing destination directory before cloning (`rm -rf <clone_dir> && cd ... && git clone ...`), so each clone scenario is self-contained regardless of what a prior run left behind.

Fixes #438

## Test plan
- [x] Added `selftests/test_workbench_git_ops.py` to pin down the command construction (fails without the fix, passes with it)
- [x] `uv run pytest selftests/` — 890 passed
- [x] `just check` — lint and format clean
- [x] `vip verify --collect-only` still collects all 9 git-ops scenarios with no errors

## Demo

# Fix: Workbench git-ops clone reuses stale directory (#438)

*2026-07-08T15:46:55Z by Showboat 0.6.1*
<!-- showboat-id: 74ec94bb-ee79-49c2-9bfa-0b395cf9760d -->

Every Workbench git-ops clone scenario clones into the fixed path /tmp/jumpstart_examples,
and nothing ever removes it. On long-lived QA VMs (Workbench scenarios run serially against
one VM), a leftover clone directory from a prior IDE scenario or a previous day's run makes
git clone fail with "destination path already exists and is not an empty directory".

Fix: _do_clone (src/vip_tests/workbench/test_git_ops.py) now removes any pre-existing
destination directory before cloning, so each clone scenario is self-contained regardless
of what a prior run left behind. New selftests in selftests/test_workbench_git_ops.py pin
down the command construction by monkeypatching terminal_run and asserting the built
shell command runs "rm -rf <clone_dir>" before "git clone".

```bash
uv run pytest selftests/test_workbench_git_ops.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
2 passed
```

```bash
uv run pytest selftests/ -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
890 passed, 26 warnings
```

```bash
just check
```

```output
uv run ruff check src/ selftests/ examples/ docker/
All checks passed!
uv run ruff format --check src/ selftests/ examples/ docker/
150 files already formatted
```

```bash
sed -n '372,393p' src/vip_tests/workbench/test_git_ops.py
```

```output
def _do_clone(
    page: Page,
    git_session_ctx: dict,
    git_cfg,
    readback_lang: str,
    *,
    workdir: str = "/tmp",
) -> str:
    """Run ``git clone`` in the IDE terminal and return the cloned directory path."""
    auth_url = _inject_token_into_url(git_cfg.clone_url, git_cfg.token)
    repo_dir = _repo_dir_from_url(git_cfg.clone_url)
    clone_dir = f"{workdir}/{repo_dir}"

    terminal_run(
        page,
        f"rm -rf {shlex.quote(clone_dir)} && cd {shlex.quote(workdir)} && "
        f"GIT_TERMINAL_PROMPT=0 git clone {shlex.quote(auth_url)}",
        timeout=_TIMEOUT_GIT_NETWORK,
        readback_lang=readback_lang,
    )
    git_session_ctx["clone_dir"] = clone_dir
    return clone_dir
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)