### PR TITLE
fix(workbench): extensions search input selector and keyboard entry

### DIFF
--- a/src/vip_tests/workbench/pages/positron_session.py
+++ b/src/vip_tests/workbench/pages/positron_session.py
@@ -38,8 +38,8 @@ class PositronSession:
     # Extensions panel (same as VS Code)
     # The extensions search box is a Monaco editor, not an <input> — the old
     # `input[type='text']` selector matches nothing on Workbench 2026.04+.
-    # Locator reported working on a live 2026.04 deployment in #280. Click to
-    # focus, then type keystrokes; Locator.fill() rejects Monaco widgets.
+    # Selector taken from the reporter's live-2026.04 findings in #280; not yet
+    # re-validated by VIP. Click to focus, then type; fill() rejects Monaco.
     EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
 
     # Posit Workbench extension

--- a/src/vip_tests/workbench/pages/positron_session.py
+++ b/src/vip_tests/workbench/pages/positron_session.py
@@ -48,7 +48,13 @@ class PositronSession:
 
     @staticmethod
     def extension_list_item(extension_id: str) -> str:
-        """Selector for an installed extension by its ID (e.g. 'quarto.quarto')."""
+        """Selector for an installed extension by its ID (e.g. 'quarto.quarto').
+
+        ``data-extension-id`` is carried on the outer ``.monaco-list-row``; the
+        nested ``.extension-list-item`` div does not have it, so a combined
+        ``.extension-list-item[data-extension-id=...]`` never matches (verified
+        on VS Code web 1.105.1, issue #280).
+        """
         if not EXTENSION_ID_RE.match(extension_id):
             raise ValueError(f"Invalid extension ID (contains unsafe characters): {extension_id!r}")
-        return f".extension-list-item[data-extension-id='{extension_id}']"
+        return f".monaco-list-row[data-extension-id='{extension_id}']"

--- a/src/vip_tests/workbench/pages/positron_session.py
+++ b/src/vip_tests/workbench/pages/positron_session.py
@@ -36,7 +36,11 @@ class PositronSession:
     DATA_EXPLORER = ".positron-data-explorer"
 
     # Extensions panel (same as VS Code)
-    EXTENSIONS_SEARCH_INPUT = ".extensions-search-container input[type='text']"
+    # The extensions search box is a Monaco editor, not an <input> — the old
+    # `input[type='text']` selector matches nothing on Workbench 2026.04+.
+    # Locator reported working on a live 2026.04 deployment in #280. Click to
+    # focus, then type keystrokes; Locator.fill() rejects Monaco widgets.
+    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
 
     # Posit Workbench extension
     POSIT_EXTENSION_TAB_NAME = "Posit Workbench"

--- a/src/vip_tests/workbench/pages/vscode_session.py
+++ b/src/vip_tests/workbench/pages/vscode_session.py
@@ -36,8 +36,8 @@ class VSCodeSession:
     # Extensions panel
     # The extensions search box is a Monaco editor, not an <input> — the old
     # `input[type='text']` selector matches nothing on Workbench 2026.04+.
-    # Locator reported working on a live 2026.04 deployment in #280. Click to
-    # focus, then type keystrokes; Locator.fill() rejects Monaco widgets.
+    # Selector taken from the reporter's live-2026.04 findings in #280; not yet
+    # re-validated by VIP. Click to focus, then type; fill() rejects Monaco.
     EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
 
     # Posit Workbench extension

--- a/src/vip_tests/workbench/pages/vscode_session.py
+++ b/src/vip_tests/workbench/pages/vscode_session.py
@@ -46,7 +46,13 @@ class VSCodeSession:
 
     @staticmethod
     def extension_list_item(extension_id: str) -> str:
-        """Selector for an installed extension by its ID (e.g. 'quarto.quarto')."""
+        """Selector for an installed extension by its ID (e.g. 'quarto.quarto').
+
+        ``data-extension-id`` is carried on the outer ``.monaco-list-row``; the
+        nested ``.extension-list-item`` div does not have it, so a combined
+        ``.extension-list-item[data-extension-id=...]`` never matches (verified
+        on VS Code web 1.105.1, issue #280).
+        """
         if not EXTENSION_ID_RE.match(extension_id):
             raise ValueError(f"Invalid extension ID (contains unsafe characters): {extension_id!r}")
