### PR TITLE
fix(workbench): escalate orphaned-session cleanup to the UI sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,15 +145,16 @@ Key principles:
 
 | File | Purpose |
 |------------------------------------|------------------------------------|
-| `src/vip/cli.py` | CLI entry point: version, verify, cleanup, install, uninstall, auth, scaffold commands; `--version` flag |
+| `src/vip/cli.py` | CLI entry point: version, verify, cleanup (Connect content + orphaned Workbench sessions via `--workbench-url`), install, uninstall, auth, scaffold commands; `--version` flag |
 | `src/vip/config.py` | TOML config loader and dataclasses |
-| `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers |
+| `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers; `authenticated_page` opens a headless page from a cached auth session for `vip cleanup --workbench-url` |
 | `src/vip/idp.py` | IdP login form strategies for headless auth (Keycloak, Okta) |
 | `src/vip/plugin.py` | pytest plugin: markers, auto-skip, JSON report output |
 | `src/vip/version.py` | `ProductVersion` parsing/comparison for `min_version` gating; `MINIMUM_SUPPORTED_POSIT_TEAM` support floor (powers `vip version`) |
+| `src/vip/workbench_ui.py` | Browser-driven Workbench session-cleanup sweep (`quit_vip_sessions_via_ui`), shared by the per-test cleanup fixture and `vip cleanup --workbench-url` |
 | `src/vip/reporting.py` | Report data model for Quarto templates |
 | `src/vip/clients/connect.py` | httpx client for Connect API |
-| `src/vip/clients/workbench.py` | httpx client for Workbench API |
+| `src/vip/clients/workbench.py` | httpx client for Workbench API; `quit_vip_sessions` warns loudly (not silently) when a VIP session persists after all retries |
 | `src/vip/clients/packagemanager.py` | httpx client for Package Manager API |
 | `src/vip/install/platform.py` | Distro detection (rhel/debian/macos) + canonical Chromium package lists |
 | `src/vip/install/manifest.py` | `.vip-install.json` read/write (atomic), schema gate, pending-package helpers |

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vip.auth import AuthConfigError, start_headless_auth
+from vip.auth import (
+    AuthConfigError,
+    InteractiveAuthSession,
+    authenticated_page,
+    start_headless_auth,
+)
 
 
 class TestStartHeadlessAuthValidation:
@@ -1852,3 +1857,89 @@ class TestHeadlessAuthTLSFlags:
                 )
 
         assert os.environ.get("NODE_EXTRA_CA_CERTS") == prev_value
+
+
+class TestAuthenticatedPage:
+    """Tests for authenticated_page(): the CLI cleanup escape hatch's
+    browser-driven Workbench UI access (see vip.cli.run_cleanup)."""
+
+    def _make_session(self, tmp_path) -> InteractiveAuthSession:
+        state_path = tmp_path / "vip-auth-state.json"
+        state_path.write_text('{"cookies": []}')
+        return InteractiveAuthSession(storage_state_path=state_path, _tmpdir="")
+
+    def test_loads_storage_state_and_yields_page(self, tmp_path):
+        session = self._make_session(tmp_path)
+
+        pw = MagicMock()
+        browser = pw.start.return_value.chromium.launch.return_value
+        context = browser.new_context.return_value
+        page = context.new_page.return_value
+
+        with patch("vip.auth.sync_playwright", return_value=pw):
+            with authenticated_page(session) as yielded_page:
+                assert yielded_page is page
+
+        browser.new_context.assert_called_once_with(
+            storage_state=str(session.storage_state_path),
+            ignore_https_errors=False,
+        )
+        context.close.assert_called_once()
+        browser.close.assert_called_once()
+        pw.start.return_value.stop.assert_called_once()
+
+    def test_insecure_passed_through_to_new_context(self, tmp_path):
+        session = self._make_session(tmp_path)
+
+        pw = MagicMock()
+        browser = pw.start.return_value.chromium.launch.return_value
+        context = browser.new_context.return_value
+
+        with patch("vip.auth.sync_playwright", return_value=pw):
+            with authenticated_page(session, insecure=True):
+                pass
+
+        _, kwargs = browser.new_context.call_args
+        assert kwargs["ignore_https_errors"] is True
+        context.close.assert_called_once()
+
+    def test_closes_browser_and_context_even_when_block_raises(self, tmp_path):
+        session = self._make_session(tmp_path)
+
+        pw = MagicMock()
+        browser = pw.start.return_value.chromium.launch.return_value
+        context = browser.new_context.return_value
+
+        with patch("vip.auth.sync_playwright", return_value=pw):
+            with pytest.raises(RuntimeError, match="boom"):
+                with authenticated_page(session):
+                    raise RuntimeError("boom")
+
+        context.close.assert_called_once()
+        browser.close.assert_called_once()
+        pw.start.return_value.stop.assert_called_once()
+
+    def test_ca_bundle_sets_and_restores_node_extra_ca_certs(self, tmp_path, monkeypatch):
+        import os
+
+        monkeypatch.delenv("NODE_EXTRA_CA_CERTS", raising=False)
+        session = self._make_session(tmp_path)
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("# fake CA")
+
+        captured: list[str | None] = []
+
+        pw = MagicMock()
+
+        def capturing_launch(*args, **kwargs):
+            captured.append(os.environ.get("NODE_EXTRA_CA_CERTS"))
+            return pw.start.return_value.chromium.launch.return_value
+
+        pw.start.return_value.chromium.launch.side_effect = capturing_launch
+
+        with patch("vip.auth.sync_playwright", return_value=pw):
+            with authenticated_page(session, ca_bundle=ca_file):
+                pass
+
+        assert captured == [str(ca_file)]
+        assert os.environ.get("NODE_EXTRA_CA_CERTS") is None

