### PR TITLE
ci: ignore actions/cache in dependabot (gh-aw lockfile guard)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
   ignore:
   - dependency-name: "github/gh-aw-actions/**" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
   - dependency-name: "actions/create-github-app-token" # Only used inside gh-aw .lock.yml (compiler-managed); bumping it there leaves the lockfile stale.
-  - dependency-name: "actions/cache" # gh-aw pins cache/restore + cache/save to v5.0.5 inside .lock.yml; dependabot bumping them to v6.x is reverted on recompile and fails the lockfile guard. Hand-written workflows already use the latest cache.
+  - dependency-name: "actions/cache/**" # gh-aw pins cache/restore + cache/save to v5.0.5 inside .lock.yml; dependabot bumping them to v6.x is reverted on recompile and fails the lockfile guard. Hand-written workflows already use the latest cache.
   package-ecosystem: github-actions
   schedule:
     interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
   ignore:
   - dependency-name: "github/gh-aw-actions/**" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
   - dependency-name: "actions/create-github-app-token" # Only used inside gh-aw .lock.yml (compiler-managed); bumping it there leaves the lockfile stale.
+  - dependency-name: "actions/cache" # gh-aw pins cache/restore + cache/save to v5.0.5 inside .lock.yml; dependabot bumping them to v6.x is reverted on recompile and fails the lockfile guard. Hand-written workflows already use the latest cache.
   package-ecosystem: github-actions
   schedule:
     interval: weekly


### PR DESCRIPTION
## Problem

Follow-up to #448. The **Agentic Workflow Lockfile Guard** still fails on the dependabot actions-group PR (#450), now because of `actions/cache`. gh-aw pins `actions/cache/restore` and `actions/cache/save` to `v5.0.5` inside the generated `*.lock.yml` files. Dependabot bumps those references to `v6.1.0`; `gh aw compile` reverts them on recompile, failing the guard.

Unlike checkout (fixed in #448 by bumping the gh-aw pin), this cannot be resolved by recompiling: the latest gh-aw (v0.81.6) pins cache to v5.0.5 and no release produces v6.x. The compiler owns the version inside the lock files.

## Fix

Add `actions/cache` to dependabot's `ignore` list for the github-actions ecosystem, matching the existing carve-outs for `github/gh-aw-actions/**` and `actions/create-github-app-token`.

Zero cost: the hand-written workflows (connect-smoke, linux-smoke, workbench-smoke) already use `actions/cache@v6.1.0` (latest). Only the compiler-pinned lock-file copies — which dependabot should never have been bumping — stop being touched.

Once merged, dependabot recreates #450 without the cache bump, keeping the `setup-cli` and `build-push-action` updates, which pass the guard.