### PR TITLE
ci: ignore gh-aw-managed shared actions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,18 @@ updates:
   - dependency-name: "github/gh-aw-actions/**" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
   - dependency-name: "actions/create-github-app-token" # Only used inside gh-aw .lock.yml (compiler-managed); bumping it there leaves the lockfile stale.
   - dependency-name: "actions/cache/**" # gh-aw pins cache/restore + cache/save to v5.0.5 inside .lock.yml; dependabot bumping them to v6.x is reverted on recompile and fails the lockfile guard. Hand-written workflows already use the latest cache.
+  # Shared actions that gh-aw pins inside the compiled .lock.yml files. Dependabot
+  # bumping them there is reverted by `gh aw compile` and fails the Agentic Workflow
+  # Lockfile Guard (ci.yml). Unlike the entries above these are also used in
+  # hand-written workflows, so ignoring them freezes version AND security updates
+  # repo-wide; bump them manually alongside the gh-aw pin on recompile. See #434.
+  - dependency-name: "actions/checkout"
+  - dependency-name: "actions/upload-artifact"
+  - dependency-name: "actions/download-artifact"
+  - dependency-name: "actions/github-script"
+  - dependency-name: "actions/setup-node"
+  - dependency-name: "astral-sh/setup-uv"
+  - dependency-name: "extractions/setup-just"
   package-ecosystem: github-actions
   schedule:
     interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - 'uv.lock'
       - '.github/workflows/**'
       - '.github/zizmor.yml'
+      - '.github/dependabot.yml'
 
 jobs:
   lint:


### PR DESCRIPTION
Fixes #434 (child of #409 robust-CI/CD epic).

## Problem
Dependabot's weekly github-actions bump edits the shared actions pinned
inside the gh-aw compiled `.lock.yml` files (`checkout`, `github-script`,
`upload`/`download-artifact`, `setup-node`, `setup-uv`, `setup-just`). Those
pins are owned by the gh-aw compiler, so the bump leaves the lockfiles stale
and the **Agentic Workflow Lockfile Guard** (`ci.yml`) fails on the Dependabot
PR — recurring red-X noise on a non-required check.

## Why not auto-recompile-and-push
The originally-designed fix (a `pull_request_target` workflow that runs
`gh aw compile` and pushes the recompiled lockfiles back to the branch) is
blocked: pushing files under `.github/workflows/` requires a token with
`workflows: write`, which the `vip-triage-bot` App does not have. Granting it
was declined for a non-required check. See the design/plan docs under
`thoughts/shared/plans/2026-07-08-issue-434-*` for the full record.

## Fix
Extend the existing `github-actions` `ignore:` list to the full set of shared
actions gh-aw pins in the `.lock.yml` files. This prevents the staleness at the
source rather than exempting the guard (exempting is unsafe — `gh aw compile`
reverts a merged `.lock.yml` bump on the next PR, failing the guard repo-wide).

## Tradeoff
`ignore` with `dependency-name` alone suppresses **both** version and security
updates for these actions repo-wide. This is accepted: a security-update PR
would bump the same `.lock.yml` pins and trip the guard identically, so an
`update-types` variant wouldn't spare us the failure — it'd only make it rarer.
These actions must be bumped manually alongside the gh-aw pin on recompile.