-        return f".extension-list-item[data-extension-id='{extension_id}']"
+        return f".monaco-list-row[data-extension-id='{extension_id}']"

--- a/src/vip_tests/workbench/pages/vscode_session.py
+++ b/src/vip_tests/workbench/pages/vscode_session.py
@@ -34,7 +34,11 @@ class VSCodeSession:
     COMMAND_PALETTE_INPUT = ".quick-input-box input"
 
     # Extensions panel
-    EXTENSIONS_SEARCH_INPUT = ".extensions-search-container input[type='text']"
+    # The extensions search box is a Monaco editor, not an <input> — the old
+    # `input[type='text']` selector matches nothing on Workbench 2026.04+.
+    # Locator reported working on a live 2026.04 deployment in #280. Click to
+    # focus, then type keystrokes; Locator.fill() rejects Monaco widgets.
+    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
 
     # Posit Workbench extension
     POSIT_EXTENSION_TAB_NAME = "Posit Workbench"

--- a/src/vip_tests/workbench/test_ide_extensions.py
+++ b/src/vip_tests/workbench/test_ide_extensions.py
@@ -308,7 +308,7 @@ def _verify_extensions_panel(page: Page, selectors, extension_ids: list[str]) ->
     if not extension_ids:
         return
 
-    page.keyboard.press("Control+Shift+x")
+    page.keyboard.press("ControlOrMeta+Shift+x")
     extensions_input = page.locator(selectors.EXTENSIONS_SEARCH_INPUT).first
     expect(extensions_input).to_be_visible(timeout=TIMEOUT_DIALOG)
 
@@ -324,7 +324,7 @@ def _verify_extensions_panel(page: Page, selectors, extension_ids: list[str]) ->
         ext_item = page.locator(selectors.extension_list_item(ext_id))
         expect(ext_item).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
 
-    page.keyboard.press("Control+Shift+x")
+    page.keyboard.press("ControlOrMeta+Shift+x")
 
 
 @then("all configured VS Code extensions are installed")

--- a/src/vip_tests/workbench/test_ide_extensions.py
+++ b/src/vip_tests/workbench/test_ide_extensions.py
@@ -309,11 +309,18 @@ def _verify_extensions_panel(page: Page, selectors, extension_ids: list[str]) ->
         return
 
     page.keyboard.press("Control+Shift+x")
-    extensions_input = page.locator(selectors.EXTENSIONS_SEARCH_INPUT)
+    extensions_input = page.locator(selectors.EXTENSIONS_SEARCH_INPUT).first
     expect(extensions_input).to_be_visible(timeout=TIMEOUT_DIALOG)
 
     for ext_id in extension_ids:
-        extensions_input.fill(f"@installed {ext_id}")
+        # Monaco search box: focus it and drive real keystrokes (same pattern
+        # as the RStudio Ace console fix, #376/PR #402). Select-all + Backspace
+        # clears the previous query between iterations; ControlOrMeta maps to
+        # Cmd on macOS where Ctrl+A would move the cursor instead.
+        extensions_input.click()
+        page.keyboard.press("ControlOrMeta+a")
+        page.keyboard.press("Backspace")
+        page.keyboard.type(f"@installed {ext_id}")
         ext_item = page.locator(selectors.extension_list_item(ext_id))
         expect(ext_item).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
 

--- a/src/vip_tests/workbench/test_ide_extensions.py
+++ b/src/vip_tests/workbench/test_ide_extensions.py
@@ -320,7 +320,11 @@ def _verify_extensions_panel(page: Page, selectors, extension_ids: list[str]) ->
         extensions_input.click()
         page.keyboard.press("ControlOrMeta+a")
         page.keyboard.press("Backspace")
-        page.keyboard.type(f"@installed {ext_id}")
+        # VS Code filters free text against the display name, not the dotted
+        # publisher.name id, so `@installed ms-python.python` returns nothing.
+        # The `@id:` qualifier filters by exact id (validated on VS Code web
+        # 1.105.1 against issue #280).
+        page.keyboard.type(f"@installed @id:{ext_id}")
         ext_item = page.locator(selectors.extension_list_item(ext_id))
         expect(ext_item).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
 

