### PR TITLE
docs: mention Bioconductor and OpenVSX in Package Manager landing copy

### DIFF
--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -234,7 +234,7 @@ vip verify --connect-url https://connect.example.com -- -x --tb=long</code></pre
                 <tr>
                   <td>Package Manager</td>
                   <td><code>package-manager</code></td>
-                  <td>CRAN, PyPI, Bioconductor, OpenVSX mirrors, repos, auth/private packages</td>
+                  <td>CRAN, PyPI, Bioconductor, and OpenVSX mirrors, repos, authenticated/private package access</td>
                 </tr>
                 <tr>
                   <td>Connect</td>

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -234,7 +234,7 @@ vip verify --connect-url https://connect.example.com -- -x --tb=long</code></pre
                 <tr>
                   <td>Package Manager</td>
                   <td><code>package-manager</code></td>
-                  <td>CRAN/PyPI mirrors, repos, private packages</td>
+                  <td>CRAN, PyPI, Bioconductor, OpenVSX mirrors, repos, auth/private packages</td>
                 </tr>
                 <tr>
                   <td>Connect</td>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,7 +23,7 @@ const products = [
   {
     name: "Package Manager",
     flag: "package-manager-url",
-    description: "CRAN/PyPI mirrors, repository configuration, and private package access",
+    description: "CRAN, PyPI, Bioconductor, and OpenVSX mirrors, repository configuration, and authenticated/private package access",
     logo: `${base}logo-packagemanager.svg`,
     testsId: "package_manager",
   },


### PR DESCRIPTION
Closes #469

The Package Manager cards on the website undersold the actual test coverage. `test_repos.feature`/`test_ui.feature` verify Bioconductor and OpenVSX mirrors, and `test_authenticated_repos.feature` verifies token-authenticated repo access — none of which the copy mentioned.

- `website/src/pages/index.astro` — product card description
- `website/src/pages/getting-started.astro` — categories table row

Copy-only change; CI's website build validates it renders.