### PR TITLE
test(package-manager): add web UI smoke tests across ecosystems

### DIFF
--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -189,7 +189,24 @@ jobs:
         if: steps.license.outputs.available == 'true'
         run: uv sync
 
-      # No Playwright needed — PM tests are API-only
+      # The UI smoke tests (test_ui.py) drive a real browser, so the Playwright
+      # browsers must be installed. The API-only tests don't need them; the
+      # browser cache keeps this cheap on repeat runs.
+      - name: Resolve Playwright version
+        if: steps.license.outputs.available == 'true'
+        id: playwright-version
+        run: echo "version=$(uv run playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        if: steps.license.outputs.available == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.license.outputs.available == 'true'
+        run: uv run vip install --skip-system
 
       # Generate vip.toml for CI Package Manager
       - name: Configure VIP for CI Package Manager
@@ -216,8 +233,10 @@ jobs:
             "src/vip_tests/prerequisites/test_components.py::test_product_server_is_reachable[Package Manager]" \
             src/vip_tests/prerequisites/test_versions.py \
             src/vip_tests/package_manager/test_repos.py \
+            src/vip_tests/package_manager/test_binary_packages.py \
             src/vip_tests/package_manager/test_authenticated_repos.py \
             src/vip_tests/package_manager/test_private_repos.py \
+            src/vip_tests/package_manager/test_ui.py \
             -v \
             --vip-config=vip.toml \
             --junitxml=smoke-results.xml

--- a/src/vip_tests/package_manager/pages/__init__.py
+++ b/src/vip_tests/package_manager/pages/__init__.py
@@ -1,6 +1,6 @@
 """Page objects for Package Manager web UI smoke tests."""
 