--- a/validation_docs/demo-fix-280-extensions-search-input.md
+++ b/validation_docs/demo-fix-280-extensions-search-input.md
@@ -1,0 +1,98 @@
+# Fix #280: extensions search input Monaco selector
+
+*2026-07-09T16:41:12Z by Showboat 0.6.1*
+<!-- showboat-id: 63a88a0e-2b36-4496-b931-759dd9d23a86 -->
+
+## Root cause
+
+On Workbench 2026.04+, the VS Code / Positron extensions sidebar's search box
+is rendered as a Monaco editor line (`div[data-uri='extensions:searchinput'] .view-line`),
+not a plain `<input type='text'>`. The old selector, `.extensions-search-container
+input[type='text']`, matches nothing, so `page.locator(...)` times out waiting
+for visibility, and even when a matching element was found in older builds,
+Playwright's `Locator.fill()` rejects Monaco's contenteditable-backed widget
+because it isn't a native form control.
+
+## Fix
+
+- Updated `EXTENSIONS_SEARCH_INPUT` in both `vscode_session.py` and
+  `positron_session.py` to point at the Monaco view-line selector.
+- Reworked `_verify_extensions_panel` in `test_ide_extensions.py` to click the
+  Monaco line to focus it, then drive real keystrokes via `page.keyboard`
+  (select-all + backspace to clear the previous query, then type the new one)
+  instead of calling `.fill()`.
+- This is the same click + `page.keyboard.type()` pattern PR #402 used to fix
+  the RStudio Ace console for issue #376 -- the established repo pattern for
+  driving non-fillable Monaco/Ace editor widgets in Workbench IDEs.
+
+## Step 2 (from the plan): confirm the blast radius
+
+Exactly three hits are expected -- the two page-object definitions and the
+single call site in `_verify_extensions_panel`. Confirmed below (against
+the pre-fix codebase this grep matched the same three lines; only the RHS
+values changed).
+
+```bash
+grep -rn --include='*.py' "EXTENSIONS_SEARCH_INPUT" src/
+```
+
+```output
+src/vip_tests/workbench/test_ide_extensions.py:312:    extensions_input = page.locator(selectors.EXTENSIONS_SEARCH_INPUT)
+src/vip_tests/workbench/pages/vscode_session.py:41:    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
+src/vip_tests/workbench/pages/positron_session.py:43:    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
+```
+
+## Verification gate
+
+Local `uv` invocations in this worktree inherit `UV_PROJECT` from the
+workspace-level direnv config, which points at a sibling project
+(`ptd/python-pulumi`) and silently re-roots dependency resolution away from
+vip. `env -u UV_PROJECT` below undoes that so these commands actually run
+against vip's own environment.
+
+`selftests/test_load_engine.py` contains known timing-sensitive tests (see
+CLAUDE.md); it is excluded from the run below to keep this demo
+deterministic. It is untouched by this change -- only the three files
+listed above were modified.
+
+```bash
+env -u UV_PROJECT uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+879 passed, 22 warnings
+```
+
+```bash
+env -u UV_PROJECT uv run ruff check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+All checks passed!
+```
+
+```bash
+env -u UV_PROJECT uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
+```
+
+```output
+152 files already formatted
+```
+
+```bash
+env -u UV_PROJECT uv run pytest src/vip_tests/workbench/ --collect-only -q 2>&1 | tail -3 | sed 's/ in [0-9.]*s//'
+```
+
+```output
+  vip_cfg = load_config(config.getoption("--vip-config"))
+
+no tests collected (35 deselected)
+```
+
+## Live validation status
+
+**Pending.** There is no live Workbench 2026.04 environment available in
+this session, so the Monaco selector and the click/keyboard-type flow have
+not been exercised against a running IDE. This must be validated against a
+real Workbench 2026.04+ deployment (VS Code and Positron sessions, extensions
+panel) before this PR merges.

--- a/validation_docs/demo-fix-280-extensions-search-input.md
+++ b/validation_docs/demo-fix-280-extensions-search-input.md
@@ -91,8 +91,21 @@ no tests collected (35 deselected)
 
 ## Live validation status
 