--- a/selftests/test_cli_cleanup.py
+++ b/selftests/test_cli_cleanup.py
@@ -1,0 +1,362 @@
+"""Tests for `vip cleanup` command wiring in vip.cli (issue #467).
+
+Exercises run_cleanup()'s Connect/Workbench branching, the Workbench
+auth-mode selection (headless vs. interactive), and the API-unreachable /
+leftover-sessions escalation to the browser-driven UI sweep. No real network
+connections or browsers are used: WorkbenchClient, ConnectClient, and the
+auth/UI-sweep functions are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import vip.auth
+import vip.cli
+import vip.workbench_ui
+from vip.auth import InteractiveAuthSession
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    defaults = {
+        "connect_url": None,
+        "api_key": None,
+        "workbench_url": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _fake_session(tmp_path: Path) -> InteractiveAuthSession:
+    state_path = tmp_path / "vip-auth-state.json"
+    state_path.write_text('{"cookies": []}')
+    return InteractiveAuthSession(storage_state_path=state_path, _tmpdir="")
+
+
+class _FakeWorkbenchClient:
+    """Stand-in for WorkbenchClient recording calls; instances are reusable."""
+
+    instances: list[_FakeWorkbenchClient] = []
+
+    def __init__(self, base_url, *, cookies=None, insecure=False, ca_bundle=None, **_):
+        self.base_url = base_url
+        self.cookies = cookies
+        self.closed = False
+        self._api_reachable = True
+        self._quit_count = 0
+        self._remaining_sessions: list[dict] = []
+        type(self).instances.append(self)
+
+    def sessions_api_reachable(self):
+        return self._api_reachable
+
+    def quit_vip_sessions(self):
+        return self._quit_count
+
+    def list_sessions(self):
+        return self._remaining_sessions
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_workbench_client():
+    _FakeWorkbenchClient.instances = []
+    yield
+    _FakeWorkbenchClient.instances = []
+
+
+class TestConnectWorkbenchRouting:
+    """run_cleanup must run Connect-only, Workbench-only, or both, based on
+    which URLs resolve — and error when neither does."""
+
+    def test_neither_url_exits_with_error(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            vip.cli.run_cleanup(_make_args())
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Connect or Workbench" in err
+
+    def test_connect_only_does_not_touch_workbench(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        class _FakeConnectClient:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 3
+
+        monkeypatch.setattr("vip.clients.connect.ConnectClient", _FakeConnectClient)
+
+        def _fail(*a, **k):
+            pytest.fail("workbench cleanup should not run without a workbench URL")
+
+        monkeypatch.setattr(vip.cli, "_cleanup_workbench_sessions", _fail)
+
+        vip.cli.run_cleanup(_make_args(connect_url="https://c.example.com"))
+
+        out = capsys.readouterr().out
+        assert "Deleted 3 VIP test content item(s)" in out
+        assert "Cleanup completed successfully" in out
+
+    def test_workbench_only_does_not_touch_connect(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        monkeypatch.delenv("VIP_TEST_USERNAME", raising=False)
+        monkeypatch.delenv("VIP_TEST_PASSWORD", raising=False)
+
+        def _fail(*a, **k):
+            pytest.fail("Connect client should not be constructed without a Connect URL")
+
+        monkeypatch.setattr("vip.clients.connect.ConnectClient", _fail)
+
+        called = {}
+        monkeypatch.setattr(
+            vip.cli,
+            "_cleanup_workbench_sessions",
+            lambda url, args, config: called.setdefault("url", url),
+        )
+
+        vip.cli.run_cleanup(_make_args(workbench_url="https://wb.example.com"))
+
+        assert called["url"] == "https://wb.example.com"
+
+    def test_both_urls_clean_both(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        class _FakeConnectClient:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 1
+
+        monkeypatch.setattr("vip.clients.connect.ConnectClient", _FakeConnectClient)
+
+        called = {}
+        monkeypatch.setattr(
+            vip.cli,
+            "_cleanup_workbench_sessions",
+            lambda url, args, config: called.setdefault("url", url),
+        )
+
+        vip.cli.run_cleanup(
+            _make_args(connect_url="https://c.example.com", workbench_url="https://wb.example.com")
+        )
+
+        out = capsys.readouterr().out
+        assert "Deleted 1 VIP test content item(s)" in out
+        assert called["url"] == "https://wb.example.com"
+
+    def test_workbench_url_falls_back_to_vip_toml(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        (tmp_path / "vip.toml").write_text(
+            '[workbench]\nurl = "https://wb-from-config.example.com"\n'
+        )
+
+        called = {}
+        monkeypatch.setattr(
+            vip.cli,
+            "_cleanup_workbench_sessions",
+            lambda url, args, config: called.setdefault("url", url),
+        )
+
+        vip.cli.run_cleanup(_make_args())
+
+        assert called["url"] == "https://wb-from-config.example.com"
+
+
+class TestWorkbenchAuthModeSelection:
+    """_cleanup_workbench_sessions must pick headless auth when test creds are
+    present, otherwise fall back to interactive."""
+
+    def _patch_client_and_ui(self, monkeypatch, *, api_reachable=True, remaining=None):
+        def _fake_client_ctor(*args, **kwargs):
+            client = _FakeWorkbenchClient(*args, **kwargs)
+            client._api_reachable = api_reachable
+            client._remaining_sessions = remaining or []
+            return client
+
+        monkeypatch.setattr("vip.clients.workbench.WorkbenchClient", _fake_client_ctor)
+        monkeypatch.setattr(vip.workbench_ui, "quit_vip_sessions_via_ui", lambda page, url, **k: 0)
+
+        @contextmanager
+        def _fake_authenticated_page(session, **kwargs):
+            yield MagicMock()
+
+        monkeypatch.setattr(vip.auth, "authenticated_page", _fake_authenticated_page)
+
+    def test_uses_headless_auth_when_test_credentials_configured(self, tmp_path, monkeypatch):
+        from vip.config import VIPConfig
+
+        self._patch_client_and_ui(monkeypatch)
+
+        calls = {}
+
+        def _fake_headless(**kwargs):
+            calls["headless"] = kwargs
+            return _fake_session(tmp_path)
+
+        monkeypatch.setattr(vip.auth, "start_headless_auth", _fake_headless)
+
+        def _fail_interactive(**kwargs):
+            pytest.fail("start_interactive_auth should not be called when creds are configured")
+
+        monkeypatch.setattr(vip.auth, "start_interactive_auth", _fail_interactive)
+
+        config = VIPConfig()
+        config.auth.username = "admin"
+        config.auth.password = "secret"
+
+        vip.cli._cleanup_workbench_sessions("https://wb.example.com", _make_args(), config)
+
+        assert calls["headless"]["workbench_url"] == "https://wb.example.com"
+        assert calls["headless"]["username"] == "admin"
+
+    def test_uses_interactive_auth_when_no_credentials(self, tmp_path, monkeypatch):
+        from vip.config import VIPConfig
+
+        self._patch_client_and_ui(monkeypatch)
+
+        def _fail_headless(**kwargs):
+            pytest.fail("start_headless_auth should not be called without credentials")
+
+        monkeypatch.setattr(vip.auth, "start_headless_auth", _fail_headless)
+
+        calls = {}
+
+        def _fake_interactive(**kwargs):
+            calls["interactive"] = kwargs
+            return _fake_session(tmp_path)
+
+        monkeypatch.setattr(vip.auth, "start_interactive_auth", _fake_interactive)
+
+        config = VIPConfig()
+        config.auth.username = ""
+        config.auth.password = ""
+
+        vip.cli._cleanup_workbench_sessions("https://wb.example.com", _make_args(), config)
+
+        assert calls["interactive"]["workbench_url"] == "https://wb.example.com"
+
+    def test_auth_config_error_exits_with_clear_message(self, tmp_path, monkeypatch, capsys):
+        from vip.auth import AuthConfigError
+        from vip.config import VIPConfig
+
+        def _boom(**kwargs):
+            raise AuthConfigError("no credentials")
+
+        monkeypatch.setattr(vip.auth, "start_interactive_auth", _boom)
+
+        config = VIPConfig()
+        config.auth.username = ""
+        config.auth.password = ""
+
+        with pytest.raises(SystemExit) as exc_info:
+            vip.cli._cleanup_workbench_sessions("https://wb.example.com", _make_args(), config)
+
+        assert exc_info.value.code == 1
+        assert "could not authenticate" in capsys.readouterr().err
+
+    def test_unexpected_auth_exception_does_not_crash_with_traceback(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from vip.config import VIPConfig
+
+        def _boom(**kwargs):
+            raise RuntimeError("browser crashed")
+
+        monkeypatch.setattr(vip.auth, "start_interactive_auth", _boom)
+
+        config = VIPConfig()
+        config.auth.username = ""
+        config.auth.password = ""
+
+        with pytest.raises(SystemExit) as exc_info:
+            vip.cli._cleanup_workbench_sessions("https://wb.example.com", _make_args(), config)
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "could not authenticate to Workbench" in err
+        assert "VIP_TEST_USERNAME" in err
+
+
+class TestWorkbenchUiEscalation:
+    """The UI sweep must fire when the API is unreachable or leaves VIP
+    sessions behind, and must be skipped when the API sweep is confirmed clean."""
+
+    def _run(self, tmp_path, monkeypatch, *, api_reachable, remaining):
+        from vip.config import VIPConfig
+
+        monkeypatch.setattr(vip.auth, "start_interactive_auth", lambda **k: _fake_session(tmp_path))
+
+        def _fake_client_ctor(*args, **kwargs):
+            client = _FakeWorkbenchClient(*args, **kwargs)
+            client._api_reachable = api_reachable
+            client._remaining_sessions = remaining
+            return client
+
+        monkeypatch.setattr("vip.clients.workbench.WorkbenchClient", _fake_client_ctor)
+
+        ui_calls: list[str] = []
+        monkeypatch.setattr(
+            vip.workbench_ui,
+            "quit_vip_sessions_via_ui",
+            lambda page, url, **k: ui_calls.append(url) or 0,
+        )
+
+        @contextmanager
+        def _fake_authenticated_page(session, **kwargs):
+            yield MagicMock()
+
+        monkeypatch.setattr(vip.auth, "authenticated_page", _fake_authenticated_page)
+
+        config = VIPConfig()
+        config.auth.username = ""
+        config.auth.password = ""
+
+        vip.cli._cleanup_workbench_sessions("https://wb.example.com", _make_args(), config)
+        return ui_calls
+
+    def test_escalates_when_api_unreachable(self, tmp_path, monkeypatch):
+        ui_calls = self._run(tmp_path, monkeypatch, api_reachable=False, remaining=[])
+        assert ui_calls == ["https://wb.example.com"]
+
+    def test_escalates_when_leftovers_remain_despite_reachable_api(self, tmp_path, monkeypatch):
+        ui_calls = self._run(
+            tmp_path,
+            monkeypatch,
+            api_reachable=True,
+            remaining=[{"id": "a", "label": "VIP stuck"}],
+        )
+        assert ui_calls == ["https://wb.example.com"]
+
+    def test_skips_ui_when_api_sweep_is_clean(self, tmp_path, monkeypatch):
+        ui_calls = self._run(tmp_path, monkeypatch, api_reachable=True, remaining=[])
+        assert ui_calls == []

--- a/selftests/test_cli_cleanup.py
+++ b/selftests/test_cli_cleanup.py
@@ -20,6 +20,7 @@ import vip.auth
 import vip.cli
 import vip.workbench_ui
 from vip.auth import InteractiveAuthSession
+from vip.clients.workbench import is_vip_session
 
 
 def _make_args(**overrides) -> argparse.Namespace:
@@ -50,6 +51,10 @@ class _FakeWorkbenchClient:
         self._api_reachable = True
         self._quit_count = 0
         self._remaining_sessions: list[dict] = []
+        # When set (not None), count_vip_sessions returns this verbatim so a
+        # test can force the "unknown" (-1) signal; otherwise it is derived
+        # from _remaining_sessions like the real client would.
+        self._vip_count: int | None = None
         type(self).instances.append(self)
 
     def sessions_api_reachable(self):
@@ -58,8 +63,14 @@ class _FakeWorkbenchClient:
     def quit_vip_sessions(self):
         return self._quit_count
 
-    def list_sessions(self):
-        return self._remaining_sessions
+    def count_vip_sessions(self):
+        if self._vip_count is not None:
+            return self._vip_count
+        return sum(
+            1
+            for s in self._remaining_sessions
+            if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
+        )
 
     def close(self):
         self.closed = True
@@ -172,6 +183,33 @@ class TestConnectWorkbenchRouting:
         out = capsys.readouterr().out
         assert "Deleted 1 VIP test content item(s)" in out
         assert called["url"] == "https://wb.example.com"
+
+    def test_connect_only_without_vip_toml_does_not_warn(self, tmp_path, monkeypatch, recwarn):
+        # `vip cleanup --connect-url ...` with no vip.toml must not emit a
+        # "Config file not found" warning (issue #467 review): the URL was
+        # supplied explicitly, so there is nothing to warn about.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        class _FakeConnectClient:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 0
+
+        monkeypatch.setattr("vip.clients.connect.ConnectClient", _FakeConnectClient)
+
+        vip.cli.run_cleanup(_make_args(connect_url="https://c.example.com"))
+
+        messages = [str(w.message) for w in recwarn.list]
+        assert not any("Config file not found" in m for m in messages), messages
 
     def test_workbench_url_falls_back_to_vip_toml(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -311,7 +349,7 @@ class TestWorkbenchUiEscalation:
     """The UI sweep must fire when the API is unreachable or leaves VIP
     sessions behind, and must be skipped when the API sweep is confirmed clean."""
 
-    def _run(self, tmp_path, monkeypatch, *, api_reachable, remaining):
+    def _run(self, tmp_path, monkeypatch, *, api_reachable, remaining, count=None):
         from vip.config import VIPConfig
 
         monkeypatch.setattr(vip.auth, "start_interactive_auth", lambda **k: _fake_session(tmp_path))
@@ -320,6 +358,7 @@ class TestWorkbenchUiEscalation:
             client = _FakeWorkbenchClient(*args, **kwargs)
             client._api_reachable = api_reachable
             client._remaining_sessions = remaining
+            client._vip_count = count
             return client
 
         monkeypatch.setattr("vip.clients.workbench.WorkbenchClient", _fake_client_ctor)
@@ -360,3 +399,10 @@ class TestWorkbenchUiEscalation:
     def test_skips_ui_when_api_sweep_is_clean(self, tmp_path, monkeypatch):
         ui_calls = self._run(tmp_path, monkeypatch, api_reachable=True, remaining=[])
         assert ui_calls == []
+
+    def test_escalates_when_count_is_unknown(self, tmp_path, monkeypatch):
+        # A reachable API whose post-sweep count cannot be determined (-1, e.g.
+        # a non-list body) must escalate rather than be mistaken for clean —
+        # otherwise an unparseable response silently re-orphans sessions (#467).
+        ui_calls = self._run(tmp_path, monkeypatch, api_reachable=True, remaining=[], count=-1)
+        assert ui_calls == ["https://wb.example.com"]

--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -220,6 +220,52 @@ def test_quit_vip_sessions_no_warning_when_fully_cleaned(caplog):
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
+def test_count_vip_sessions_counts_only_vip():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=[
+                {"id": "a", "label": "VIP foo"},
+                {"id": "b", "label": "My real work"},
+                {"id": "c", "label": "_vip_cap_1_default_0"},
+            ],
+        )
+
+    wc = _client_with_handler(handler)
+    assert wc.count_vip_sessions() == 2
+
+
+def test_count_vip_sessions_zero_when_no_vip_sessions():
+    wc = _client_with_handler(lambda r: httpx.Response(200, json=[{"id": "b", "label": "real"}]))
+    assert wc.count_vip_sessions() == 0
+
+
+def test_count_vip_sessions_minus_one_on_non_200():
+    wc = _client_with_handler(lambda r: httpx.Response(503))
+    assert wc.count_vip_sessions() == -1
+
+
+def test_count_vip_sessions_minus_one_on_transport_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    wc = _client_with_handler(handler)
+    assert wc.count_vip_sessions() == -1
+
+
+def test_count_vip_sessions_minus_one_on_non_list_json():
+    # A 200 whose body is a JSON object (not the expected array) must read as
+    # "unknown" (-1), never as "confirmed clean" (0) — else the caller would
+    # suppress the UI escalation and re-orphan sessions (issue #467).
+    wc = _client_with_handler(lambda r: httpx.Response(200, json={"error": "nope"}))
+    assert wc.count_vip_sessions() == -1
+
+
+def test_count_vip_sessions_minus_one_on_non_json_body():
+    wc = _client_with_handler(lambda r: httpx.Response(200, text="<html>app</html>"))
+    assert wc.count_vip_sessions() == -1
+
+
 def test_sessions_api_reachable_true_on_200():
     wc = _client_with_handler(lambda r: httpx.Response(200, json=[]))
     assert wc.sessions_api_reachable() is True

--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -6,6 +6,8 @@ httpx client is replaced with one backed by httpx.MockTransport.
 
 from __future__ import annotations
 
+import logging
+
 import httpx
 import pytest
 
@@ -170,6 +172,52 @@ def test_quit_vip_sessions_counts_unique_sessions_under_retry():
     wc = _client_with_handler(handler)
     # 3 attempts each DELETE "a" successfully, but it is one unique session.
     assert wc.quit_vip_sessions(retries=3, settle_seconds=0) == 1
+
+
+def test_quit_vip_sessions_warns_when_stuck_session_persists(caplog):
+    """A VIP session that never disappears across all retries must WARN (issue #467).
+
+    quit_session() treats any HTTP status < 400 as success without verifying
+    termination -- so a deployment whose DELETE is a silent no-op looks
+    "successful" while the session persists. The final re-check after the
+    retry loop must catch that and log loudly instead of returning quietly.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions":
+            # Always still listed -- simulates a no-op DELETE/suspend.
+            return httpx.Response(200, json=[{"id": "a", "label": "VIP stuck"}])
+        return httpx.Response(200)
+
+    wc = _client_with_handler(handler)
+    with caplog.at_level(logging.WARNING):
+        quit_count = wc.quit_vip_sessions(retries=2, settle_seconds=0)
+
+    assert quit_count == 1  # the quit call "succeeded" once, distinct session
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "expected a WARNING when a VIP session persists after cleanup"
+    assert any("VIP stuck" in r.message for r in warnings)
+    assert any("id=a" in r.message for r in warnings)
+
+
+def test_quit_vip_sessions_no_warning_when_fully_cleaned(caplog):
+    """No warning should fire when the retry loop confirms everything is gone."""
+    list_calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions":
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                return httpx.Response(200, json=[{"id": "a", "label": "VIP foo"}])
+            return httpx.Response(200, json=[])
+        return httpx.Response(200)
+
+    wc = _client_with_handler(handler)
+    with caplog.at_level(logging.WARNING):
+        quit_count = wc.quit_vip_sessions(retries=3, settle_seconds=0)
+
+    assert quit_count == 1
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 def test_sessions_api_reachable_true_on_200():
@@ -390,3 +438,168 @@ def test_quit_vip_sessions_via_ui_clicks_present_dialog_with_normal_timeout():
     # short probe) so a slow-but-present dialog still completes. Absent dialogs
     # (force-quit follow-ups) are not clicked.
     assert page.dialog_clicks == [(Homepage.CONFIRM_QUIT, TIMEOUT_QUICK)]
+
+
+# ---------------------------------------------------------------------------
+# _run_session_cleanup — escalation logic (issue #467)
+# ---------------------------------------------------------------------------
+
+
+def _fake_vip_config(*, api_key: str = ""):
+    from types import SimpleNamespace
+
+    workbench = SimpleNamespace(api_key=api_key)
+    return SimpleNamespace(workbench=workbench, insecure=False, ca_bundle=None)
+
+
+def _fake_page(cookies: list[dict]):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(context=SimpleNamespace(cookies=lambda: cookies))
+
+
+def _fresh_state() -> dict[str, object]:
+    return {"cookies": None, "base_url": None, "api_reachable": None}
+
+
+def _recording_ui_sweep(ui_calls: list[tuple], return_value: int = 0):
+    """Build a fake ``_quit_vip_sessions_via_ui`` that records its (page, base_url) call."""
+
+    def _fake(page, base_url, **_k):
+        ui_calls.append((page, base_url))
+        return return_value
+
+    return _fake
+
+
+def test_run_session_cleanup_escalates_to_ui_when_api_leaves_leftovers(monkeypatch):
+    """API sweep runs but VIP sessions remain -> the UI sweep must fire.
+
+    This is the core #467 fix: a reachable API whose DELETE is a no-op must
+    not be trusted just because it didn't error.
+    """
+    from types import SimpleNamespace
+
+    from vip_tests.workbench import conftest as wb
+
+    ui_calls: list[tuple] = []
+
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_cookies", lambda *a, **k: 1)
+    monkeypatch.setattr(wb, "_session_api_reachable_via_cookies", lambda *a, **k: True)
+    monkeypatch.setattr(wb, "_vip_session_count_via_cookies", lambda *a, **k: 1)
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_ui", _recording_ui_sweep(ui_calls, 1))
+
+    page = _fake_page([{"name": "a", "value": "b"}])
+    workbench_client = SimpleNamespace(base_url="https://wb.example.com")
+    state = _fresh_state()
+
+    wb._run_session_cleanup(page, workbench_client, _fake_vip_config(), state)
+
+    assert len(ui_calls) == 1
+    assert ui_calls[0][1] == "https://wb.example.com"
+
+
+def test_run_session_cleanup_skips_ui_when_api_sweep_fully_cleans(monkeypatch):
+    """API reachable and confirmed zero VIP sessions remaining -> no UI escalation."""
+    from types import SimpleNamespace
+
+    from vip_tests.workbench import conftest as wb
+
+    ui_calls: list[tuple] = []
+
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_cookies", lambda *a, **k: 1)
+    monkeypatch.setattr(wb, "_session_api_reachable_via_cookies", lambda *a, **k: True)
+    monkeypatch.setattr(wb, "_vip_session_count_via_cookies", lambda *a, **k: 0)
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_ui", _recording_ui_sweep(ui_calls, 0))
+
+    page = _fake_page([{"name": "a", "value": "b"}])
+    workbench_client = SimpleNamespace(base_url="https://wb.example.com")
+    state = _fresh_state()
+
+    wb._run_session_cleanup(page, workbench_client, _fake_vip_config(), state)
+
+    assert ui_calls == []
+
+
+def test_run_session_cleanup_escalates_when_api_unreachable(monkeypatch):
+    """Existing behavior preserved: an unreachable API still escalates to the UI."""
+    from types import SimpleNamespace
+
+    from vip_tests.workbench import conftest as wb
+
+    ui_calls: list[tuple] = []
+
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_cookies", lambda *a, **k: 0)
+    monkeypatch.setattr(wb, "_session_api_reachable_via_cookies", lambda *a, **k: False)
+    monkeypatch.setattr(wb, "_vip_session_count_via_cookies", lambda *a, **k: -1)
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_ui", _recording_ui_sweep(ui_calls, 0))
+
+    page = _fake_page([{"name": "a", "value": "b"}])
+    workbench_client = SimpleNamespace(base_url="https://wb.example.com")
+    state = _fresh_state()
+
+    wb._run_session_cleanup(page, workbench_client, _fake_vip_config(), state)
+
+    assert len(ui_calls) == 1
+
+
+def test_run_session_cleanup_warns_when_no_cookies_and_no_api_key(monkeypatch, caplog):
+    """No browser cookies and no [workbench] api_key -> warn, do not attempt any sweep."""
+    from types import SimpleNamespace
+
+    from vip_tests.workbench import conftest as wb
+
+    def _fail(*a, **k):
+        pytest.fail("no sweep should be attempted without cookies or an api_key")
+
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_cookies", _fail)
+    monkeypatch.setattr(wb, "_session_api_reachable_via_cookies", _fail)
+    monkeypatch.setattr(wb, "_vip_session_count_via_cookies", _fail)
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_ui", _fail)
+
+    page = _fake_page([])
+    workbench_client = SimpleNamespace(base_url="https://wb.example.com")
+    state = _fresh_state()
+
+    with caplog.at_level(logging.WARNING):
+        wb._run_session_cleanup(page, workbench_client, _fake_vip_config(api_key=""), state)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "expected a warning when cleanup cannot authenticate"
+    assert any("authenticate" in r.message for r in warnings)
+
+
+def test_run_session_cleanup_no_warning_when_no_cookies_but_api_key_present(monkeypatch, caplog):
+    """No browser cookies but an api_key is configured -> no warning (belt-and-suspenders
+    end-of-run sweep will use the api_key), and no per-test sweep is attempted either
+    (cookies are required for the per-test cookie-authenticated sweep)."""
+    from types import SimpleNamespace
+
+    from vip_tests.workbench import conftest as wb
+
+    def _fail(*a, **k):
+        pytest.fail("no cookie-based sweep should run without cookies")
+
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_cookies", _fail)
+    monkeypatch.setattr(wb, "_session_api_reachable_via_cookies", _fail)
+    monkeypatch.setattr(wb, "_vip_session_count_via_cookies", _fail)
+    monkeypatch.setattr(wb, "_quit_vip_sessions_via_ui", _fail)
+
+    page = _fake_page([])
+    workbench_client = SimpleNamespace(base_url="https://wb.example.com")
+    state = _fresh_state()
+
+    with caplog.at_level(logging.WARNING):
+        wb._run_session_cleanup(page, workbench_client, _fake_vip_config(api_key="k"), state)
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_run_session_cleanup_returns_early_when_workbench_client_is_none(monkeypatch):
+    """workbench_client=None (product not configured) -> no-op, no errors."""
+    from vip_tests.workbench import conftest as wb
+
+    page = _fake_page([{"name": "a", "value": "b"}])
+    state = _fresh_state()
+
+    wb._run_session_cleanup(page, None, _fake_vip_config(), state)  # must not raise

--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -370,6 +370,14 @@ class _FakeLocator:
     def first(self):
         return self
 
+    def is_visible(self):
+        # The fake models an already-authenticated homepage, so the Posit logo
+        # (the "logged in" marker _complete_sso_if_needed checks) is visible;
+        # nothing else is.
+        from vip_tests.workbench.pages import Homepage
+
+        return self._selector == Homepage.POSIT_LOGO
+
     def get_attribute(self, name):
         if name == "aria-label":
             return f"select {self._page.session_names[self._index]}"
@@ -405,9 +413,10 @@ class _FakeHomepage:
         self.dialog_clicks: list[tuple[str, object]] = []
         self.quit_clicks = 0
         self.reloads = 0
+        self.goto_urls: list[str] = []
 
-    def goto(self, *args, **kwargs):
-        pass
+    def goto(self, url, *args, **kwargs):
+        self.goto_urls.append(url)
 
     def reload(self, *args, **kwargs):
         self.reloads += 1
@@ -484,6 +493,132 @@ def test_quit_vip_sessions_via_ui_clicks_present_dialog_with_normal_timeout():
     # short probe) so a slow-but-present dialog still completes. Absent dialogs
     # (force-quit follow-ups) are not clicked.
     assert page.dialog_clicks == [(Homepage.CONFIRM_QUIT, TIMEOUT_QUICK)]
+
+
+def test_quit_vip_sessions_via_ui_navigates_to_root_not_home():
+    """The sweep must load the homepage at the site root, not ``/home``.
+
+    On WB 2026.06 the session table lives at the root (the URL the tests use);
+    ``/home`` renders no session list, which silently orphaned sessions (#467).
+    """
+    from vip_tests.workbench.conftest import _quit_vip_sessions_via_ui
+
+    page = _FakeHomepage(["VIP one - gw0-1"], quit_removes=True)
+    _quit_vip_sessions_via_ui(page, "https://wb.example.com/")
+
+    assert page.goto_urls[0] == "https://wb.example.com"
+    assert not any(u.endswith("/home") for u in page.goto_urls)
+
+
+def test_quit_vip_sessions_via_ui_bails_when_sso_cannot_complete(monkeypatch):
+    """When the homepage can't be reached (SSO not completed), quit 0 and warn."""
+    import vip.workbench_ui as wbui
+
+    monkeypatch.setattr(wbui, "_complete_sso_if_needed", lambda page: False)
+    page = _FakeHomepage(["VIP one - gw0-1"], quit_removes=True)
+    assert wbui.quit_vip_sessions_via_ui(page, "https://wb.example.com") == 0
+    # It never tried to enumerate/quit rows once auth failed.
+    assert page.quit_clicks == 0
+
+
+class _SsoFakePage:
+    """Page double for :func:`_complete_sso_if_needed`.
+
+    Models an OIDC sign-in page: a "Sign in with OpenID" button whose click
+    completes a silent SSO (making the homepage logo appear) iff *idp_valid*.
+    """
+
+    def __init__(
+        self, *, url, logo_visible=False, sso_visible=True, has_username=False, idp_valid=True
+    ):
+        self.url = url
+        self._logo_visible = logo_visible
+        self._sso_visible = sso_visible
+        self._has_username = has_username
+        self._idp_valid = idp_valid
+        self.sso_clicked = False
+
+    def locator(self, selector):
+        from vip_tests.workbench.pages import Homepage, LoginPage
+
+        if selector == Homepage.POSIT_LOGO:
+            return _SsoFakeLocator(lambda: self._logo_visible)
+        if selector == LoginPage.USERNAME:
+            return _SsoFakeLocator(lambda: self._has_username)
+        return _SsoFakeLocator(lambda: False)
+
+    def get_by_role(self, role, name=None):
+        page = self
+
+        def _on_click() -> None:
+            page.sso_clicked = True
+            if page._idp_valid:
+                page._logo_visible = True
+
+        return _SsoFakeLocator(lambda: page._sso_visible, on_click=_on_click)
+
+
+class _SsoFakeLocator:
+    def __init__(self, is_visible_fn, *, on_click=None):
+        self._is_visible_fn = is_visible_fn
+        self._on_click = on_click
+
+    @property
+    def first(self):
+        return self
+
+    def is_visible(self):
+        return self._is_visible_fn()
+
+    def wait_for(self, *, state=None, timeout=None):
+        if not self._is_visible_fn():
+            raise RuntimeError("not visible")
+
+    def click(self, timeout=None):
+        if self._on_click is not None:
+            self._on_click()
+
+
+def test_complete_sso_true_when_already_authenticated():
+    from vip.workbench_ui import _complete_sso_if_needed
+
+    page = _SsoFakePage(url="https://wb.example.com/", logo_visible=True)
+    assert _complete_sso_if_needed(page) is True
+    assert page.sso_clicked is False  # no SSO needed
+
+
+def test_complete_sso_clicks_button_and_succeeds_with_valid_idp():
+    from vip.workbench_ui import _complete_sso_if_needed
+
+    page = _SsoFakePage(url="https://wb.example.com/auth-sign-in?appUri=%2F", idp_valid=True)
+    assert _complete_sso_if_needed(page) is True
+    assert page.sso_clicked is True
+
+
+def test_complete_sso_false_when_idp_session_expired():
+    from vip.workbench_ui import _complete_sso_if_needed
+
+    # SSO button present and clicked, but the homepage logo never appears.
+    page = _SsoFakePage(url="https://wb.example.com/auth-sign-in", idp_valid=False)
+    assert _complete_sso_if_needed(page) is False
+    assert page.sso_clicked is True
+
+
+def test_complete_sso_false_on_password_form():
+    from vip.workbench_ui import _complete_sso_if_needed
+
+    # A username field means a password form, not silent SSO: don't click.
+    page = _SsoFakePage(url="https://wb.example.com/auth-sign-in", has_username=True)
+    assert _complete_sso_if_needed(page) is False
+    assert page.sso_clicked is False
+
+
+def test_complete_sso_false_when_not_on_login_page():
+    from vip.workbench_ui import _complete_sso_if_needed
+
+    # No logo and not a login URL — nothing we can do.
+    page = _SsoFakePage(url="https://wb.example.com/some/other/page", sso_visible=False)
+    assert _complete_sso_if_needed(page) is False
 
 
 # ---------------------------------------------------------------------------

--- a/selftests/test_workbench_login.py
+++ b/selftests/test_workbench_login.py
@@ -1,0 +1,100 @@
+"""Selftests for workbench_login's password-vs-SSO detection (issue #467).
+
+On an OIDC-only Workbench (no password form), the config-less password-login
+path must *skip* gracefully rather than fall through to the password retry
+loop and fail with "Login failed after 3 attempts". The sign-in page renders
+client-side, so detection must wait for either the username field or the
+"Sign in with OpenID" button before deciding -- a race that previously misread
+a slow OIDC sign-in page as a password deployment.
+
+No real browser is used: a tiny Page double models the sign-in page.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _pytest.outcomes import Skipped
+
+from vip_tests.workbench.conftest import workbench_login
+
+
+class _AuthFakeLocator:
+    def __init__(self, *, visible: bool = False, on_click=None):
+        self._visible = visible
+        self._on_click = on_click
+
+    @property
+    def first(self):
+        return self
+
+    def is_visible(self) -> bool:
+        return self._visible()
+
+    def wait_for(self, *, state=None, timeout=None):
+        if not self._visible():
+            raise RuntimeError("locator not visible")
+
+    def click(self, *args, **kwargs):
+        if self._on_click is not None:
+            self._on_click()
+
+
+class _OidcLoginFakePage:
+    """Models an OIDC-only sign-in page: a "Sign in with OpenID" button and no
+    username field. *idp_valid* controls whether clicking the button reaches an
+    authenticated homepage (the logo becoming visible)."""
+
+    def __init__(self, *, idp_valid: bool = True):
+        self.url = "https://wb.example.com/auth-sign-in?appUri=&error=2"
+        self._logged_in = False
+        self._idp_valid = idp_valid
+        self.sso_clicked = False
+
+    def goto(self, *args, **kwargs):
+        pass
+
+    def wait_for_load_state(self, *args, **kwargs):
+        pass
+
+    def locator(self, selector):
+        from vip_tests.workbench.pages import Homepage
+
+        if selector == Homepage.POSIT_LOGO:
+            return _AuthFakeLocator(visible=lambda: self._logged_in)
+        # Everything else this flow queries (the username field, the combined
+        # settle-wait selector) is absent on an OIDC-only page.
+        return _AuthFakeLocator(visible=lambda: False)
+
+    def get_by_role(self, role, name=None):
+        def _click():
+            self.sso_clicked = True
+            if self._idp_valid:
+                self._logged_in = True
+
+        return _AuthFakeLocator(visible=lambda: True, on_click=_click)
+
+
+def test_password_login_skips_on_oidc_only_deployment():
+    # Config-less defaults: auth_provider="password", interactive_auth=False.
+    page = _OidcLoginFakePage()
+    with pytest.raises(Skipped) as exc:
+        workbench_login(page, "https://wb.example.com", "user", "pass")
+    assert "SSO/OIDC" in str(exc.value)
+    assert page.sso_clicked is False  # password mode never clicks the SSO button
+
+
+def test_interactive_auth_completes_sso_and_returns():
+    # --interactive-auth with a valid pre-loaded IdP session: click SSO, land on
+    # the homepage, and return without skipping.
+    page = _OidcLoginFakePage(idp_valid=True)
+    workbench_login(page, "https://wb.example.com", "", "", interactive_auth=True)
+    assert page.sso_clicked is True
+
+
+def test_interactive_auth_skips_when_sso_cannot_complete():
+    # --interactive-auth but the IdP session is gone: clicking SSO never reaches
+    # the homepage, so skip gracefully instead of hanging or failing.
+    page = _OidcLoginFakePage(idp_valid=False)
+    with pytest.raises(Skipped):
+        workbench_login(page, "https://wb.example.com", "", "", interactive_auth=True)
+    assert page.sso_clicked is True

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -12,7 +12,8 @@ import os
 import shutil
 import tempfile
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -196,6 +197,64 @@ class InteractiveAuthSession:
 
         if self._tmpdir and os.path.isdir(self._tmpdir):
             shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+
+@contextmanager
+def authenticated_page(
+    session: InteractiveAuthSession,
+    *,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
+) -> Iterator[Page]:
+    """Open a headless, authenticated Playwright page from a cached auth session.
+
+    Loads *session*'s saved storage state into a fresh headless browser
+    context, so callers outside of a pytest run (e.g. ``vip cleanup
+    --workbench-url``, see :func:`vip.cli.run_cleanup`) can drive a product's
+    UI using the same login a prior ``vip verify`` already completed, without
+    prompting for credentials again.
+
+    Honors *insecure*/*ca_bundle* the same way :func:`start_headless_auth`
+    does (TLS verification skip, ``NODE_EXTRA_CA_CERTS`` for a custom CA).
+    Closes the page's context, the browser, and the Playwright driver on
+    exit, restoring ``NODE_EXTRA_CA_CERTS`` to its previous value, regardless
+    of how the ``with`` block exits.
+    """
+    pw = None
+    browser = None
+    _prev_node_ca = os.environ.get("NODE_EXTRA_CA_CERTS")
+    if ca_bundle is not None:
+        os.environ["NODE_EXTRA_CA_CERTS"] = str(ca_bundle)
+    try:
+        pw = sync_playwright().start()
+        browser = _launch_chromium(pw, headless=True)
+        context = browser.new_context(
+            storage_state=str(session.storage_state_path),
+            ignore_https_errors=insecure,
+        )
+        try:
+            yield context.new_page()
+        finally:
+            try:
+                context.close()
+            except Exception:
+                pass
+    finally:
+        if browser is not None:
+            try:
+                browser.close()
+            except Exception:
+                pass
+        if pw is not None:
+            try:
+                pw.stop()
+            except Exception:
+                pass
+        if ca_bundle is not None:
+            if _prev_node_ca is None:
+                os.environ.pop("NODE_EXTRA_CA_CERTS", None)
+            else:
+                os.environ["NODE_EXTRA_CA_CERTS"] = _prev_node_ca
 
 
 def _load_cached_auth(

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import re
 import subprocess
@@ -923,6 +924,24 @@ def _cleanup_workbench_sessions(
         session.cleanup()
 
 
+def _ensure_cli_logging() -> None:
+    """Route ``vip.*`` INFO/WARNING logs to stderr for the cleanup command.
+
+    The session-cleanup path (WorkbenchClient + workbench_ui) emits progress
+    and "sessions still present" warnings via ``logging``; without a handler
+    those are invisible (or only WARNING via the lastResort handler). Attach a
+    single stderr handler to the ``vip`` logger so ``vip cleanup`` surfaces
+    what it did. Idempotent: only configures once.
+    """
+    vip_logger = logging.getLogger("vip")
+    if not vip_logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        vip_logger.addHandler(handler)
+        vip_logger.setLevel(logging.INFO)
+        vip_logger.propagate = False
+
+
 def _load_cleanup_config() -> VIPConfig:
     """Load ``vip.toml`` if present, else a default ``VIPConfig``.
 
@@ -954,6 +973,7 @@ def run_cleanup(args: argparse.Namespace) -> None:
     ``[connect] url``/``[workbench] url`` in ``vip.toml``. At least one of
     the two must resolve.
     """
+    _ensure_cli_logging()
     connect_url = getattr(args, "connect_url", None)
     api_key = getattr(args, "api_key", None) or os.environ.get("VIP_CONNECT_API_KEY", "")
     workbench_url = getattr(args, "workbench_url", None)

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -821,38 +821,160 @@ def run_scaffold(args: argparse.Namespace) -> None:
     )
 
 
-def run_cleanup(args: argparse.Namespace) -> None:
-    """Delete VIP test credentials and resources.
+def _cleanup_workbench_sessions(
+    workbench_url: str,
+    args: argparse.Namespace,
+    config: VIPConfig,
+) -> None:
+    """Authenticate to Workbench and quit orphaned VIP-named sessions.
 
-    Connects directly to a Connect server and deletes all content tagged
-    ``_vip_test``. The Connect URL is taken from ``--connect-url`` or, if
-    omitted, from ``[connect] url`` in ``vip.toml``.
+    API-first: quits via :meth:`~vip.clients.workbench.WorkbenchClient.quit_vip_sessions`
+    when the session API is reachable. Escalates to a browser-driven UI sweep
+    (:func:`vip.workbench_ui.quit_vip_sessions_via_ui`) when the API is
+    unreachable *or* VIP sessions remain after the API sweep — a reachable API
+    whose DELETE/suspend call is a silent no-op is exactly the #467 bug, so a
+    "no error" response is not trusted on its own.
+
+    Authentication is cache-aware: reuses a storage state saved by a prior
+    ``vip verify`` run (same cache path, <4h old) when available. Uses
+    ``--headless-auth``'s flow when ``VIP_TEST_USERNAME``/``VIP_TEST_PASSWORD``
+    are set, otherwise opens an interactive browser login. Never lets an
+    authentication failure crash with a bare traceback — prints an actionable
+    error and exits 1.
     """
-    # Determine Connect URL and API key for content cleanup.
-    connect_url = getattr(args, "connect_url", None)
-    api_key = getattr(args, "api_key", None) or os.environ.get("VIP_CONNECT_API_KEY", "")
+    from vip.auth import (
+        AuthConfigError,
+        authenticated_page,
+        start_headless_auth,
+        start_interactive_auth,
+    )
+    from vip.clients.workbench import WorkbenchClient, is_vip_session
+    from vip.workbench_ui import quit_vip_sessions_via_ui
 
-    # Fall back to vip.toml for the URL only when no CLI override is supplied,
-    # so `vip cleanup --connect-url ...` runs without a "config not found" warning.
-    if not connect_url:
-        from vip.config import load_config
+    insecure = config.insecure
+    ca_bundle = config.ca_bundle
+    # Mirrors plugin.py's cache path (Path(config.rootpath) / ".vip-auth-cache.json"):
+    # there is no pytest config here, so the invocation directory stands in for
+    # rootpath, matching where a prior `vip verify` run from the same directory
+    # would have written its cache.
+    cache_path = Path.cwd() / ".vip-auth-cache.json"
 
-        config = load_config()
-        if config.connect and config.connect.url:
-            connect_url = config.connect.url
-    if not connect_url:
+    username = config.auth.username
+    password = config.auth.password
+
+    try:
+        if username and password:
+            session = start_headless_auth(
+                workbench_url=workbench_url,
+                provider=config.auth.provider,
+                username=username,
+                password=password,
+                idp=config.auth.idp,
+                cache_path=cache_path,
+                insecure=insecure,
+                ca_bundle=ca_bundle,
+            )
+        else:
+            session = start_interactive_auth(
+                workbench_url=workbench_url,
+                cache_path=cache_path,
+                insecure=insecure,
+                ca_bundle=ca_bundle,
+            )
+    except AuthConfigError as exc:
+        print(f"Error: could not authenticate to Workbench: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
         print(
-            "Error: no Connect URL found. Pass --connect-url or set [connect] url in vip.toml.",
+            f"Error: could not authenticate to Workbench at {workbench_url}: {exc}\n"
+            "Set VIP_TEST_USERNAME and VIP_TEST_PASSWORD for non-interactive cleanup, "
+            "or run this command where a browser can open for an interactive login.",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    from vip.clients.connect import ConnectClient
+    try:
+        print(f"Cleaning up orphaned Workbench sessions at {workbench_url}")
+        cookies = session.load_cookies()
+        client = WorkbenchClient(
+            workbench_url, cookies=cookies, insecure=insecure, ca_bundle=ca_bundle
+        )
+        try:
+            api_reachable = client.sessions_api_reachable()
+            if api_reachable:
+                quit_count = client.quit_vip_sessions()
+                print(f"Quit {quit_count} VIP Workbench session(s) via the API")
+                remaining = sum(
+                    1
+                    for s in client.list_sessions()
+                    if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
+                )
+            else:
+                remaining = 0  # unknown — escalation below is driven by api_reachable
 
-    print(f"Cleaning up VIP test content on Connect at {connect_url}")
-    with ConnectClient(connect_url, api_key) as client:
-        deleted = client.cleanup_vip_content()
-    print(f"Deleted {deleted} VIP test content item(s)")
+            if not api_reachable or remaining:
+                print("Escalating to browser-driven session cleanup ...")
+                with authenticated_page(session, insecure=insecure, ca_bundle=ca_bundle) as page:
+                    ui_count = quit_vip_sessions_via_ui(page, workbench_url)
+                print(f"Quit {ui_count} VIP Workbench session(s) via the UI")
+        finally:
+            client.close()
+    finally:
+        session.cleanup()
+
+
+def run_cleanup(args: argparse.Namespace) -> None:
+    """Delete VIP test content from Connect and quit orphaned Workbench sessions.
+
+    Connect cleanup deletes all content tagged ``_vip_test``. Workbench
+    cleanup quits VIP-named sessions (see
+    :func:`vip.clients.workbench.is_vip_session`), escalating to a
+    browser-driven UI sweep when the session API is unreachable or sessions
+    persist despite the API reporting success. The Connect/Workbench URLs
+    come from ``--connect-url``/``--workbench-url`` or, if omitted, from
+    ``[connect] url``/``[workbench] url`` in ``vip.toml``. At least one of
+    the two must resolve.
+    """
+    connect_url = getattr(args, "connect_url", None)
+    api_key = getattr(args, "api_key", None) or os.environ.get("VIP_CONNECT_API_KEY", "")
+    workbench_url = getattr(args, "workbench_url", None)
+
+    # Fall back to vip.toml for whichever URL(s) weren't passed on the CLI, so
+    # `vip cleanup --connect-url ...` (or --workbench-url) runs without a
+    # "config not found" warning when only one product is being cleaned up.
+    config: VIPConfig | None = None
+    if not connect_url or not workbench_url:
+        from vip.config import load_config
+
+        config = load_config()
+        if not connect_url and config.connect and config.connect.url:
+            connect_url = config.connect.url
+        if not workbench_url and config.workbench and config.workbench.url:
+            workbench_url = config.workbench.url
+
+    if not connect_url and not workbench_url:
+        print(
+            "Error: no Connect or Workbench URL found. Pass --connect-url / "
+            "--workbench-url, or set [connect] url / [workbench] url in vip.toml.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if connect_url:
+        from vip.clients.connect import ConnectClient
+
+        print(f"Cleaning up VIP test content on Connect at {connect_url}")
+        with ConnectClient(connect_url, api_key) as client:
+            deleted = client.cleanup_vip_content()
+        print(f"Deleted {deleted} VIP test content item(s)")
+
+    if workbench_url:
+        if config is None:
+            from vip.config import load_config
+
+            config = load_config()
+        _cleanup_workbench_sessions(workbench_url, args, config)
+
     print("Cleanup completed successfully")
 
 
@@ -1120,10 +1242,13 @@ def main() -> None:
     # vip cleanup
     cleanup_parser = subparsers.add_parser(
         "cleanup",
-        help="Delete VIP _vip_test content from Connect",
+        help="Delete VIP _vip_test content from Connect and quit orphaned Workbench sessions",
         description=(
-            "Delete VIP _vip_test-tagged content from Connect.\n\n"
+            "Delete VIP _vip_test-tagged content from Connect, and/or quit orphaned\n"
+            "VIP-named Workbench sessions. At least one of --connect-url /\n"
+            "--workbench-url (or the corresponding vip.toml URL) must resolve.\n\n"
             "  vip cleanup --connect-url https://connect.example.com\n"
+            "  vip cleanup --workbench-url https://workbench.example.com\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1136,6 +1261,17 @@ def main() -> None:
         "--api-key",
         default=None,
         help="Connect API key (default: VIP_CONNECT_API_KEY env var)",
+    )
+    cleanup_parser.add_argument(
+        "--workbench-url",
+        default=None,
+        help=(
+            "Workbench server URL (falls back to vip.toml if omitted). Quits orphaned "
+            "VIP-named sessions via the session API, escalating to a browser-driven UI "
+            "sweep if the API is unreachable or sessions persist. Requires "
+            "VIP_TEST_USERNAME/VIP_TEST_PASSWORD for non-interactive auth, or an "
+            "interactive browser login."
+        ),
     )
     cleanup_parser.set_defaults(func=run_cleanup)
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -848,7 +848,7 @@ def _cleanup_workbench_sessions(
         start_headless_auth,
         start_interactive_auth,
     )
-    from vip.clients.workbench import WorkbenchClient, is_vip_session
+    from vip.clients.workbench import WorkbenchClient
     from vip.workbench_ui import quit_vip_sessions_via_ui
 
     insecure = config.insecure
@@ -904,15 +904,15 @@ def _cleanup_workbench_sessions(
             if api_reachable:
                 quit_count = client.quit_vip_sessions()
                 print(f"Quit {quit_count} VIP Workbench session(s) via the API")
-                remaining = sum(
-                    1
-                    for s in client.list_sessions()
-                    if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
-                )
+                remaining = client.count_vip_sessions()
             else:
-                remaining = 0  # unknown — escalation below is driven by api_reachable
+                remaining = -1  # unknown — escalate below
 
-            if not api_reachable or remaining:
+            # Escalate when the API is unreachable, when VIP sessions remain, or
+            # when the count is undeterminable (-1). Only a confirmed 0 skips the
+            # UI sweep, so an unparseable API response can never silently orphan
+            # sessions (issue #467).
+            if not api_reachable or remaining != 0:
                 print("Escalating to browser-driven session cleanup ...")
                 with authenticated_page(session, insecure=insecure, ca_bundle=ca_bundle) as page:
                     ui_count = quit_vip_sessions_via_ui(page, workbench_url)
@@ -921,6 +921,25 @@ def _cleanup_workbench_sessions(
             client.close()
     finally:
         session.cleanup()
+
+
+def _load_cleanup_config() -> VIPConfig:
+    """Load ``vip.toml`` if present, else a default ``VIPConfig``.
+
+    ``load_config`` warns when no config file exists, which is noise for
+    ``vip cleanup`` when the user passes URLs explicitly and has no
+    ``vip.toml``. This loads the file only when it actually exists; otherwise
+    it returns a default ``VIPConfig`` whose ``__post_init__`` still picks up
+    env-based credentials (``VIP_TEST_USERNAME``/``VIP_TEST_PASSWORD``,
+    ``VIP_WORKBENCH_API_KEY``, etc.).
+    """
+    from vip.config import VIPConfig, load_config
+
+    env = os.environ.get("VIP_CONFIG")
+    path = Path(env) if env else Path("vip.toml")
+    if path.exists():
+        return load_config()
+    return VIPConfig()
 
 
 def run_cleanup(args: argparse.Namespace) -> None:
@@ -939,18 +958,15 @@ def run_cleanup(args: argparse.Namespace) -> None:
     api_key = getattr(args, "api_key", None) or os.environ.get("VIP_CONNECT_API_KEY", "")
     workbench_url = getattr(args, "workbench_url", None)
 
-    # Fall back to vip.toml for whichever URL(s) weren't passed on the CLI, so
-    # `vip cleanup --connect-url ...` (or --workbench-url) runs without a
-    # "config not found" warning when only one product is being cleaned up.
-    config: VIPConfig | None = None
-    if not connect_url or not workbench_url:
-        from vip.config import load_config
-
-        config = load_config()
-        if not connect_url and config.connect and config.connect.url:
-            connect_url = config.connect.url
-        if not workbench_url and config.workbench and config.workbench.url:
-            workbench_url = config.workbench.url
+    # Load vip.toml when present to fill in any URL not passed on the CLI, and
+    # to supply TLS/auth settings for the Workbench path. Loaded quietly: an
+    # explicit `vip cleanup --connect-url ...` with no vip.toml must not emit a
+    # "Config file not found" warning (env-based credentials still apply).
+    config = _load_cleanup_config()
+    if not connect_url and config.connect and config.connect.url:
+        connect_url = config.connect.url
+    if not workbench_url and config.workbench and config.workbench.url:
+        workbench_url = config.workbench.url
 
     if not connect_url and not workbench_url:
         print(
@@ -969,10 +985,6 @@ def run_cleanup(args: argparse.Namespace) -> None:
         print(f"Deleted {deleted} VIP test content item(s)")
 
     if workbench_url:
-        if config is None:
-            from vip.config import load_config
-
-            config = load_config()
         _cleanup_workbench_sessions(workbench_url, args, config)
 
     print("Cleanup completed successfully")

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -83,6 +83,31 @@ class WorkbenchClient(BaseClient):
             return resp.json()
         return []
 
+    def count_vip_sessions(self) -> int:
+        """Count VIP-named sessions currently listed, or ``-1`` if undeterminable.
+
+        Returns the number of sessions matching :func:`is_vip_session`
+        (``0`` when the list genuinely holds none), or ``-1`` when the count
+        cannot be determined — a transport error, a non-200, or a body that is
+        not a JSON ``list`` (e.g. a ``200`` HTML/SPA fallback or an error
+        object).  Callers use the ``-1`` "unknown" signal to escalate cleanup
+        defensively rather than mistake an unparseable response for "clean"
+        (which would suppress the UI sweep and re-orphan sessions — issue #467).
+        Never raises.
+        """
+        try:
+            resp = self._client.get("/api/sessions")
+            if resp.status_code != 200:
+                return -1
+            sessions = resp.json()
+        except Exception:
+            return -1
+        if not isinstance(sessions, list):
+            return -1
+        return sum(
+            1 for s in sessions if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
+        )
+
     def sessions_api_reachable(self) -> bool:
         """Return True only if ``/api/sessions`` returns a usable session list.
 

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -6,6 +6,7 @@ APIs than Connect, so many checks are done via the web UI with Playwright.
 
 from __future__ import annotations
 
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,8 @@ from typing import Any
 import httpx
 
 from vip.clients.base import BaseClient
+
+logger = logging.getLogger(__name__)
 
 _VIP_SESSION_PREFIXES = ("VIP ", "_vip_")
 
@@ -128,8 +131,19 @@ class WorkbenchClient(BaseClient):
 
         Authentication uses whatever this client already carries (cookies set
         via :meth:`set_cookies`, or an API-key Authorization header).
+
+        :meth:`quit_session` treats any HTTP status below 400 as success
+        without confirming the session actually terminated — some
+        deployments accept the DELETE/suspend call but leave the session
+        running (issue #467).  If the retry loop runs out its full budget
+        without ever observing an empty listing (i.e. VIP sessions were still
+        listed on the final attempt), a ``WARNING`` is logged naming the
+        labels/ids still present so the leak is visible instead of silent.
+        No warning is logged when a listing already confirmed nothing
+        remains (the loop exited via the "no targets" break).
         """
         quit_ids: set[str] = set()
+        exhausted_with_targets = False
         for attempt in range(retries):
             try:
                 resp = self._client.get("/api/sessions")
@@ -153,4 +167,38 @@ class WorkbenchClient(BaseClient):
                     quit_ids.add(str(sid))
             if attempt < retries - 1:
                 time.sleep(settle_seconds)
+            exhausted_with_targets = attempt == retries - 1
+        if exhausted_with_targets:
+            self._warn_if_vip_sessions_remain()
         return len(quit_ids)
+
+    def _warn_if_vip_sessions_remain(self) -> None:
+        """Log a WARNING naming any VIP session still listed right now.
+
+        Called after :meth:`quit_vip_sessions` exhausts its retries with VIP
+        sessions still present on the last listing, so a session that quietly
+        survived every quit attempt is surfaced loudly instead of the caller
+        just getting back a count.  Best-effort: swallows all exceptions and
+        never raises.
+        """
+        try:
+            resp = self._client.get("/api/sessions")
+            sessions = resp.json() if resp.status_code == 200 else []
+        except Exception:
+            return
+        if not isinstance(sessions, list):
+            return
+        remaining = [
+            s for s in sessions if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
+        ]
+        if not remaining:
+            return
+        details = ", ".join(
+            f"{s.get('label')!r} (id={s.get('id') or s.get('session_id') or '?'})"
+            for s in remaining
+        )
+        logger.warning(
+            "quit_vip_sessions: %d VIP-named Workbench session(s) still present after cleanup: %s",
+            len(remaining),
+            details,
+        )

--- a/src/vip/workbench_ui.py
+++ b/src/vip/workbench_ui.py
@@ -26,11 +26,20 @@ evolves.
 
 from __future__ import annotations
 
+import logging
+import re
+
 from playwright.sync_api import Page
 
 from vip.clients.workbench import is_vip_session
 from vip.timeouts import timeout_scale
-from vip_tests.workbench.pages import Homepage
+from vip_tests.workbench.pages import Homepage, LoginPage
+
+logger = logging.getLogger(__name__)
+
+# Substrings that mark a Workbench login / IdP URL (mirrors the private
+# _LOGIN_KEYWORDS in vip_tests.workbench.conftest).
+_LOGIN_URL_KEYWORDS = ("sign-in", "login", "auth")
 
 # Mirrors the scaled timeout constants defined in
 # vip_tests/workbench/conftest.py.  Duplicated (not imported) so this module
@@ -61,6 +70,78 @@ def vip_names_from_select_labels(labels: list[str]) -> list[str]:
     return names
 
 
+def _complete_sso_if_needed(page: Page) -> bool:
+    """Reach the authenticated homepage, completing a silent OIDC SSO if needed.
+
+    On an OIDC-fronted Workbench, loading saved storage state and navigating to
+    the site does not land on the homepage: Workbench redirects to its sign-in
+    page, which (rather than auto-redirecting to the IdP) renders a "Sign in
+    with OpenID" button.  Clicking it completes a silent SSO round-trip using
+    the IdP cookies already in the browser context, landing on the
+    authenticated homepage with no credentials required.  This is the same
+    mechanism ``vip_tests.workbench.conftest.workbench_login`` uses under
+    ``--interactive-auth``; reusing it lets ``vip cleanup --workbench-url``
+    authenticate the same way the session-launching tests did (issue #467).
+
+    Returns True when the authenticated homepage is loaded (it already was, or
+    the SSO click succeeded), False when authentication could not be
+    established (e.g. a password form with no username we can fill, or the IdP
+    session itself has expired).  Best-effort: never raises.
+    """
+    logo = page.locator(Homepage.POSIT_LOGO)
+    try:
+        if logo.is_visible():
+            return True  # already authenticated (e.g. the in-test page)
+    except Exception:
+        pass
+    try:
+        if not any(kw in page.url.lower() for kw in _LOGIN_URL_KEYWORDS):
+            return False  # not on a login page, but no homepage either
+    except Exception:
+        return False
+    # The OIDC sign-in page renders a "Sign in with OpenID" button. Wait briefly
+    # so a slow sign-in page is detected reliably rather than raced.
+    try:
+        sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
+        sso_button.wait_for(state="visible", timeout=TIMEOUT_QUICK)
+    except Exception:
+        return False
+    # A username field means this is a password form, not silent SSO -- nothing
+    # we can complete headlessly, so don't click a blank submit.
+    try:
+        if page.locator(LoginPage.USERNAME).is_visible():
+            return False
+    except Exception:
+        pass
+    try:
+        sso_button.click()
+        logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+        return True
+    except Exception:
+        return False  # no valid IdP session to complete SSO silently
+
+
+def _wait_for_session_list(page: Page) -> None:
+    """Wait for the client-rendered session table before enumerating rows.
+
+    The 2026.05+ homepage is a shadcn SPA that fetches and paints the session
+    list *after* the page ``load`` event fires, so enumerating the row
+    checkboxes immediately after ``goto``/``reload`` can see zero rows even
+    when sessions exist -- which made the UI sweep silently no-op and orphan
+    sessions (issue #467).  Wait first for the homepage shell (the New Session
+    button, present regardless of session count -- this is the same readiness
+    signal ``assert_homepage_loaded`` uses), then for the first session-row
+    checkbox.  If no checkbox appears within the window the homepage is
+    genuinely empty (or still loading), so return quietly and let the caller
+    enumerate zero.  Best-effort: never raises.
+    """
+    for selector in (Homepage.NEW_SESSION_BUTTON, "[aria-label^='select ']"):
+        try:
+            page.locator(selector).first.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+        except Exception:
+            pass
+
+
 def quit_vip_sessions_via_ui(page: Page, base_url: str, *, max_iterations: int = 10) -> int:
     """Quit orphaned VIP-named sessions through the homepage UI.
 
@@ -77,8 +158,23 @@ def quit_vip_sessions_via_ui(page: Page, base_url: str, *, max_iterations: int =
     across iterations is counted once, not per attempt).
     """
     quit_names: set[str] = set()
+    first_rows: int | None = None
+    first_vip: int | None = None
     try:
-        page.goto(base_url.rstrip("/") + "/home", wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
+        # The session list lives on the homepage at the site root (same URL the
+        # tests use via ``page.goto(workbench_url)``), NOT at ``/home`` -- on WB
+        # 2026.06 ``/home`` does not render the session table, so the sweep saw
+        # zero rows and orphaned sessions (issue #467).
+        page.goto(base_url.rstrip("/"), wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
+        if not _complete_sso_if_needed(page):
+            logger.warning(
+                "UI cleanup at %s: could not reach an authenticated homepage "
+                "(Workbench redirected to its OIDC sign-in page and the cached session "
+                "could not silently complete SSO -- it may have expired). Quit 0 sessions.",
+                base_url,
+            )
+            return 0
+        _wait_for_session_list(page)
         for _ in range(max_iterations):
             checkboxes = page.locator("[aria-label^='select ']")
             labels = [
@@ -86,6 +182,11 @@ def quit_vip_sessions_via_ui(page: Page, base_url: str, *, max_iterations: int =
                 for i in range(checkboxes.count())
             ]
             vip_names = vip_names_from_select_labels(labels)
+            # Record the state on the first pass so the closing summary can
+            # report what the sweep actually saw (and whether it cleared it).
+            if first_rows is None:
+                first_rows = len(labels)
+                first_vip = len(vip_names)
             if not vip_names:
                 break
             selected: list[str] = []
@@ -93,13 +194,19 @@ def quit_vip_sessions_via_ui(page: Page, base_url: str, *, max_iterations: int =
                 try:
                     page.locator(Homepage.session_checkbox(name)).first.click(timeout=TIMEOUT_QUICK)
                     selected.append(name)
-                except Exception:
+                except Exception as exc:
+                    logger.warning(
+                        "UI cleanup: could not select session %r at %s: %s", name, base_url, exc
+                    )
                     continue
             if not selected:
                 break
             try:
                 page.locator(Homepage.QUIT_BUTTON).first.click(timeout=TIMEOUT_QUICK)
-            except Exception:
+            except Exception as exc:
+                logger.warning(
+                    "UI cleanup: could not click the Quit button at %s: %s", base_url, exc
+                )
                 break
             # Confirm/force-quit dialogs are optional -- a normal quit completes
             # without them (see session_cleaned_up). Probe each within a short
@@ -119,8 +226,33 @@ def quit_vip_sessions_via_ui(page: Page, base_url: str, *, max_iterations: int =
             quit_names.update(selected)
             try:
                 page.reload(wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
-            except Exception:
+            except Exception as exc:
+                logger.warning("UI cleanup: could not reload %s after quitting: %s", base_url, exc)
                 break
-    except Exception:
-        pass
+            _complete_sso_if_needed(page)  # a reload can bounce back to sign-in
+            _wait_for_session_list(page)
+    except Exception as exc:
+        logger.warning("UI cleanup at %s failed before completing: %s", base_url, exc)
+    # One always-visible summary so the sweep is never a silent black box.
+    if first_rows == 0:
+        logger.info(
+            "UI cleanup at %s: no VIP session rows were visible; nothing to quit.",
+            base_url,
+        )
+    elif first_vip and len(quit_names) < first_vip:
+        logger.warning(
+            "UI cleanup at %s: found %d VIP session(s) across %d visible row(s) but only "
+            "confirmed %d quit; some may still be running.",
+            base_url,
+            first_vip,
+            first_rows,
+            len(quit_names),
+        )
+    else:
+        logger.info(
+            "UI cleanup at %s: quit %d VIP session(s) (%s row(s) visible).",
+            base_url,
+            len(quit_names),
+            first_rows if first_rows is not None else "?",
+        )
     return len(quit_names)

--- a/src/vip/workbench_ui.py
+++ b/src/vip/workbench_ui.py
@@ -1,0 +1,126 @@
+"""Browser-driven Workbench session-cleanup helpers.
+
+This module lives under ``src/vip/`` (rather than ``src/vip_tests/``,
+where most Playwright-driving code for Workbench lives) because
+:func:`quit_vip_sessions_via_ui` backs two callers:
+
+* ``vip_tests.workbench.conftest._cleanup_sessions`` -- the per-test/
+  end-of-run safety net that escalates to the UI when the session API
+  sweep is unreachable or leaves VIP sessions behind (issue #467).
+* ``vip cleanup --workbench-url`` (see :mod:`vip.cli`) -- a standalone CLI
+  escape hatch that runs outside of any pytest session.
+
+Keeping one implementation here means both callers share the exact same
+selection/quit/retry logic instead of drifting apart.
+
+Note: this module imports :class:`~vip_tests.workbench.pages.Homepage` from
+the ``vip_tests`` package for its session-list selectors.  ``vip_tests`` is
+shipped as part of the installed ``posit-vip`` distribution (``vip verify``
+locates it via ``importlib.util.find_spec("vip_tests")``), so this is not a
+test-only import at runtime.  The alternative -- duplicating the raw CSS/XPath
+selectors here -- was rejected because ``Homepage`` already tracks
+version-specific Workbench UI redesigns (see ``Homepage_2026_05``); a second
+copy of those selectors would silently drift out of sync as Workbench's UI
+evolves.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page
+
+from vip.clients.workbench import is_vip_session
+from vip.timeouts import timeout_scale
+from vip_tests.workbench.pages import Homepage
+
+# Mirrors the scaled timeout constants defined in
+# vip_tests/workbench/conftest.py.  Duplicated (not imported) so this module
+# has no import-time dependency on the test-fixture module; both are computed
+# from the same scaled(...) formula so the values stay numerically identical.
+TIMEOUT_QUICK = int(5_000 * timeout_scale())
+TIMEOUT_PAGE_LOAD = int(15_000 * timeout_scale())
+TIMEOUT_DIALOG_PROBE = int(1_000 * timeout_scale())
+
+_SELECT_PREFIX = "select "
+
+
+def vip_names_from_select_labels(labels: list[str]) -> list[str]:
+    """Extract VIP-named session names from session-row checkbox aria-labels.
+
+    Each homepage session row exposes a checkbox whose aria-label is
+    ``"select <session name>"``.  Returns the names (without the ``"select "``
+    prefix) that match :func:`is_vip_session`, so a real user's sessions are
+    never selected for quitting.  Input order is preserved.
+    """
+    names: list[str] = []
+    for label in labels:
+        if not label.startswith(_SELECT_PREFIX):
+            continue
+        name = label[len(_SELECT_PREFIX) :]
+        if is_vip_session(name):
+            names.append(name)
+    return names
+
+
+def quit_vip_sessions_via_ui(page: Page, base_url: str, *, max_iterations: int = 10) -> int:
+    """Quit orphaned VIP-named sessions through the homepage UI.
+
+    Fallback for deployments whose session API is unreachable (see
+    :meth:`~vip.clients.workbench.WorkbenchClient.sessions_api_reachable`) or
+    where the cookie/API sweep is a no-op (the DELETE call "succeeds" without
+    actually terminating the session -- issue #467).  Navigates to the
+    homepage, selects only VIP-named session rows (validated via
+    :func:`is_vip_session`), clicks Quit, and dismisses any
+    confirmation/force-quit dialogs, repeating until no VIP rows remain or
+    *max_iterations* is hit.  Never uses "Quit All".  Best-effort: all
+    Playwright errors are swallowed and it never raises.  Returns the number
+    of distinct VIP sessions a quit was issued for (a session that persists
+    across iterations is counted once, not per attempt).
+    """
+    quit_names: set[str] = set()
+    try:
+        page.goto(base_url.rstrip("/") + "/home", wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
+        for _ in range(max_iterations):
+            checkboxes = page.locator("[aria-label^='select ']")
+            labels = [
+                checkboxes.nth(i).get_attribute("aria-label") or ""
+                for i in range(checkboxes.count())
+            ]
+            vip_names = vip_names_from_select_labels(labels)
+            if not vip_names:
+                break
+            selected: list[str] = []
+            for name in vip_names:
+                try:
+                    page.locator(Homepage.session_checkbox(name)).first.click(timeout=TIMEOUT_QUICK)
+                    selected.append(name)
+                except Exception:
+                    continue
+            if not selected:
+                break
+            try:
+                page.locator(Homepage.QUIT_BUTTON).first.click(timeout=TIMEOUT_QUICK)
+            except Exception:
+                break
+            # Confirm/force-quit dialogs are optional -- a normal quit completes
+            # without them (see session_cleaned_up). Probe each within a short
+            # window so an absent dialog doesn't dominate runtime; if one does
+            # appear, click it with the normal timeout so a present-but-slow
+            # dialog still completes (a short click timeout could drop it).
+            for sel in (Homepage.CONFIRM_QUIT, Homepage.FORCE_QUIT, Homepage.CONFIRM_FORCE_QUIT):
+                dialog = page.locator(sel)
+                try:
+                    dialog.wait_for(state="visible", timeout=TIMEOUT_DIALOG_PROBE)
+                except Exception:
+                    continue
+                try:
+                    dialog.first.click(timeout=TIMEOUT_QUICK)
+                except Exception:
+                    pass
+            quit_names.update(selected)
+            try:
+                page.reload(wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
+            except Exception:
+                break
+    except Exception:
+        pass
+    return len(quit_names)

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -365,48 +365,50 @@ def workbench_login(
 
     # Check if we landed on a login/IdP page
     if _on_login_page(page.url):
-        if interactive_auth:
+        # The sign-in page renders client-side after ``load``; wait once for
+        # either the password form's username field or an OIDC "Sign in with ..."
+        # button to appear before deciding which flow applies. A short fixed wait
+        # on only the SSO button races the render and can misread a slow OIDC
+        # sign-in page (e.g. an ``?error=2`` bounce) as a password deployment --
+        # which then fails the retry loop with "Login failed after 3 attempts"
+        # instead of skipping. Waiting for either control settles that race
+        # without penalising real password deployments (the username field
+        # appears promptly there).
+        try:
+            page.locator(f"{LoginPage.USERNAME}, button:has-text('Sign in')").first.wait_for(
+                state="visible", timeout=TIMEOUT_PAGE_LOAD
+            )
+        except Exception:
+            pass
+
+        # An OIDC sign-in page shows a "Sign in with ..." button and no username
+        # field. The "sign in" role-name also matches a password form's submit
+        # button, so the *absence* of the username field is what distinguishes a
+        # true SSO-only page from a password form.
+        sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
+        sso_only = sso_button.is_visible() and not page.locator(LoginPage.USERNAME).is_visible()
+
+        if interactive_auth and sso_only:
             # Storage state was pre-loaded by --interactive-auth / --headless-auth.
             # Workbench's SSO sign-in page does not auto-redirect to the IdP; it
-            # renders a "Sign in with OpenID" button instead.  Clicking it triggers
-            # a silent SSO round-trip using the saved IdP cookies, landing us on the
+            # renders a "Sign in with OpenID" button.  Clicking it triggers a
+            # silent SSO round-trip using the saved IdP cookies, landing on the
             # authenticated homepage with no credentials required.
-            # Wait briefly for the SSO button to render so a slow OIDC sign-in
-            # page is detected reliably; an instant visibility check can race the
-            # page load and fall through to the password path (which then fails
-            # with "Login failed after 3 attempts" on a deployment that has no
-            # password form, e.g. the storage-state-stripped login scenario).
-            sso_button = page.get_by_role(
-                "button", name=re.compile(r"sign in", re.IGNORECASE)
-            ).first
+            sso_button.click()
             try:
-                sso_button.wait_for(state="visible", timeout=TIMEOUT_QUICK)
-                sso_visible = True
+                homepage_logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+                return  # Silent SSO succeeded
             except Exception:
-                sso_visible = False
-            # The "sign in" role-name also matches a password form's submit
-            # button, so only treat this as SSO when there is no username field.
-            # On a password deployment with stale storage state this lets us fall
-            # through to the password retry path instead of clicking an empty
-            # submit and then skipping.
-            if sso_visible and not page.locator(LoginPage.USERNAME).is_visible():
-                sso_button.click()
-                try:
-                    homepage_logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
-                    return  # Silent SSO succeeded
-                except Exception:
-                    # No pre-loaded IdP session (expired, or storage state was
-                    # stripped for the password-login test) — silent SSO can't
-                    # complete on an OIDC deployment, so skip gracefully.
-                    pytest.skip(
-                        _workbench_session_skip_message(
-                            auth_mode=auth_mode,
-                            workbench_auth_error=workbench_auth_error,
-                            landed_url=page.url,
-                        )
+                # No usable IdP session (expired, or storage state was stripped
+                # for the password-login test) — silent SSO can't complete on an
+                # OIDC deployment, so skip gracefully.
+                pytest.skip(
+                    _workbench_session_skip_message(
+                        auth_mode=auth_mode,
+                        workbench_auth_error=workbench_auth_error,
+                        landed_url=page.url,
                     )
-            # No SSO button found and interactive_auth is set — fall through to the
-            # skip below (covers non-password providers without an SSO button).
+                )
 
         if auth_provider != "password":
             pytest.skip(
@@ -418,15 +420,9 @@ def workbench_login(
             )
         # Even when auth_provider is reported as "password", the deployment may
         # actually present an SSO/OIDC sign-in page (a "Sign in with ..." button
-        # and no username field) — e.g. auth_provider was mis-detected on a
-        # config-less run.  The password login form is unavailable there, so skip
-        # rather than fail the retry loop with "Login failed after 3 attempts".
-        sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
-        try:
-            sso_button.wait_for(state="visible", timeout=TIMEOUT_QUICK)
-            sso_only = not page.locator(LoginPage.USERNAME).is_visible()
-        except Exception:
-            sso_only = False
+        # and no username field) — e.g. auth_provider defaulted to "password" on
+        # a config-less run against an OIDC deployment.  The password login form
+        # is unavailable there, so skip rather than fail the retry loop.
         if sso_only:
             pytest.skip(
                 "Workbench is configured for SSO/OIDC (no password login form); "

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -15,7 +15,7 @@ import pytest
 from playwright.sync_api import Locator, Page, expect
 from pytest_bdd import given
 
-from vip.clients.workbench import WorkbenchClient, is_vip_session
+from vip.clients.workbench import WorkbenchClient
 from vip.plugin import _auth_session_key
 from vip.timeouts import timeout_scale
 from vip.workbench_ui import (
@@ -568,12 +568,7 @@ def _vip_session_count_via_cookies(
         scratch = WorkbenchClient(base_url, insecure=insecure, ca_bundle=ca_bundle)
         try:
             scratch.set_cookies(cookies)
-            sessions = scratch.list_sessions()
-            return sum(
-                1
-                for s in sessions
-                if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
-            )
+            return scratch.count_vip_sessions()
         finally:
             scratch.close()
     except Exception:

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -5,6 +5,7 @@ Page selectors are in the pages/ subpackage
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import time
@@ -17,7 +18,18 @@ from pytest_bdd import given
 from vip.clients.workbench import WorkbenchClient, is_vip_session
 from vip.plugin import _auth_session_key
 from vip.timeouts import timeout_scale
+from vip.workbench_ui import (
+    quit_vip_sessions_via_ui as _quit_vip_sessions_via_ui,
+)
+
+# Re-exported for selftests/test_workbench_cleanup.py, which imports it from
+# here (not from vip.workbench_ui directly) to match the pre-move layout.
+from vip.workbench_ui import (
+    vip_names_from_select_labels as _vip_names_from_select_labels,  # noqa: F401
+)
 from vip_tests.workbench.pages import Homepage, LoginPage
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.workbench, pytest.mark.xdist_group("workbench")]
 
@@ -486,26 +498,6 @@ def workbench_login(
 # Shared Fixtures
 # ---------------------------------------------------------------------------
 
-_SELECT_PREFIX = "select "
-
-
-def _vip_names_from_select_labels(labels: list[str]) -> list[str]:
-    """Extract VIP-named session names from session-row checkbox aria-labels.
-
-    Each homepage session row exposes a checkbox whose aria-label is
-    ``"select <session name>"``.  Returns the names (without the ``"select "``
-    prefix) that match :func:`is_vip_session`, so a real user's sessions are
-    never selected for quitting.  Input order is preserved.
-    """
-    names: list[str] = []
-    for label in labels:
-        if not label.startswith(_SELECT_PREFIX):
-            continue
-        name = label[len(_SELECT_PREFIX) :]
-        if is_vip_session(name):
-            names.append(name)
-    return names
-
 
 def _quit_vip_sessions_via_cookies(
     base_url: str,
@@ -531,69 +523,6 @@ def _quit_vip_sessions_via_cookies(
         return 0
 
 
-def _quit_vip_sessions_via_ui(page: Page, base_url: str, *, max_iterations: int = 10) -> int:
-    """Quit orphaned VIP-named sessions through the homepage UI.
-
-    Fallback for deployments whose session API is unreachable (see
-    :meth:`WorkbenchClient.sessions_api_reachable`), where the cookie/API sweep
-    is a no-op.  Navigates to the homepage, selects only VIP-named session rows
-    (validated via :func:`is_vip_session`), clicks Quit, and dismisses any
-    confirmation/force-quit dialogs, repeating until no VIP rows remain or
-    *max_iterations* is hit.  Never uses "Quit All".  Best-effort: all
-    Playwright errors are swallowed and it never raises.  Returns the number of
-    distinct VIP sessions a quit was issued for (a session that persists across
-    iterations is counted once, not per attempt).
-    """
-    quit_names: set[str] = set()
-    try:
-        page.goto(base_url.rstrip("/") + "/home", wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
-        for _ in range(max_iterations):
-            checkboxes = page.locator("[aria-label^='select ']")
-            labels = [
-                checkboxes.nth(i).get_attribute("aria-label") or ""
-                for i in range(checkboxes.count())
-            ]
-            vip_names = _vip_names_from_select_labels(labels)
-            if not vip_names:
-                break
-            selected: list[str] = []
-            for name in vip_names:
-                try:
-                    page.locator(Homepage.session_checkbox(name)).first.click(timeout=TIMEOUT_QUICK)
-                    selected.append(name)
-                except Exception:
-                    continue
-            if not selected:
-                break
-            try:
-                page.locator(Homepage.QUIT_BUTTON).first.click(timeout=TIMEOUT_QUICK)
-            except Exception:
-                break
-            # Confirm/force-quit dialogs are optional — a normal quit completes
-            # without them (see session_cleaned_up). Probe each within a short
-            # window so an absent dialog doesn't dominate runtime; if one does
-            # appear, click it with the normal timeout so a present-but-slow
-            # dialog still completes (a short click timeout could drop it).
-            for sel in (Homepage.CONFIRM_QUIT, Homepage.FORCE_QUIT, Homepage.CONFIRM_FORCE_QUIT):
-                dialog = page.locator(sel)
-                try:
-                    dialog.wait_for(state="visible", timeout=TIMEOUT_DIALOG_PROBE)
-                except Exception:
-                    continue
-                try:
-                    dialog.first.click(timeout=TIMEOUT_QUICK)
-                except Exception:
-                    pass
-            quit_names.update(selected)
-            try:
-                page.reload(wait_until="load", timeout=TIMEOUT_PAGE_LOAD)
-            except Exception:
-                break
-    except Exception:
-        pass
-    return len(quit_names)
-
-
 def _session_api_reachable_via_cookies(
     base_url: str,
     cookies: dict[str, str],
@@ -616,6 +545,39 @@ def _session_api_reachable_via_cookies(
             scratch.close()
     except Exception:
         return False
+
+
+def _vip_session_count_via_cookies(
+    base_url: str,
+    cookies: dict[str, str],
+    *,
+    insecure: bool,
+    ca_bundle,
+) -> int:
+    """Count VIP-named sessions still listed for a cookie-authenticated client.
+
+    Mirrors :func:`_quit_vip_sessions_via_cookies` / :func:`_session_api_reachable_via_cookies`:
+    uses a scratch ``WorkbenchClient`` so the session-scoped client's cookie
+    jar is untouched.  Convention: returns ``0`` only when the list call
+    genuinely succeeded and no VIP sessions were found; returns ``-1`` when
+    the count could not be determined at all (transport error, non-200,
+    unparseable body) so callers can tell "confirmed clean" apart from
+    "unknown" and escalate defensively in the latter case.  Never raises.
+    """
+    try:
+        scratch = WorkbenchClient(base_url, insecure=insecure, ca_bundle=ca_bundle)
+        try:
+            scratch.set_cookies(cookies)
+            sessions = scratch.list_sessions()
+            return sum(
+                1
+                for s in sessions
+                if isinstance(s, dict) and is_vip_session(str(s.get("label") or ""))
+            )
+        finally:
+            scratch.close()
+    except Exception:
+        return -1
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -650,10 +612,21 @@ def _wb_cleanup_state(vip_config, workbench_client):
             pass
 
 
-@pytest.fixture(autouse=True)
-def _cleanup_sessions(page, workbench_client, vip_config, _wb_cleanup_state):
-    """Quit any VIP-named Workbench sessions created during the test."""
-    yield
+def _run_session_cleanup(page, workbench_client, vip_config, state: dict[str, object]) -> None:
+    """Quit any VIP-named Workbench sessions created during the test.
+
+    Factored out of the ``_cleanup_sessions`` fixture body so it can be unit
+    tested directly (the fixture depends on ``page``/``workbench_client``/
+    ``vip_config``/``_wb_cleanup_state``, which are awkward to construct in a
+    selftest). Runs the cookie/API sweep first, then escalates to a
+    browser-driven UI sweep (:func:`_quit_vip_sessions_via_ui`) whenever the
+    session API is unreachable *or* VIP sessions remain after the API sweep --
+    not only when the API is unreachable, since a deployment can accept the
+    DELETE/suspend call without the session actually terminating (issue #467).
+    Defensive throughout: every network/Playwright call is wrapped so cleanup
+    never raises out of the fixture; failures are logged as warnings (cleanup
+    is a safety net, not an assertion) rather than failing the test.
+    """
     if workbench_client is None:
         return
     try:
@@ -661,29 +634,67 @@ def _cleanup_sessions(page, workbench_client, vip_config, _wb_cleanup_state):
     except Exception:
         cookies = {}
     if not cookies:
+        if not vip_config.workbench.api_key:
+            logger.warning(
+                "could not authenticate to clean up Workbench sessions at %s "
+                "(no browser cookies captured and no [workbench] api_key configured); "
+                "orphaned VIP sessions may remain.",
+                workbench_client.base_url,
+            )
         return
     # Remember the latest good cookies for the end-of-run sweep.
-    _wb_cleanup_state["cookies"] = cookies
-    _wb_cleanup_state["base_url"] = workbench_client.base_url
+    state["cookies"] = cookies
+    state["base_url"] = workbench_client.base_url
     _quit_vip_sessions_via_cookies(
         workbench_client.base_url,
         cookies,
         insecure=vip_config.insecure,
         ca_bundle=vip_config.ca_bundle,
     )
-    # If the session API is unreachable on this deployment (e.g. /api/sessions
-    # 404s), the cookie/API sweep above is a no-op. Detect reachability once per
-    # session (cached on _wb_cleanup_state) and, when unavailable, fall back to a
-    # UI-driven sweep that quits orphaned VIP sessions via the homepage.
-    if _wb_cleanup_state["api_reachable"] is None:
-        _wb_cleanup_state["api_reachable"] = _session_api_reachable_via_cookies(
+    # Detect API reachability once per session (cached on state).
+    if state["api_reachable"] is None:
+        state["api_reachable"] = _session_api_reachable_via_cookies(
             workbench_client.base_url,
             cookies,
             insecure=vip_config.insecure,
             ca_bundle=vip_config.ca_bundle,
         )
-    if not _wb_cleanup_state["api_reachable"]:
+    api_reachable = bool(state["api_reachable"])
+    # Escalate to the UI sweep both when the API is unreachable (the cookie/API
+    # sweep above was necessarily a no-op) AND when the API is reachable but
+    # left VIP sessions behind (a no-op DELETE/suspend -- the actual #467 bug).
+    # -1 ("could not determine") is treated the same as "sessions remain":
+    # when in doubt, escalate rather than silently trust an unconfirmed sweep.
+    remaining = _vip_session_count_via_cookies(
+        workbench_client.base_url,
+        cookies,
+        insecure=vip_config.insecure,
+        ca_bundle=vip_config.ca_bundle,
+    )
+    if not api_reachable or remaining != 0:
         _quit_vip_sessions_via_ui(page, workbench_client.base_url)
+        # Best-effort post-escalation check, for logging only -- never blocks
+        # or fails the test.
+        still_remaining = _vip_session_count_via_cookies(
+            workbench_client.base_url,
+            cookies,
+            insecure=vip_config.insecure,
+            ca_bundle=vip_config.ca_bundle,
+        )
+        if still_remaining > 0:
+            logger.warning(
+                "%d VIP-named Workbench session(s) may still be running at %s "
+                "after the UI cleanup escalation; manual cleanup may be required.",
+                still_remaining,
+                workbench_client.base_url,
+            )
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_sessions(page, workbench_client, vip_config, _wb_cleanup_state):
+    """Quit any VIP-named Workbench sessions created during the test."""
+    yield
+    _run_session_cleanup(page, workbench_client, vip_config, _wb_cleanup_state)
 
 
 @pytest.fixture

--- a/validation_docs/demo-issue-467-session-cleanup.md
+++ b/validation_docs/demo-issue-467-session-cleanup.md
@@ -1,0 +1,120 @@
+# Fix: Workbench orphaned-session cleanup escalation (issue #467)
+
+*2026-07-15T18:41:14Z by Showboat 0.6.1*
+<!-- showboat-id: 0915325c-b729-41d8-89ae-3e21e6b99e2d -->
+
+Issue #467: VIP's Workbench product tests left orphaned sessions behind
+(named "VIP <file> - <worker>-<ns>" and "_vip_cap_<ts>_..."). Root cause: three
+layers each trusted a signal that didn't actually confirm cleanup.
+
+1. `WorkbenchClient.quit_session` treated any HTTP status below 400 as success
+   without verifying the session actually terminated -- a deployment whose
+   DELETE/suspend is a silent no-op looked "successful."
+2. The per-test `_cleanup_sessions` fixture only escalated to a browser-driven
+   UI sweep when the session API was *unreachable*. When the API was reachable
+   but its DELETE was a no-op, sessions persisted and the UI fallback never
+   fired -- the exact #467 leak.
+3. Every layer swallowed exceptions silently, so the issue report had empty logs.
+4. `vip cleanup` only cleaned Connect content; there was no out-of-band recovery
+   for orphaned Workbench sessions if `vip verify` crashed mid-run.
+
+This demo proves the fix for all four:
+- `WorkbenchClient.quit_vip_sessions` now logs a WARNING (not silence) when a
+  VIP session is still listed after exhausting its retries.
+- The per-test cleanup fixture (`_run_session_cleanup`, extracted from
+  `_cleanup_sessions` for testability) now escalates to the UI sweep whenever
+  the API is unreachable *or* VIP sessions remain after the API sweep --
+  not only when the API is unreachable.
+- `vip cleanup --workbench-url` is a new browser-driven escape hatch: it
+  authenticates (reusing a `vip verify` auth cache when available), sweeps
+  via the session API, and escalates to the same UI sweep used by the test
+  fixture.
+- The UI sweep itself (`quit_vip_sessions_via_ui`) moved to `src/vip/workbench_ui.py`
+  so both the pytest fixture and the standalone CLI command share one
+  implementation instead of drifting apart.
+
+New selftests covering Change A (loud warning on a stuck session) all pass:
+
+```bash
+uv run pytest selftests/test_workbench_cleanup.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+35 passed
+```
+
+New selftests covering Change B (per-test cleanup fixture escalation logic in _run_session_cleanup) and Change C (authenticated_page, vip cleanup CLI wiring) all pass:
+
+```bash
+uv run pytest selftests/test_auth.py selftests/test_cli_cleanup.py -q 2>&1 | grep -E '^[0-9]+ (passed|failed)' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+96 passed, 4 warnings
+```
+
+The new --workbench-url flag on vip cleanup:
+
+```bash
+uv run vip cleanup --help
+```
+
+```output
+usage: vip cleanup [-h] [--connect-url CONNECT_URL] [--api-key API_KEY]
+                   [--workbench-url WORKBENCH_URL]
+
+Delete VIP _vip_test-tagged content from Connect, and/or quit orphaned
+VIP-named Workbench sessions. At least one of --connect-url /
+--workbench-url (or the corresponding vip.toml URL) must resolve.
+
+  vip cleanup --connect-url https://connect.example.com
+  vip cleanup --workbench-url https://workbench.example.com
+
+options:
+  -h, --help            show this help message and exit
+  --connect-url CONNECT_URL
+                        Connect server URL (falls back to vip.toml if omitted)
+  --api-key API_KEY     Connect API key (default: VIP_CONNECT_API_KEY env var)
+  --workbench-url WORKBENCH_URL
+                        Workbench server URL (falls back to vip.toml if
+                        omitted). Quits orphaned VIP-named sessions via the
+                        session API, escalating to a browser-driven UI sweep
+                        if the API is unreachable or sessions persist.
+                        Requires VIP_TEST_USERNAME/VIP_TEST_PASSWORD for non-
+                        interactive auth, or an interactive browser login.
+```
+
+Lint, format, and type checks (just check covers ruff lint + format; mypy run separately):
+
+```bash
+just check
+```
+
+```output
+uv run ruff check src/ selftests/ examples/ docker/
+All checks passed!
+uv run ruff format --check src/ selftests/ examples/ docker/
+159 files already formatted
+```
+
+Type checking (mypy, run in CI as a separate job):
+
+```bash
+uv run mypy src/vip/
+```
+
+```output
+src/vip/load_users.py:124: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
+src/vip/load_users.py:125: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
+Success: no issues found in 29 source files
+```
+
+Full selftest suite (excluding selftests/test_load_engine.py, which has 2 known timing-flaky tests unrelated to this change -- see CLAUDE.md):
+
+```bash
+uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -E '^[0-9]+ (passed|failed)' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+922 passed, 26 warnings
+```

--- a/validation_docs/demo-issue-467-session-cleanup.md
+++ b/validation_docs/demo-issue-467-session-cleanup.md
@@ -94,7 +94,7 @@ just check
 uv run ruff check src/ selftests/ examples/ docker/
 All checks passed!
 uv run ruff format --check src/ selftests/ examples/ docker/
-159 files already formatted
+160 files already formatted
 ```
 
 Type checking (mypy, run in CI as a separate job):
@@ -116,5 +116,5 @@ uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -
 ```
 
 ```output
-937 passed, 22 warnings
+940 passed, 22 warnings
 ```

--- a/validation_docs/demo-issue-467-session-cleanup.md
+++ b/validation_docs/demo-issue-467-session-cleanup.md
@@ -40,7 +40,7 @@ uv run pytest selftests/test_workbench_cleanup.py -q 2>&1 | grep -E 'passed|fail
 ```
 
 ```output
-35 passed
+41 passed
 ```
 
 New selftests covering Change B (per-test cleanup fixture escalation logic in _run_session_cleanup) and Change C (authenticated_page, vip cleanup CLI wiring) all pass:
@@ -50,7 +50,7 @@ uv run pytest selftests/test_auth.py selftests/test_cli_cleanup.py -q 2>&1 | gre
 ```
 
 ```output
-96 passed, 4 warnings
+98 passed
 ```
 
 The new --workbench-url flag on vip cleanup:
@@ -116,5 +116,5 @@ uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -
 ```
 
 ```output
-922 passed, 26 warnings
+930 passed, 22 warnings
 ```

--- a/validation_docs/demo-issue-467-session-cleanup.md
+++ b/validation_docs/demo-issue-467-session-cleanup.md
@@ -40,7 +40,7 @@ uv run pytest selftests/test_workbench_cleanup.py -q 2>&1 | grep -E 'passed|fail
 ```
 
 ```output
-41 passed
+48 passed
 ```
 
 New selftests covering Change B (per-test cleanup fixture escalation logic in _run_session_cleanup) and Change C (authenticated_page, vip cleanup CLI wiring) all pass:
@@ -116,5 +116,5 @@ uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -
 ```
 
 ```output
-930 passed, 22 warnings
+937 passed, 22 warnings
 ```


### PR DESCRIPTION
Fixes #467.

## Root cause
VIP creates Workbench sessions by driving the UI with Playwright, but the
in-test cleanup's primary path is the HTTP session API. `quit_session`
treated any `status < 400` as success without verifying the session actually
terminated, and the UI sweep only ran when the session API was *unreachable*.
So when a deployment accepted the `DELETE`/`suspend` but left the session
running, cleanup reported success, the UI escalation never fired, and the
sessions leaked — silently, since every layer swallowed its exceptions and
logged nothing. If `vip verify` itself crashed mid-run, no fixture teardown
ran at all and there was no out-of-band recovery (`vip cleanup` was
Connect-only).

## Fix
- **Escalate to the UI sweep whenever the API sweep leaves sessions behind**,
  not only when the API is unreachable (`_cleanup_sessions`, refactored into a
  directly-testable `_run_session_cleanup`).
- **Make failures loud**: `quit_vip_sessions` logs a `WARNING` naming any VIP
  session still present after its retries; `count_vip_sessions` returns `-1`
  ("unknown") on any uncertain response so an unparseable API reply can never
  be mistaken for "clean" and suppress escalation.
- **New `vip cleanup --workbench-url`**: an out-of-band escape hatch that
  authenticates cache-aware, sweeps via the API first, then escalates to the
  browser UI. Recovers orphans left by an interrupted run.
- Shared the UI-sweep logic in a new `src/vip/workbench_ui.py` so the fixture
  and the CLI use one implementation.

## Live validation against Workbench 2026.06 (OIDC-fronted)
Validating end-to-end against a real OIDC-fronted Workbench `2026.06.0` (rather
than trusting green CI) surfaced three further real defects in the UI sweep —
all of which had made it silently no-op and orphan sessions:

1. **Wrong URL** — the sweep navigated to `/home`, which renders no session
   table on 2026.06. It now loads the site **root**, the same URL the tests use.
2. **SPA render race** — the shadcn homepage paints the session list *after* the
   `load` event, so enumeration saw zero rows. It now **waits for the New
   Session shell and the session rows** before enumerating.
3. **OIDC auth** — the CLI's headless browser reused saved storage-state but
   never completed the SSO handshake, landing on the "Sign in with OpenID" page.
   It now **clicks "Sign in with OpenID"** to complete a silent SSO (the same
   mechanism `workbench_login` uses under `--interactive-auth`).

The sweep is also no longer a silent black box — it logs what it saw and quit,
and `vip cleanup` routes `vip.*` logs to stderr. Confirmed on `dev.demo`:
`vip cleanup --workbench-url …` now completes SSO, finds the sessions, and quits
them.

## Demo
See `validation_docs/demo-issue-467-session-cleanup.md`.
