### PR TITLE
fix(report): render from any directory and add badge styling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,13 @@ packages = ["src/vip", "src/vip_tests"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "examples/cross_product_validation" = "vip/_scaffold/cross_product_validation"
+# Quarto report templates so `vip report` works when installed as a wheel,
+# not only from a source checkout. Copied into the working ./report dir by
+# run_report(). Keep this list in sync with cli._REPORT_TEMPLATE_FILES.
+"report/index.qmd" = "vip/_report/index.qmd"
+"report/details.qmd" = "vip/_report/details.qmd"
+"report/_quarto.yml" = "vip/_report/_quarto.yml"
+"report/styles.css" = "vip/_report/styles.css"
 
 [tool.pytest.ini_options]
 testpaths = ["src/vip_tests"]

--- a/report/.gitignore
+++ b/report/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/report/_quarto.yml
+++ b/report/_quarto.yml
@@ -16,3 +16,4 @@ format:
     theme: cosmo
     toc: true
     code-fold: true
+    css: styles.css

--- a/report/details.qmd
+++ b/report/details.qmd
@@ -17,24 +17,29 @@ from pathlib import Path
 from IPython.display import HTML, Markdown, display
 
 from vip.gherkin import parse_feature_file
-from vip.reporting import load_results, load_troubleshooting
+from vip.reporting import (
+    feature_file_for_nodeid,
+    load_results,
+    load_troubleshooting,
+    troubleshooting_path,
+)
 
 data = load_results(Path("results.json"))
-hints = load_troubleshooting(Path("../src/vip_tests/troubleshooting.toml"))
+_tp = troubleshooting_path()
+hints = load_troubleshooting(_tp) if _tp else {}
 
 _feature_cache: dict[str, dict] = {}
 
 
 def _get_feature(nodeid: str) -> dict | None:
-    py_file = nodeid.split("::")[0] if "::" in nodeid else nodeid
-    feature_file = py_file.rsplit(".", 1)[0] + ".feature"
-    if feature_file not in _feature_cache:
-        p = Path("..") / feature_file
-        if p.exists():
-            _feature_cache[feature_file] = parse_feature_file(p)
+    feature_file = feature_file_for_nodeid(nodeid)
+    key = str(feature_file) if feature_file else nodeid
+    if key not in _feature_cache:
+        if feature_file is not None:
+            _feature_cache[key] = parse_feature_file(feature_file)
         else:
-            _feature_cache[feature_file] = {}
-    return _feature_cache[feature_file] or None
+            _feature_cache[key] = {}
+    return _feature_cache[key] or None
 
 
 def _get_steps(item) -> list[str]:

--- a/report/index.qmd
+++ b/report/index.qmd
@@ -74,23 +74,27 @@ from html import escape as _esc
 from IPython.display import HTML
 
 from vip.gherkin import parse_feature_file
-from vip.reporting import load_troubleshooting
+from vip.reporting import (
+    feature_file_for_nodeid,
+    load_troubleshooting,
+    troubleshooting_path,
+)
 
-_hints = load_troubleshooting(Path("../src/vip_tests/troubleshooting.toml"))
+_tp = troubleshooting_path()
+_hints = load_troubleshooting(_tp) if _tp else {}
 _feature_cache: dict[str, dict] = {}
 _error_idx = 0
 
 
 def _get_feature(nodeid: str) -> dict | None:
-    py_file = nodeid.split("::")[0] if "::" in nodeid else nodeid
-    feature_file = py_file.rsplit(".", 1)[0] + ".feature"
-    if feature_file not in _feature_cache:
-        p = Path("..") / feature_file
-        if p.exists():
-            _feature_cache[feature_file] = parse_feature_file(p)
+    feature_file = feature_file_for_nodeid(nodeid)
+    key = str(feature_file) if feature_file else nodeid
+    if key not in _feature_cache:
+        if feature_file is not None:
+            _feature_cache[key] = parse_feature_file(feature_file)
         else:
-            _feature_cache[feature_file] = {}
-    return _feature_cache[feature_file] or None
+            _feature_cache[key] = {}
+    return _feature_cache[key] or None
 
 
 def _get_steps(item) -> list[str]:

--- a/report/styles.css
+++ b/report/styles.css
@@ -1,0 +1,40 @@
+/* Shared styles for the VIP Quarto report.
+   Product/category badges rendered by index.qmd and details.qmd reference the
+   .badge-* classes below (see _PRODUCT_BADGE_CSS in those files). Keeping them
+   here — loaded via _quarto.yml's format.html.css — means both pages share one
+   definition instead of duplicating it in each inline <style> block. */
+
+/* Product badges */
+.badge-connect,
+.badge-workbench,
+.badge-package-manager,
+.badge-security,
+.badge-prerequisites {
+  display: inline-block;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75em;
+  font-weight: 600;
+  margin-left: 6px;
+}
+
+.badge-connect {
+  background-color: #447099;
+}
+
+.badge-workbench {
+  background-color: #72994e;
+}
+
+.badge-package-manager {
+  background-color: #9a4665;
+}
+
+.badge-security {
+  background-color: #d4526e;
+}
+
+.badge-prerequisites {
+  background-color: #6c757d;
+}

--- a/selftests/test_cli_report.py
+++ b/selftests/test_cli_report.py
@@ -1,0 +1,157 @@
+"""Tests for the ``vip report`` subcommand (run_report in vip.cli).
+
+These cover the fix that lets ``vip report`` render from any working
+directory (not just a source checkout): the Quarto templates are bundled in
+the wheel and copied into the working ``report/`` dir, and the command fails
+loudly instead of silently producing nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import types
+
+import pytest
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    defaults = {"results": "report/results.json", "open": False}
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _fake_quarto(create_output: bool):
+    """Return a subprocess.run stand-in that fakes a quarto render.
+
+    When ``create_output`` is true it writes the index.html that a real
+    render would produce, so run_report's success path can be exercised
+    without Quarto installed.
+    """
+
+    def _run(cmd, cwd=None, **kwargs):
+        if create_output and cwd is not None:
+            from pathlib import Path
+
+            out = Path(cwd) / "_output"
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "index.html").write_text("<html>report</html>")
+        return types.SimpleNamespace(returncode=0)
+
+    return _run
+
+
+class TestEnsureReportTemplates:
+    """_ensure_report_templates populates a working directory from a checkout/wheel."""
+
+    def test_copies_template_files_into_empty_dir(self, tmp_path):
+        from vip.cli import _REPORT_TEMPLATE_FILES, _ensure_report_templates
+
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+
+        assert _ensure_report_templates(report_dir) is True
+        for name in _REPORT_TEMPLATE_FILES:
+            assert (report_dir / name).is_file(), f"missing {name}"
+
+    def test_styles_css_has_badge_rules(self, tmp_path):
+        from vip.cli import _ensure_report_templates
+
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+        _ensure_report_templates(report_dir)
+
+        assert ".badge-connect" in (report_dir / "styles.css").read_text()
+
+
+class TestRunReportFromArbitraryDir:
+    """run_report works from a directory that is not a source checkout."""
+
+    def test_renders_report_when_results_present(self, tmp_path, monkeypatch, capsys):
+        from vip import cli
+
+        monkeypatch.chdir(tmp_path)
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+        (report_dir / "results.json").write_text('{"results": []}')
+        monkeypatch.setattr(cli.subprocess, "run", _fake_quarto(create_output=True))
+
+        cli.run_report(_make_args())
+
+        assert (report_dir / "index.qmd").is_file()
+        assert (report_dir / "_output" / "index.html").is_file()
+        assert "Report generated" in capsys.readouterr().out
+
+    def test_errors_when_render_produces_no_output(self, tmp_path, monkeypatch, capsys):
+        from vip import cli
+
+        monkeypatch.chdir(tmp_path)
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+        (report_dir / "results.json").write_text('{"results": []}')
+        # quarto "succeeds" but writes nothing — the old bug rendered silently.
+        monkeypatch.setattr(cli.subprocess, "run", _fake_quarto(create_output=False))
+
+        with pytest.raises(SystemExit) as exc:
+            cli.run_report(_make_args())
+
+        assert exc.value.code == 1
+        assert "no report was produced" in capsys.readouterr().err
+
+    def test_errors_when_results_missing(self, tmp_path, monkeypatch, capsys):
+        from vip import cli
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(cli.subprocess, "run", _fake_quarto(create_output=True))
+
+        with pytest.raises(SystemExit) as exc:
+            cli.run_report(_make_args(results=str(tmp_path / "nope.json")))
+
+        assert exc.value.code == 1
+        assert "results file not found" in capsys.readouterr().err
+
+
+class TestSupportFileResolution:
+    """troubleshooting.toml and feature files resolve from checkout or install."""
+
+    def test_troubleshooting_path_resolves(self):
+        from vip.reporting import troubleshooting_path
+
+        p = troubleshooting_path()
+        assert p is not None and p.exists()
+        assert p.name == "troubleshooting.toml"
+
+    def test_feature_file_for_nodeid_resolves_installed_layout(self):
+        from vip.reporting import feature_file_for_nodeid
+
+        nodeid = "/opt/x/site-packages/vip_tests/connect/test_auth.py::test_connect_login_ui"
+        p = feature_file_for_nodeid(nodeid)
+        assert p is not None and p.exists()
+        assert p.name == "test_auth.feature"
+
+    def test_feature_file_for_nodeid_returns_none_when_absent(self):
+        from vip.reporting import feature_file_for_nodeid
+
+        assert feature_file_for_nodeid("vip_tests/nope/test_missing.py::test_x") is None
+
+
+class TestReportCLI:
+    """``vip report`` is wired into the CLI."""
+
+    def test_report_in_cli_help(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "vip.cli", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert "report" in result.stdout
+
+    def test_report_subcommand_help(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "vip.cli", "report", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--results" in result.stdout

--- a/selftests/test_cli_report.py
+++ b/selftests/test_cli_report.py
@@ -9,9 +9,11 @@ loudly instead of silently producing nothing.
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
@@ -40,6 +42,25 @@ def _fake_quarto(create_output: bool):
         return types.SimpleNamespace(returncode=0)
 
     return _run
+
+
+def _fake_bundled_templates(monkeypatch, tmp_path) -> Path:
+    """Point importlib.resources at a fake installed ``vip/_report`` directory.
+
+    Selftests run from an editable install where the wheel bundle does not
+    exist, so tests of the bundled-refresh path fake one on disk.
+    """
+    import importlib.resources
+
+    from vip.cli import _REPORT_TEMPLATE_FILES
+
+    pkg_root = tmp_path / "installed-vip"
+    bundled = pkg_root / "_report"
+    bundled.mkdir(parents=True)
+    for name in _REPORT_TEMPLATE_FILES:
+        (bundled / name).write_text(f"packaged {name}\n")
+    monkeypatch.setattr(importlib.resources, "files", lambda pkg: pkg_root)
+    return bundled
 
 
 class TestEnsureReportTemplates:
@@ -76,6 +97,75 @@ class TestEnsureReportTemplates:
         for name in _REPORT_TEMPLATE_FILES:
             (report_dir / name).write_text("x")
         assert _has_all_report_templates(report_dir) is True
+
+    def test_pyproject_force_include_matches_template_list(self):
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            import tomli as tomllib
+
+        from vip.cli import _REPORT_TEMPLATE_FILES
+
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+        force_include = data["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+
+        expected = {f"report/{name}": f"vip/_report/{name}" for name in _REPORT_TEMPLATE_FILES}
+        bundled = {s: d for s, d in force_include.items() if d.startswith("vip/_report/")}
+        assert bundled == expected
+
+
+class TestTemplateRefresh:
+    """The bundled-template refresh is loud about overwrites and skips identical files."""
+
+    def test_customized_template_is_refreshed_with_notice(self, tmp_path, monkeypatch, capsys):
+        from vip.cli import _ensure_report_templates
+
+        _fake_bundled_templates(monkeypatch, tmp_path)
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+        _ensure_report_templates(report_dir)
+        capsys.readouterr()
+        (report_dir / "styles.css").write_text("custom user styles\n")
+
+        assert _ensure_report_templates(report_dir) is True
+
+        assert (report_dir / "styles.css").read_text() == "packaged styles.css\n"
+        assert "styles.css" in capsys.readouterr().err
+
+    def test_unchanged_templates_are_not_rewritten(self, tmp_path, monkeypatch, capsys):
+        from vip.cli import _REPORT_TEMPLATE_FILES, _ensure_report_templates
+
+        _fake_bundled_templates(monkeypatch, tmp_path)
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+        _ensure_report_templates(report_dir)
+        sentinel = 946684800  # 2000-01-01, distinct from any freshly written mtime
+        for name in _REPORT_TEMPLATE_FILES:
+            os.utime(report_dir / name, (sentinel, sentinel))
+
+        assert _ensure_report_templates(report_dir) is True
+
+        for name in _REPORT_TEMPLATE_FILES:
+            assert (report_dir / name).stat().st_mtime == sentinel, f"{name} was rewritten"
+        assert capsys.readouterr().err == ""
+
+    def test_bundled_lookup_oserror_falls_back_to_checkout(self, tmp_path, monkeypatch):
+        import importlib.resources
+
+        from vip.cli import _ensure_report_templates
+
+        def _raise_is_a_directory(path):
+            raise IsADirectoryError(str(path))
+
+        # as_file can raise OSError subclasses for zip-imported packages on
+        # Python < 3.12; the repo-checkout fallback must still succeed.
+        monkeypatch.setattr(importlib.resources, "as_file", _raise_is_a_directory)
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+
+        assert _ensure_report_templates(report_dir) is True
 
 
 class TestRunReportFromArbitraryDir:
@@ -123,6 +213,25 @@ class TestRunReportFromArbitraryDir:
 
         assert exc.value.code == 1
         assert "results file not found" in capsys.readouterr().err
+
+    def test_errors_when_quarto_not_installed(self, tmp_path, monkeypatch, capsys):
+        from vip import cli
+
+        monkeypatch.chdir(tmp_path)
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+        (report_dir / "results.json").write_text('{"results": []}')
+
+        def _missing_quarto(cmd, cwd=None, **kwargs):
+            raise FileNotFoundError(2, "No such file or directory", cmd[0])
+
+        monkeypatch.setattr(cli.subprocess, "run", _missing_quarto)
+
+        with pytest.raises(SystemExit) as exc:
+            cli.run_report(_make_args())
+
+        assert exc.value.code == 1
+        assert "quarto was not found" in capsys.readouterr().err
 
 
 class TestSupportFileResolution:

--- a/selftests/test_cli_report.py
+++ b/selftests/test_cli_report.py
@@ -64,6 +64,19 @@ class TestEnsureReportTemplates:
 
         assert ".badge-connect" in (report_dir / "styles.css").read_text()
 
+    def test_partial_template_set_is_not_complete(self, tmp_path):
+        from vip.cli import _REPORT_TEMPLATE_FILES, _has_all_report_templates
+
+        report_dir = tmp_path / "report"
+        report_dir.mkdir()
+        # Only one of the required files present — must not count as complete.
+        (report_dir / "index.qmd").write_text("x")
+        assert _has_all_report_templates(report_dir) is False
+
+        for name in _REPORT_TEMPLATE_FILES:
+            (report_dir / name).write_text("x")
+        assert _has_all_report_templates(report_dir) is True
+
 
 class TestRunReportFromArbitraryDir:
     """run_report works from a directory that is not a source checkout."""
@@ -145,6 +158,7 @@ class TestReportCLI:
             capture_output=True,
             text=True,
         )
+        assert result.returncode == 0
         assert "report" in result.stdout
 
     def test_report_subcommand_help(self):

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -510,26 +510,101 @@ def run_verify(args: argparse.Namespace) -> None:
             Path(temp_config).unlink(missing_ok=True)
 
 
+# Quarto report template files copied into the working report/ directory.
+# Keep in sync with the force-include block in pyproject.toml.
+_REPORT_TEMPLATE_FILES = ("index.qmd", "details.qmd", "_quarto.yml", "styles.css")
+
+
+def _copy_report_templates(src: Path, report_dir: Path) -> None:
+    import shutil
+
+    for name in _REPORT_TEMPLATE_FILES:
+        candidate = src / name
+        if candidate.is_file():
+            shutil.copy2(candidate, report_dir / name)
+
+
+def _ensure_report_templates(report_dir: Path) -> bool:
+    """Make sure the Quarto templates exist in ``report_dir``.
+
+    Prefers the copy bundled in the installed wheel (``vip/_report``),
+    refreshing ``report_dir`` from it on every run so an upgraded VIP renders
+    its current templates. Falls back to the repo's top-level ``report/`` so
+    in-repo usage and selftests work without building a wheel. Returns
+    ``True`` when templates are available, ``False`` otherwise.
+    """
+    import importlib.resources
+
+    # Bundled wheel copy: refresh templates into the working directory.
+    try:
+        bundled = importlib.resources.files("vip") / "_report"
+        with importlib.resources.as_file(bundled) as p:
+            if (p / "index.qmd").is_file():
+                _copy_report_templates(p, report_dir)
+                return True
+    except (TypeError, FileNotFoundError, ModuleNotFoundError):
+        pass
+
+    # Source checkout: three levels up from src/vip/cli.py → repo root/report.
+    repo_report = Path(__file__).parent.parent.parent / "report"
+    if (repo_report / "index.qmd").is_file():
+        if repo_report.resolve() != report_dir.resolve():
+            _copy_report_templates(repo_report, report_dir)
+        return True
+
+    # Already-populated working directory (e.g. a prior run's copy).
+    return (report_dir / "index.qmd").is_file()
+
+
 def run_report(args: argparse.Namespace) -> None:
     """Render the Quarto report from a results.json file."""
     import shutil
     import webbrowser
 
+    report_dir = Path("report")
+    report_dir.mkdir(parents=True, exist_ok=True)
+
     results_src = Path(args.results)
-    results_dest = Path("report/results.json")
+    results_dest = report_dir / "results.json"
 
     if results_src.resolve() != results_dest.resolve():
         if not results_src.exists():
             print(f"Error: results file not found: {results_src}", file=sys.stderr)
             sys.exit(1)
         shutil.copy2(results_src, results_dest)
+    elif not results_dest.exists():
+        print(
+            f"Error: no results found at {results_dest}. "
+            "Run 'vip verify' first, or pass --results PATH.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-    result = subprocess.run(["quarto", "render"], cwd="report")
+    if not _ensure_report_templates(report_dir):
+        print(
+            "Error: could not locate the VIP report templates. "
+            "Reinstall posit-vip so the bundled report is available.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-    if args.open and result.returncode == 0:
-        webbrowser.open(str(Path("report/_site/index.html").resolve()))
+    result = subprocess.run(["quarto", "render"], cwd=str(report_dir))
 
-    sys.exit(result.returncode)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+    output = report_dir / "_output" / "index.html"
+    if not output.exists():
+        print(
+            "Error: no report was produced. Ensure Quarto is installed and the "
+            "report extra is available (pip install 'posit-vip[report]').",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"Report generated: {output}")
+    if args.open:
+        webbrowser.open(output.resolve().as_uri())
 
 
 def _collect_status(config: VIPConfig) -> dict:

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -520,13 +520,27 @@ def _has_all_report_templates(directory: Path) -> bool:
     return all((directory / name).is_file() for name in _REPORT_TEMPLATE_FILES)
 
 
-def _copy_report_templates(src: Path, report_dir: Path) -> None:
+def _copy_report_templates(src: Path, report_dir: Path) -> list[str]:
+    """Copy template files from ``src``, returning names whose content changed.
+
+    Files already identical in ``report_dir`` are left untouched, and only
+    pre-existing files that were overwritten with different content are
+    reported (fresh copies into an empty directory are not).
+    """
     import shutil
 
+    replaced = []
     for name in _REPORT_TEMPLATE_FILES:
         candidate = src / name
-        if candidate.is_file():
-            shutil.copy2(candidate, report_dir / name)
+        dest = report_dir / name
+        if not candidate.is_file():
+            continue
+        if dest.is_file():
+            if dest.read_bytes() == candidate.read_bytes():
+                continue
+            replaced.append(name)
+        shutil.copy2(candidate, dest)
+    return replaced
 
 
 def _ensure_report_templates(report_dir: Path) -> bool:
@@ -539,23 +553,36 @@ def _ensure_report_templates(report_dir: Path) -> bool:
     only when *all* of ``_REPORT_TEMPLATE_FILES`` are present in ``report_dir``,
     so a partial source (e.g. a template missing from one location) is topped
     up from the other rather than silently rendering a degraded report.
+
+    Identical files are not rewritten, and a notice lists any existing files
+    that the refresh did overwrite, so local template customizations never
+    disappear silently.
     """
     import importlib.resources
 
+    replaced: list[str] = []
+
     # Bundled wheel copy: refresh templates into the working directory.
+    # OSError covers as_file() failures on zip-imported packages (< 3.12).
     try:
         bundled = importlib.resources.files("vip") / "_report"
         with importlib.resources.as_file(bundled) as p:
             if _has_all_report_templates(p):
-                _copy_report_templates(p, report_dir)
-    except (TypeError, FileNotFoundError, ModuleNotFoundError):
+                replaced += _copy_report_templates(p, report_dir)
+    except (TypeError, OSError, ModuleNotFoundError):
         pass
 
     # Source checkout: three levels up from src/vip/cli.py → repo root/report.
     if not _has_all_report_templates(report_dir):
         repo_report = Path(__file__).parent.parent.parent / "report"
         if _has_all_report_templates(repo_report) and repo_report.resolve() != report_dir.resolve():
-            _copy_report_templates(repo_report, report_dir)
+            replaced += _copy_report_templates(repo_report, report_dir)
+
+    if replaced:
+        print(
+            f"Refreshed report templates in {report_dir}: {', '.join(replaced)}",
+            file=sys.stderr,
+        )
 
     # True only if the working directory now has the complete set (from a
     # bundled/repo copy above, or from a prior run's copy already present).
@@ -594,7 +621,15 @@ def run_report(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    result = subprocess.run(["quarto", "render"], cwd=str(report_dir))
+    try:
+        result = subprocess.run(["quarto", "render"], cwd=str(report_dir))
+    except FileNotFoundError:
+        print(
+            "Error: quarto was not found on PATH. Install Quarto "
+            "(https://quarto.org/docs/get-started/) and re-run.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if result.returncode != 0:
         sys.exit(result.returncode)

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -515,6 +515,11 @@ def run_verify(args: argparse.Namespace) -> None:
 _REPORT_TEMPLATE_FILES = ("index.qmd", "details.qmd", "_quarto.yml", "styles.css")
 
 
+def _has_all_report_templates(directory: Path) -> bool:
+    """Whether ``directory`` contains every required Quarto template file."""
+    return all((directory / name).is_file() for name in _REPORT_TEMPLATE_FILES)
+
+
 def _copy_report_templates(src: Path, report_dir: Path) -> None:
     import shutil
 
@@ -530,8 +535,10 @@ def _ensure_report_templates(report_dir: Path) -> bool:
     Prefers the copy bundled in the installed wheel (``vip/_report``),
     refreshing ``report_dir`` from it on every run so an upgraded VIP renders
     its current templates. Falls back to the repo's top-level ``report/`` so
-    in-repo usage and selftests work without building a wheel. Returns
-    ``True`` when templates are available, ``False`` otherwise.
+    in-repo usage and selftests work without building a wheel. Returns ``True``
+    only when *all* of ``_REPORT_TEMPLATE_FILES`` are present in ``report_dir``,
+    so a partial source (e.g. a template missing from one location) is topped
+    up from the other rather than silently rendering a degraded report.
     """
     import importlib.resources
 
@@ -539,21 +546,20 @@ def _ensure_report_templates(report_dir: Path) -> bool:
     try:
         bundled = importlib.resources.files("vip") / "_report"
         with importlib.resources.as_file(bundled) as p:
-            if (p / "index.qmd").is_file():
+            if _has_all_report_templates(p):
                 _copy_report_templates(p, report_dir)
-                return True
     except (TypeError, FileNotFoundError, ModuleNotFoundError):
         pass
 
     # Source checkout: three levels up from src/vip/cli.py → repo root/report.
-    repo_report = Path(__file__).parent.parent.parent / "report"
-    if (repo_report / "index.qmd").is_file():
-        if repo_report.resolve() != report_dir.resolve():
+    if not _has_all_report_templates(report_dir):
+        repo_report = Path(__file__).parent.parent.parent / "report"
+        if _has_all_report_templates(repo_report) and repo_report.resolve() != report_dir.resolve():
             _copy_report_templates(repo_report, report_dir)
-        return True
 
-    # Already-populated working directory (e.g. a prior run's copy).
-    return (report_dir / "index.qmd").is_file()
+    # True only if the working directory now has the complete set (from a
+    # bundled/repo copy above, or from a prior run's copy already present).
+    return _has_all_report_templates(report_dir)
 
 
 def run_report(args: argparse.Namespace) -> None:

--- a/src/vip/reporting.py
+++ b/src/vip/reporting.py
@@ -155,6 +155,57 @@ def load_results(path: str | Path) -> ReportData:
     )
 
 
+def _installed_vip_tests_dir() -> Path | None:
+    """Return the directory of the installed ``vip_tests`` package, if any."""
+    try:
+        import vip_tests
+    except Exception:
+        return None
+    location = getattr(vip_tests, "__file__", None)
+    return Path(location).resolve().parent if location else None
+
+
+def troubleshooting_path() -> Path | None:
+    """Locate ``troubleshooting.toml`` in a source checkout or installed package.
+
+    The report templates render from a working ``report/`` directory, so a
+    source checkout is found via the repo-relative ``../src/vip_tests`` path.
+    When VIP is installed as a wheel that path does not exist, so fall back to
+    the copy shipped inside the installed ``vip_tests`` package. Returns
+    ``None`` when neither is present (the report then renders without hints).
+    """
+    repo = Path("../src/vip_tests/troubleshooting.toml")
+    if repo.exists():
+        return repo
+    pkg = _installed_vip_tests_dir()
+    if pkg is not None:
+        candidate = pkg / "troubleshooting.toml"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def feature_file_for_nodeid(nodeid: str) -> Path | None:
+    """Resolve the ``.feature`` file for a pytest nodeid.
+
+    Works both from a source checkout (repo-relative paths) and when VIP is
+    installed as a wheel (resolving inside the installed ``vip_tests``
+    package). Returns ``None`` when no matching feature file exists.
+    """
+    py_file = nodeid.split("::", 1)[0]
+    feature_rel = py_file.rsplit(".", 1)[0] + ".feature"
+    candidates = [Path("..") / feature_rel, Path(feature_rel)]
+    if "vip_tests/" in feature_rel:
+        sub = feature_rel.split("vip_tests/", 1)[1]
+        pkg = _installed_vip_tests_dir()
+        if pkg is not None:
+            candidates.append(pkg / sub)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def load_troubleshooting(path: str | Path) -> dict[str, dict]:
     """Load troubleshooting hints from a TOML file.
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -104,7 +104,7 @@ const categories = [
           <span class="step-number">3</span>
           <div>
             <h4>Review</h4>
-            <p>Generate a Quarto report with detailed results you can publish to Connect.</p>
+            <p>You can review the output from the run on the command-line or generate a Quarto report with <code>vip report</code></p>
           </div>
         </div>
       </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -104,7 +104,7 @@ const categories = [
           <span class="step-number">3</span>
           <div>
             <h4>Review</h4>
-            <p>You can review the output from the run on the command-line or generate a Quarto report with <code>vip report</code></p>
+            <p>You can review the output from the run on the command line or generate a Quarto report with <code>vip report</code>.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Two related fixes to the Quarto report, found while running `vip report`.

### 1. `vip report` produced no report when run outside a source checkout

`run_report` shelled out to `quarto render` in `./report`, but the Quarto
templates (`index.qmd`, `details.qmd`, `_quarto.yml`, `styles.css`) only exist
in a source checkout — they were not shipped in the wheel. Run from any other
directory (e.g. after `uv tool install`), `./report` held only the
`results.json` that `vip verify` wrote, so quarto found no inputs, rendered
nothing, and exited 0 — the command silently produced no report.

- Bundle the templates in the wheel (`force-include → vip/_report`), mirroring
  the existing `scaffold` pattern.
- `run_report` copies the bundled templates into the working `report/` dir
  (refreshing from the package, falling back to a repo checkout), then renders.
  It now errors loudly when the results file or templates are missing, or when
  quarto produces no output, and prints the output path. Also fixes the
  `--open` path (`_output`, not the stale `_site`).
- Resolve `troubleshooting.toml` and `.feature` files from the installed
  `vip_tests` package (with repo fallback), so troubleshooting hints and BDD
  steps render when installed, not only from a checkout.

### 2. Product/category badges rendered as unstyled text

`index.qmd` / `details.qmd` render product badges (Connect, Workbench, Package
Manager, Security, Prerequisites) with `.badge-*` CSS classes, but those
classes were never defined in any stylesheet, so every badge showed as plain
text next to the test title.

- Add `report/styles.css` with the `.badge-*` rules (Posit brand colors) and
  reference it from `_quarto.yml` so both report pages share one definition.

## Verification

- End-to-end: ran the fixed `vip report --results <results.json>` from a fresh
  temp directory (reproducing the installed-tool scenario). It produced
  `report/_output/index.html` with styled badges, the `Failed (27)` section, 7
  troubleshooting-hint blocks, and 34 feature-step procedures — hints and steps
  resolved from the installed package.
- Built the wheel and confirmed `vip/_report/{index.qmd,details.qmd,_quarto.yml,styles.css}`
  are bundled.
- Full selftest suite: 975 passed, 3 skipped. `ruff check` + `ruff format` clean.
- CI renders via `cd report && uv run quarto render` from the checkout, where
  the repo-relative paths still resolve, so the example-report preview keeps
  working (and now gets styled badges).

## Test plan

- New `selftests/test_cli_report.py` covers template bundling/copy, the
  arbitrary-directory render path, the no-output error, and support-file
  resolution.