-**Pending.** There is no live Workbench 2026.04 environment available in
-this session, so the Monaco selector and the click/keyboard-type flow have
-not been exercised against a running IDE. This must be validated against a
-real Workbench 2026.04+ deployment (VS Code and Positron sessions, extensions
-panel) before this PR merges.
+**Validated against real VS Code web (openvscode-server, VS Code 1.105.1).**
+Using the actual repo selectors and query, the full flow was exercised
+end-to-end: `ControlOrMeta+Shift+x` opens the Extensions panel, the Monaco
+search box (`div[data-uri='extensions:searchinput'] .view-line`) accepts
+keyboard input, and an installed extension's row
+(`.monaco-list-row[data-extension-id='ms-python.python']`) is found with
+count 1. Negative controls confirmed all three original bugs were real: the
+old `input[type='text']` selector never resolves, the old `@installed <id>`
+query returns zero rows (VS Code filters free text by display name, not the
+dotted id — hence `@installed @id:<id>`), and the old
+`.extension-list-item[data-extension-id=...]` selector never matches (the
+attribute lives on `.monaco-list-row`).
+
+**Still pending:** validation against Workbench-hosted VS Code and Positron
+specifically — the local Workbench 2026.04+ containers available had expired
+licenses, so those paths could not be exercised. The underlying Monaco DOM is
+shared, but Positron's marketplace UI should be confirmed on a licensed
+deployment before relying on this in production.

--- a/validation_docs/demo-fix-280-extensions-search-input.md
+++ b/validation_docs/demo-fix-280-extensions-search-input.md
@@ -37,7 +37,7 @@ grep -rn --include='*.py' "EXTENSIONS_SEARCH_INPUT" src/
 ```
 
 ```output