-from vip_tests.package_manager.pages.ui import (
+from .ui import (
     Homepage,
     PackageDetailPage,
     PackagesPage,

--- a/src/vip_tests/package_manager/pages/__init__.py
+++ b/src/vip_tests/package_manager/pages/__init__.py
@@ -1,0 +1,9 @@
+"""Page objects for Package Manager web UI smoke tests."""
+
+from vip_tests.package_manager.pages.ui import (
+    Homepage,
+    PackageDetailPage,
+    PackagesPage,
+)
+
+__all__ = ["Homepage", "PackageDetailPage", "PackagesPage"]

--- a/src/vip_tests/package_manager/pages/__init__.py
+++ b/src/vip_tests/package_manager/pages/__init__.py
@@ -4,6 +4,18 @@ from .ui import (
     Homepage,
     PackageDetailPage,
     PackagesPage,
+    open_homepage,
+    open_package_detail_via_click,
+    open_repo_packages,
+    search_packages,
 )
 
-__all__ = ["Homepage", "PackageDetailPage", "PackagesPage"]
+__all__ = [
+    "Homepage",
+    "PackageDetailPage",
+    "PackagesPage",
+    "open_homepage",
+    "open_package_detail_via_click",
+    "open_repo_packages",
+    "search_packages",
+]

--- a/src/vip_tests/package_manager/pages/ui.py
+++ b/src/vip_tests/package_manager/pages/ui.py
@@ -11,12 +11,30 @@ full page load.
 from __future__ import annotations
 
 from playwright.sync_api import Page, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from vip.timeouts import timeout_scale
 
 # Scaled the same way the Workbench UI tests scale theirs, via VIP_TIMEOUT_SCALE.
 TIMEOUT_PAGE_LOAD = int(15_000 * timeout_scale())
 TIMEOUT_ELEMENT = int(10_000 * timeout_scale())
+
+
+def _settle_network(page: Page) -> None:
+    """Best-effort wait for the SPA's network activity to go idle.
+
+    ``networkidle`` is a heuristic — it waits for a 500ms gap in network
+    activity, which a single background poll or keep-alive can defeat, so a
+    timeout here is not a failure. Bound it with the module's scaled timeout so
+    it honors ``VIP_TIMEOUT_SCALE`` (rather than Playwright's unscaled 30s
+    default), but swallow the timeout: the explicit element and URL waits that
+    follow every call are the real readiness gates, and letting a never-idle
+    page fail here just makes the smoke tests flaky.
+    """
+    try:
+        page.wait_for_load_state("networkidle", timeout=TIMEOUT_PAGE_LOAD)
+    except PlaywrightTimeoutError:
+        pass
 
 
 class Homepage:
@@ -64,18 +82,18 @@ def open_repo_packages(page: Page, base_url: str, repo: str) -> None:
     """Navigate to a repository's packages page and wait for it to settle.
 
     Resets to the app root first so the subsequent hash-only change triggers a
-    real SPA navigation, then waits for network idle so the page's queries
-    resolve before a caller interacts with the search input (mirrors Package
-    Manager's own NavigateToPackage helper).
+    real SPA navigation, gives the page a best-effort chance to settle (see
+    _settle_network), then gates on the search input being visible before a
+    caller interacts with it — the deterministic readiness signal.
     """
     page.goto(_root(base_url) + "/#/", wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
-    page.wait_for_load_state("networkidle")
+    _settle_network(page)
     page.goto(
         f"{_root(base_url)}/#/repos/{repo}/packages",
         wait_until="load",
         timeout=TIMEOUT_PAGE_LOAD,
     )
-    page.wait_for_load_state("networkidle")
+    _settle_network(page)
     expect(page.locator(PackagesPage.SEARCH_INPUT)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
 
 

--- a/src/vip_tests/package_manager/pages/ui.py
+++ b/src/vip_tests/package_manager/pages/ui.py
@@ -1,0 +1,115 @@
+"""Page objects and navigation helpers for Package Manager web UI smoke tests.
+
+Selectors mirror the ``data-automation`` hooks used by Package Manager's own
+Playwright smoke suite (rstudio/package-manager:
+``src/e2e/ui/selectors/selectors.go``). Package Manager is a Vue SPA that uses
+hash-based routing (``createWebHashHistory``), so every in-app route lives
+behind ``#/`` — a change to only the hash is a client-side navigation, not a
+full page load.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+from vip.timeouts import timeout_scale
+
+# Scaled the same way the Workbench UI tests scale theirs, via VIP_TIMEOUT_SCALE.
+TIMEOUT_PAGE_LOAD = int(15_000 * timeout_scale())
+TIMEOUT_ELEMENT = int(10_000 * timeout_scale())
+
+
+class Homepage:
+    """Selectors for the redesigned Package Manager homepage (HomePageLayout)."""
+
+    # The hgroup that is Package Manager's canonical "I'm on the homepage" hook.
+    HERO_TITLE = "[data-automation='home-title']"
+    # The clickable repository-selection card that opens the repository modal.
+    REPO_SELECTION_CARD = "[data-automation='repository-selection-card']"
+    # The homepage's own package search bar (hidden from the navbar here).
+    SEARCH_BAR = "[data-automation='search-input-home-package-search']"
+
+
+class PackagesPage:
+    """Selectors for a repo-scoped packages/search page."""
+
+    # The navbar package search input, present on repo-scoped pages.
+    SEARCH_INPUT = "[data-automation=search-input-package-search]"
+
+    # Every result row (PackageListItem) renders a ``package-link-<id>`` hook.
+    # Match the shared prefix rather than a specific id: it's ecosystem-agnostic
+    # (OpenVSX rows key off the extension's display name, not its dotted id), so
+    # this is the robust "a result rendered" signal — the same approach Package
+    # Manager's own OpenVSX smoke test uses.
+    RESULT_ITEMS = "[data-automation^='package-link-']"
+
+
+class PackageDetailPage:
+    """Selectors for a package detail (overview) page."""
+
+    TITLE = "[data-automation=package-title]"
+
+
+def _root(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def open_homepage(page: Page, base_url: str) -> None:
+    """Load the homepage and wait for the SPA to hydrate its hero."""
+    page.goto(_root(base_url) + "/", wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
+    expect(page.locator(Homepage.HERO_TITLE)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+
+
+def open_repo_packages(page: Page, base_url: str, repo: str) -> None:
+    """Navigate to a repository's packages page and wait for it to settle.
+
+    Resets to the app root first so the subsequent hash-only change triggers a
+    real SPA navigation, then waits for network idle so the page's queries
+    resolve before a caller interacts with the search input (mirrors Package
+    Manager's own NavigateToPackage helper).
+    """
+    page.goto(_root(base_url) + "/#/", wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
+    page.wait_for_load_state("networkidle")
+    page.goto(
+        f"{_root(base_url)}/#/repos/{repo}/packages",
+        wait_until="load",
+        timeout=TIMEOUT_PAGE_LOAD,
+    )
+    page.wait_for_load_state("networkidle")
+    expect(page.locator(PackagesPage.SEARCH_INPUT)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+
+
+def search_packages(page: Page, package: str) -> None:
+    """Type a query into the packages-page search input and wait for it to commit.
+
+    The search bar debounces input (~500ms) before committing the query to the
+    URL via router.replace. Wait for that commit before returning: otherwise a
+    caller that immediately clicks a result races the trailing debounce, whose
+    router.replace re-renders the list and cancels the click's navigation —
+    leaving you stranded on the results page. This mirrors the wait in Package
+    Manager's own Search helper, which exists for exactly this reason.
+    """
+    page.locator(PackagesPage.SEARCH_INPUT).fill(package)
+    page.wait_for_function(
+        "term => decodeURIComponent(window.location.hash).includes('search=' + term)",
+        arg=package,
+        timeout=TIMEOUT_ELEMENT,
+    )
+
+
+def open_package_detail_via_click(page: Page) -> None:
+    """Click the first search-result row and wait for its detail page.
+
+    Reaching detail by clicking the result (rather than constructing a detail
+    URL) keeps this ecosystem-agnostic: OpenVSX extension ids are dotted (e.g.
+    ``golang.Go``), and the click path is the real flow a user reaches the
+    detail page by. PackageDetails gates its hero on the package query
+    resolving, so the title only renders once the data has loaded.
+
+    Assumes a search has already been run so at least one result row is present;
+    clicks the first result and waits for the detail hero.
+    """
+    result = page.locator(PackagesPage.RESULT_ITEMS).first
+    result.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+    result.click()
+    expect(page.locator(PackageDetailPage.TITLE)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)

--- a/src/vip_tests/package_manager/test_ui.feature
+++ b/src/vip_tests/package_manager/test_ui.feature
@@ -1,0 +1,36 @@
+@package_manager
+Feature: Package Manager web UI
+  As a Posit Team administrator
+  I want to verify that the Package Manager web UI renders and package search works
+  So that end users can browse and find packages after a deployment
+
+  Background:
+    Given the Package Manager web UI is reachable
+
+  Scenario: Homepage renders its core surfaces
+    When I open the Package Manager homepage
+    Then the homepage hero, repository selector, and package search bar are visible
+
+  Scenario Outline: Package search returns a result for <ecosystem>
+    Given a "<ecosystem>" repository with a known package is available
+    When I search for that package in the web UI
+    Then the package appears in the search results
+
+    Examples:
+      | ecosystem    |
+      | CRAN         |
+      | PyPI         |
+      | Bioconductor |
+      | OpenVSX      |
+
+  Scenario Outline: Package detail page renders for <ecosystem>
+    Given a "<ecosystem>" repository with a known package is available
+    When I open that package's detail page in the web UI
+    Then the package detail page shows the package metadata
+
+    Examples:
+      | ecosystem    |
+      | CRAN         |
+      | PyPI         |
+      | Bioconductor |
+      | OpenVSX      |

--- a/src/vip_tests/package_manager/test_ui.py
+++ b/src/vip_tests/package_manager/test_ui.py
@@ -46,25 +46,25 @@ _ECOSYSTEMS: dict[str, dict] = {
         "type": "cran",
         "hint": "cran",
         "package": "Matrix",
-        "available": lambda c, r: c.cran_package_available(r, "Matrix"),
+        "available": lambda c, r, p: c.cran_package_available(r, p),
     },
     "PyPI": {
         "type": "pypi",
         "hint": "pypi",
         "package": "requests",
-        "available": lambda c, r: c.pypi_package_available(r, "requests"),
+        "available": lambda c, r, p: c.pypi_package_available(r, p),
     },
     "Bioconductor": {
         "type": "bioconductor",
         "hint": "bioc",
         "package": "BiocGenerics",
-        "available": lambda c, r: c.bioconductor_package_available(r, "BiocGenerics"),
+        "available": lambda c, r, p: c.bioconductor_package_available(r, p),
     },
     "OpenVSX": {
         "type": "vsx",
         "hint": "vsx",
         "package": "golang.Go",
-        "available": lambda c, r: c.openvsx_extension_available(r, "golang.Go"),
+        "available": lambda c, r, p: c.openvsx_extension_available(r, p),
     },
 }
 
@@ -83,7 +83,7 @@ def _find_ui_target(pm_client, ecosystem: str) -> dict[str, str]:
         hint_matches = eco["hint"] in name.lower()
         if not (type_matches or hint_matches):
             continue
-        if eco["available"](pm_client, name):
+        if eco["available"](pm_client, name, eco["package"]):
             return {"repo": name, "package": eco["package"], "ecosystem": ecosystem}
     return {}
 

--- a/src/vip_tests/package_manager/test_ui.py
+++ b/src/vip_tests/package_manager/test_ui.py
@@ -20,9 +20,7 @@ import pytest
 from playwright.sync_api import Page, expect
 from pytest_bdd import given, parsers, scenarios, then, when
 
-from vip_tests.package_manager.pages.ui import (
-    TIMEOUT_ELEMENT,
-    TIMEOUT_PAGE_LOAD,
+from vip_tests.package_manager.pages import (
     Homepage,
     PackageDetailPage,
     PackagesPage,
@@ -31,6 +29,7 @@ from vip_tests.package_manager.pages.ui import (
     open_repo_packages,
     search_packages,
 )
+from vip_tests.package_manager.pages.ui import TIMEOUT_ELEMENT, TIMEOUT_PAGE_LOAD
 
 scenarios("test_ui.feature")
 

--- a/src/vip_tests/package_manager/test_ui.py
+++ b/src/vip_tests/package_manager/test_ui.py
@@ -1,0 +1,165 @@
+"""Step definitions for Package Manager web UI smoke tests.
+
+These drive a real browser (Playwright) against the deployed Package Manager
+UI to confirm the non-admin surfaces an end user relies on — the homepage,
+package search, and package detail — render after a deployment. They complement
+the API-level checks in the other package_manager feature files, which never
+exercise the browser.
+
+The search and detail checks are parametrized per ecosystem (CRAN, PyPI,
+Bioconductor, OpenVSX) so coverage scales with whatever the target deployment
+actually serves: each ecosystem confirms package availability over the API
+first, and *skips* when that repo isn't configured/synced rather than failing.
+This mirrors the granularity of the API-level test_repos scenarios, so a
+minimal deployment (say CRAN + PyPI only) runs those two and skips the rest.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from vip_tests.package_manager.pages.ui import (
+    TIMEOUT_ELEMENT,
+    TIMEOUT_PAGE_LOAD,
+    Homepage,
+    PackageDetailPage,
+    PackagesPage,
+    open_homepage,
+    open_package_detail_via_click,
+    open_repo_packages,
+    search_packages,
+)
+
+scenarios("test_ui.feature")
+
+
+# Maps the Gherkin <ecosystem> name to how we find a repo that serves it and a
+# known package to exercise. The package names match the API-level test_repos
+# scenarios so the UI tests lean on content the deployment is already expected
+# to serve. `available` confirms the package over the API before we drive the
+# browser, so a UI failure means the UI is broken — not that the repo is
+# unsynced.
+_ECOSYSTEMS: dict[str, dict] = {
+    "CRAN": {
+        "type": "cran",
+        "hint": "cran",
+        "package": "Matrix",
+        "available": lambda c, r: c.cran_package_available(r, "Matrix"),
+    },
+    "PyPI": {
+        "type": "pypi",
+        "hint": "pypi",
+        "package": "requests",
+        "available": lambda c, r: c.pypi_package_available(r, "requests"),
+    },
+    "Bioconductor": {
+        "type": "bioconductor",
+        "hint": "bioc",
+        "package": "BiocGenerics",
+        "available": lambda c, r: c.bioconductor_package_available(r, "BiocGenerics"),
+    },
+    "OpenVSX": {
+        "type": "vsx",
+        "hint": "vsx",
+        "package": "golang.Go",
+        "available": lambda c, r: c.openvsx_extension_available(r, "golang.Go"),
+    },
+}
+
+
+def _find_ui_target(pm_client, ecosystem: str) -> dict[str, str]:
+    """Return the first repo of *ecosystem* that serves its known package.
+
+    Matches by repo ``type`` or a name hint (a deployment may name a repo
+    ``cran`` without setting a canonical type), then confirms availability over
+    the API. Returns ``{}`` when nothing suitable is configured/synced.
+    """
+    eco = _ECOSYSTEMS[ecosystem]
+    for repo in pm_client.list_repos():
+        name = repo.get("name", "")
+        type_matches = (repo.get("type") or "").lower() == eco["type"]
+        hint_matches = eco["hint"] in name.lower()
+        if not (type_matches or hint_matches):
+            continue
+        if eco["available"](pm_client, name):
+            return {"repo": name, "package": eco["package"], "ecosystem": ecosystem}
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Steps
+# ---------------------------------------------------------------------------
+
+
+@given("the Package Manager web UI is reachable")
+def ui_reachable(pm_client):
+    if pm_client is None:
+        pytest.skip("Package Manager is not configured")
+    status = pm_client.health()
+    assert status < 400, f"Package Manager returned HTTP {status}"
+
+
+@given(
+    parsers.parse('a "{ecosystem}" repository with a known package is available'),
+    target_fixture="ui_target",
+)
+def ui_target(pm_client, ecosystem: str) -> dict[str, str]:
+    if ecosystem not in _ECOSYSTEMS:
+        pytest.fail(f"Unknown ecosystem in feature examples: {ecosystem!r}")
+    target = _find_ui_target(pm_client, ecosystem)
+    if not target:
+        pkg = _ECOSYSTEMS[ecosystem]["package"]
+        pytest.skip(
+            f"No {ecosystem} repository with {pkg!r} available — repo may not be synced yet"
+        )
+    return target
+
+
+@when("I open the Package Manager homepage")
+def when_open_homepage(page: Page, pm_url: str):
+    open_homepage(page, pm_url)
+
+
+@then("the homepage hero, repository selector, and package search bar are visible")
+def then_homepage_surfaces(page: Page):
+    expect(page.locator(Homepage.HERO_TITLE)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    expect(page.locator(Homepage.REPO_SELECTION_CARD)).to_be_visible(timeout=TIMEOUT_ELEMENT)
+    # Presence (attached) rather than visibility is the least layout-sensitive
+    # signal that the search bar rendered.
+    expect(page.locator(Homepage.SEARCH_BAR)).to_be_attached(timeout=TIMEOUT_ELEMENT)
+
+
+@when("I search for that package in the web UI")
+def when_search(page: Page, pm_url: str, ui_target: dict[str, str]):
+    open_repo_packages(page, pm_url, ui_target["repo"])
+    search_packages(page, ui_target["package"])
+
+
+@then("the package appears in the search results")
+def then_search_result(page: Page):
+    # We searched for a package confirmed to exist over the API, so the search
+    # returning at least one result row is the signal that search works. Assert
+    # on the shared result-row selector rather than a per-id hook so this holds
+    # for every ecosystem (see PackagesPage.RESULT_ITEMS).
+    expect(page.locator(PackagesPage.RESULT_ITEMS).first).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+
+
+@when("I open that package's detail page in the web UI")
+def when_open_detail(page: Page, pm_url: str, ui_target: dict[str, str]):
+    open_repo_packages(page, pm_url, ui_target["repo"])
+    search_packages(page, ui_target["package"])
+    open_package_detail_via_click(page)
+
+
+@then("the package detail page shows the package metadata")
+def then_detail(page: Page):
+    # Assert the detail hero rendered with a non-empty title. We deliberately
+    # don't assert the title equals the package id: OpenVSX detail shows the
+    # extension's display name (e.g. "Go" for golang.Go), so an exact-match
+    # would be ecosystem-specific. A visible, non-empty title is the shared
+    # signal that the detail page rendered for every ecosystem.
+    title = page.locator(PackageDetailPage.TITLE)
+    expect(title).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    expect(title).not_to_be_empty(timeout=TIMEOUT_ELEMENT)


### PR DESCRIPTION
## What

Adds Playwright-driven UI smoke tests for Package Manager's non-admin surfaces — homepage, package search, and package detail — under `src/vip_tests/package_manager/`. Until now VIP exercised Package Manager only at the API level; nothing drove the browser.

Search and detail are parametrized across CRAN, PyPI, Bioconductor, and OpenVSX. Each ecosystem confirms package availability over the API first and **skips** when the repo isn't configured/synced, so coverage scales with the target deployment (a CRAN+PyPI-only instance runs those two and skips the rest) — matching the granularity of the existing `test_repos` scenarios.

## Why

The Snowflake team runs VIP as their acceptance smoke suite before deploying Package Manager, and asked for basic coverage of package search and other non-admin UI, which VIP didn't have. Tracks rstudio/package-manager#18738.

## CI

Wires the tests into `packagemanager-smoke.yml`: installs Playwright browsers (cached) and runs `test_ui.py` alongside the API suites. Also adds the existing `test_binary_packages.py`, which was not previously being run.

## Testing

Ran the full suite against a local Package Manager (all four ecosystems present): `pytest src/vip_tests/package_manager/test_ui.py` → **9 passed** (homepage + search×4 + detail×4), stable across repeated runs. Selector strategy and the search-debounce / result-click handling mirror Package Manager's own Playwright smoke suite.