-src/vip_tests/workbench/test_ide_extensions.py:312:    extensions_input = page.locator(selectors.EXTENSIONS_SEARCH_INPUT)
+src/vip_tests/workbench/test_ide_extensions.py:312:    extensions_input = page.locator(selectors.EXTENSIONS_SEARCH_INPUT).first
 src/vip_tests/workbench/pages/vscode_session.py:41:    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
 src/vip_tests/workbench/pages/positron_session.py:43:    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
 ```


### PR DESCRIPTION
## Summary

- On Workbench 2026.04+, the VS Code / Positron extensions sidebar's search
  box is a Monaco editor (`div[data-uri='extensions:searchinput'] .view-line`),
  not a plain `<input type='text'>`. The old
  `.extensions-search-container input[type='text']` selector matches nothing,
  causing the locator to time out, and even where a match existed in older
  builds, `Locator.fill()` rejects Monaco's contenteditable-backed widget.
- Updated `EXTENSIONS_SEARCH_INPUT` in `vscode_session.py` and
  `positron_session.py` to the Monaco view-line selector.
- Reworked `_verify_extensions_panel` to click the Monaco line to focus it,
  then drive real keystrokes (select-all + backspace to clear, then type)
  instead of `.fill()` — the same click + `page.keyboard.type()` pattern PR
  #402 used for the RStudio Ace console fix (#376). The locator uses `.first`
  to stay safe under Playwright strict mode. Both panel toggles use
  `ControlOrMeta+Shift+x` so the flow runs from macOS hosts too.
- Fixed two further causes of the same timeout, found during local
  validation: the search query now uses `@installed @id:{ext_id}` (VS Code
  filters bare free text against the display name, so `@installed <dotted-id>`
  returned zero rows), and `extension_list_item` now targets
  `.monaco-list-row[data-extension-id=...]` (the attribute lives on the row,
  not the nested `.extension-list-item`, so the old combined selector never
  matched).

Fixes #280

**Local validation (openvscode-server, VS Code web 1.105.1):** the full flow
is validated end-to-end against real VS Code Monaco DOM using the actual repo
selectors/query — the search box accepts keyboard input, and an installed
extension's row is found (count=1). Negative controls confirm all three
original bugs (Monaco search input, `@installed <id>` query returning zero
rows, and the `.extension-list-item[data-extension-id]` selector never
matching) were real.

**Still pending:** validation against Workbench-hosted VS Code and Positron
specifically — the local Workbench 2026.04+ containers available had expired
licenses, so the Workbench-hosted and Positron paths could not be exercised.
The underlying Monaco DOM is shared, but Positron's marketplace UI should be
confirmed on a licensed deployment before relying on this in production.

## Demo

# Fix #280: extensions search input Monaco selector

*2026-07-09T16:41:12Z by Showboat 0.6.1*
<!-- showboat-id: 63a88a0e-2b36-4496-b931-759dd9d23a86 -->

## Root cause

On Workbench 2026.04+, the VS Code / Positron extensions sidebar's search box
is rendered as a Monaco editor line (`div[data-uri='extensions:searchinput'] .view-line`),
not a plain `<input type='text'>`. The old selector, `.extensions-search-container
input[type='text']`, matches nothing, so `page.locator(...)` times out waiting
for visibility, and even when a matching element was found in older builds,
Playwright's `Locator.fill()` rejects Monaco's contenteditable-backed widget
because it isn't a native form control.

## Fix

- Updated `EXTENSIONS_SEARCH_INPUT` in both `vscode_session.py` and
  `positron_session.py` to point at the Monaco view-line selector.
- Reworked `_verify_extensions_panel` in `test_ide_extensions.py` to click the
  Monaco line to focus it, then drive real keystrokes via `page.keyboard`
  (select-all + backspace to clear the previous query, then type the new one)
  instead of calling `.fill()`.
- This is the same click + `page.keyboard.type()` pattern PR #402 used to fix
  the RStudio Ace console for issue #376 -- the established repo pattern for
  driving non-fillable Monaco/Ace editor widgets in Workbench IDEs.

## Step 2 (from the plan): confirm the blast radius

Exactly three hits are expected -- the two page-object definitions and the
single call site in `_verify_extensions_panel`. Confirmed below (against
the pre-fix codebase this grep matched the same three lines; only the RHS
values changed).

```bash
grep -rn --include='*.py' "EXTENSIONS_SEARCH_INPUT" src/
```

```output
src/vip_tests/workbench/test_ide_extensions.py:312:    extensions_input = page.locator(selectors.EXTENSIONS_SEARCH_INPUT).first
src/vip_tests/workbench/pages/vscode_session.py:41:    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
src/vip_tests/workbench/pages/positron_session.py:43:    EXTENSIONS_SEARCH_INPUT = "div[data-uri='extensions:searchinput'] .view-line"
```

## Verification gate

Local `uv` invocations in this worktree inherit `UV_PROJECT` from the
workspace-level direnv config, which points at a sibling project
(`ptd/python-pulumi`) and silently re-roots dependency resolution away from
vip. `env -u UV_PROJECT` below undoes that so these commands actually run
against vip's own environment.

`selftests/test_load_engine.py` contains known timing-sensitive tests (see
CLAUDE.md); it is excluded from the run below to keep this demo
deterministic. It is untouched by this change -- only the three files
listed above were modified.

```bash
env -u UV_PROJECT uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
879 passed, 22 warnings
```

```bash
env -u UV_PROJECT uv run ruff check src/ src/vip_tests/ selftests/ examples/
```

```output
All checks passed!
```

```bash
env -u UV_PROJECT uv run ruff format --check src/ src/vip_tests/ selftests/ examples/
```

```output
152 files already formatted
```

```bash
env -u UV_PROJECT uv run pytest src/vip_tests/workbench/ --collect-only -q 2>&1 | tail -3 | sed 's/ in [0-9.]*s//'
```

```output
  vip_cfg = load_config(config.getoption("--vip-config"))

no tests collected (35 deselected)
```

## Live validation status

**Validated against real VS Code web (openvscode-server, VS Code 1.105.1).**
Using the actual repo selectors and query, the full flow was exercised
end-to-end: `ControlOrMeta+Shift+x` opens the Extensions panel, the Monaco
search box (`div[data-uri='extensions:searchinput'] .view-line`) accepts
keyboard input, and an installed extension's row
(`.monaco-list-row[data-extension-id='ms-python.python']`) is found with
count 1. Negative controls confirmed all three original bugs were real: the
old `input[type='text']` selector never resolves, the old `@installed <id>`
query returns zero rows (VS Code filters free text by display name, not the
dotted id — hence `@installed @id:<id>`), and the old
`.extension-list-item[data-extension-id=...]` selector never matches (the
attribute lives on `.monaco-list-row`).

**Still pending:** validation against Workbench-hosted VS Code and Positron
specifically — the local Workbench 2026.04+ containers available had expired
licenses, so those paths could not be exercised. The underlying Monaco DOM is
shared, but Positron's marketplace UI should be confirmed on a licensed
deployment before relying on this in production.
