### PR TITLE
docs(website): refresh getting started and feature matrix content

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ be published to a Connect server.
 ## Quick start
 
 ```bash
-uv venv
-source .venv/bin/activate
-uv pip install posit-vip
-uv run vip install
+uv tool install posit-vip
+vip install
 vip verify --connect-url https://connect.example.com --interactive-auth
 ```
 
@@ -48,9 +46,11 @@ vip verify --config vip.toml
 To reverse what `vip install` (or `just setup`) did:
 
 ```bash
-uv run vip uninstall        # dry run; prints the full plan including any sudo command
-uv run vip uninstall --yes  # remove Playwright cache + manifest; prints the sudo command
-                            # for any system packages so you can remove them yourself
+vip uninstall        # dry run; prints the full plan including any sudo command
+vip uninstall --yes  # remove Playwright cache + manifest; prints the sudo command
+                     # for any system packages so you can remove them yourself
+
+uv tool uninstall posit-vip  # remove vip itself once you're done
 ```
 
 `vip uninstall` only removes packages and files that `vip install` recorded

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@
 An open-source, extensible test suite that validates Posit Team deployments are
 installed correctly and functioning properly.
 
-VIP uses **BDD-style tests** (pytest-bdd + Playwright) to verify Connect,
-Workbench, and Package Manager across standalone, Kubernetes, and Snowflake
-Native App deployments.  Results are compiled into an **HTML report** that can
-be published to a Connect server.
+VIP uses BDD-style tests (pytest-bdd + Playwright) to verify Connect,
+Workbench, and Package Manager deployments. Results can be viewed
+from the command-line runs or compiled into an HTML report.
 
 **Documentation:** https://posit-dev.github.io/vip/
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ installed correctly and functioning properly.
 
 VIP uses BDD-style tests (pytest-bdd + Playwright) to verify Connect,
 Workbench, and Package Manager deployments. Results can be viewed
-from the command-line runs or compiled into an HTML report.
+from the command-line output or compiled into an HTML report.
 
 **Documentation:** https://posit-dev.github.io/vip/
 

--- a/scripts/generate-feature-matrix.py
+++ b/scripts/generate-feature-matrix.py
@@ -232,14 +232,12 @@ def generate_matrix(tests_dir: Path, output: Path) -> dict:
 
     # Not-yet-covered areas (from issue #108).
     not_covered = [
-        {"name": "Flightdeck", "description": "Not yet available in VIP"},
         {
             "name": "LDAP/SAML/OAuth2 auth flows in CI",
             "description": "Requires identity provider setup",
         },
         {"name": "Connect scheduled content", "description": "Planned for future release"},
         {"name": "Workbench HA/multi-node", "description": "Planned for future release"},
-        {"name": "Package Manager admin UI", "description": "Planned for future release"},
     ]
 
     matrix = {

--- a/website/src/pages/feature-matrix.astro
+++ b/website/src/pages/feature-matrix.astro
@@ -157,24 +157,6 @@ const productTotalSum = Object.values(productTotals).reduce((a, b) => a + b, 0);
         </div>
       </div>
 
-      {/* Deployment environments section */}
-      <div class="host-platforms-section">
-        <h2>Deployment Environments</h2>
-        <p class="host-platforms-desc">
-          Posit Team deployment targets that VIP can verify.
-        </p>
-        <div class="host-platforms-grid">
-          <div class="host-platform-card">
-            <span class="host-platform-icon">&#10003;</span>
-            <strong>Standalone (Linux)</strong>
-          </div>
-          <div class="host-platform-card">
-            <span class="host-platform-icon">&#10003;</span>
-            <strong>Snowflake Native App</strong>
-          </div>
-        </div>
-      </div>
-
       {/* Not yet covered section */}
       <div class="not-covered-section">
         <h2>Not Yet Covered</h2>

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -341,14 +341,13 @@ extension_dirs = ["/opt/vip-custom-tests"]</code></pre>
           <h2>Uninstalling</h2>
           <p>
             When you are done with VIP, run <code>vip uninstall</code> to preview
-            what will be removed. It prints a dry-run plan &mdash; the Chromium
-            browser cache and other test artifacts &mdash; without changing
+            what will be removed. It prints a dry-run plan without changing
             anything:
           </p>
           <pre><code>vip uninstall</code></pre>
           <p>
             Pass <code>--yes</code> to remove those artifacts. On Linux, VIP does
-            not remove the system libraries it installed; instead it prints a
+            not remove the system libraries it installed and instead it prints a
             <code>sudo</code> command for you to run. Complete the uninstall in
             this order:
           </p>

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -73,8 +73,13 @@ vip verify --connect-url https://connect.example.com --api-auth</code></pre>
             on to others using not just <code>--connect-url</code> but also
             <code>--workbench-url</code> and <code>--package-manager-url</code>.
             You can also see what other options are available by reading below or
-            running <code>vip --help</code>.
+            reading the command-line help:
           </p>
+          <pre><code>vip --help</code></pre>
+          <p>
+            Whenever you are done with vip, you can easily uninstall it:
+          </p>
+          <pre><code>vip uninstall</code></pre>
         </section>
 
         <section id="authentication">

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -24,6 +24,7 @@ import Footer from "../components/Footer.astro";
           <li><a href="#running-tests">Running tests</a></li>
           <li><a href="#configuration-file">Configuration file</a></li>
           <li><a href="#generating-reports">Generating reports</a></li>
+          <li><a href="#uninstalling">Uninstalling</a></li>
           <li><a href="#extending-vip">Extending VIP</a></li>
         </ul>
       </aside>
@@ -76,16 +77,6 @@ vip verify --connect-url https://connect.example.com --api-auth</code></pre>
             reading the command-line help:
           </p>
           <pre><code>vip --help</code></pre>
-          <p>
-            Whenever you are done with vip, you can see how uninstall will go with:
-          </p>
-          <pre><code>vip uninstall</code></pre>
-          <p>
-            And then to finish the uninstall:
-          </p>
-          <pre><code>vip uninstall --yes
-uv pip uninstall posit-vip
-</code></pre>
         </section>
 
         <section id="authentication">
@@ -327,6 +318,23 @@ quarto publish connect --server https://connect.example.com</code></pre>
             <a href="https://quarto.org/docs/download/">Quarto CLI</a> must be
             installed.
           </p>
+        </section>
+
+        <section id="uninstalling">
+          <h2>Uninstalling</h2>
+          <p>
+            When you are done with VIP, preview what will be removed. By default
+            <code>vip uninstall</code> prints a dry-run plan &mdash; the Chromium
+            browser, system libraries, and other artifacts that
+            <code>vip install</code> added &mdash; without changing anything:
+          </p>
+          <pre><code>vip uninstall</code></pre>
+          <p>
+            Pass <code>--yes</code> to execute the plan, then remove the package
+            itself:
+          </p>
+          <pre><code>vip uninstall --yes
+uv pip uninstall posit-vip</code></pre>
         </section>
 
         <section id="extending-vip">

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -36,7 +36,7 @@ import Footer from "../components/Footer.astro";
             VIP verifies Posit Team across standalone deployments.
           </p>
           <p>Install VIP to start:</p>
-          <pre><code>uv pip install posit-vip
+          <pre><code>uv tool install posit-vip
 vip install</code></pre>
           <p>
             <code>vip install</code> installs Playwright's Chromium browser
@@ -353,7 +353,7 @@ extension_dirs = ["/opt/vip-custom-tests"]</code></pre>
           </p>
           <pre><code>vip uninstall --yes
 # then run the sudo removal command that vip uninstall prints, if any
-uv pip uninstall posit-vip</code></pre>
+uv tool uninstall posit-vip</code></pre>
         </section>
       </article>
     </div>

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -77,9 +77,15 @@ vip verify --connect-url https://connect.example.com --api-auth</code></pre>
           </p>
           <pre><code>vip --help</code></pre>
           <p>
-            Whenever you are done with vip, you can easily uninstall it:
+            Whenever you are done with vip, you can see how uninstall will go with:
           </p>
           <pre><code>vip uninstall</code></pre>
+          <p>
+            And then to finish the uninstall:
+          </p>
+          <pre><code>vip uninstall --yes
+uv pip uninstall posit-vip
+</code></pre>
         </section>
 
         <section id="authentication">

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -24,8 +24,8 @@ import Footer from "../components/Footer.astro";
           <li><a href="#running-tests">Running tests</a></li>
           <li><a href="#configuration-file">Configuration file</a></li>
           <li><a href="#generating-reports">Generating reports</a></li>
-          <li><a href="#uninstalling">Uninstalling</a></li>
           <li><a href="#extending-vip">Extending VIP</a></li>
+          <li><a href="#uninstalling">Uninstalling</a></li>
         </ul>
       </aside>
 
@@ -320,23 +320,6 @@ quarto publish connect --server https://connect.example.com</code></pre>
           </p>
         </section>
 
-        <section id="uninstalling">
-          <h2>Uninstalling</h2>
-          <p>
-            When you are done with VIP, preview what will be removed. By default
-            <code>vip uninstall</code> prints a dry-run plan &mdash; the Chromium
-            browser, system libraries, and other artifacts that
-            <code>vip install</code> added &mdash; without changing anything:
-          </p>
-          <pre><code>vip uninstall</code></pre>
-          <p>
-            Pass <code>--yes</code> to execute the plan, then remove the package
-            itself:
-          </p>
-          <pre><code>vip uninstall --yes
-uv pip uninstall posit-vip</code></pre>
-        </section>
-
         <section id="extending-vip">
           <h2>Extending VIP</h2>
           <p>
@@ -352,6 +335,23 @@ extension_dirs = ["/opt/vip-custom-tests"]</code></pre>
           <p>
             See <a href="https://github.com/posit-dev/vip/tree/main/examples/custom_tests"><code>examples/custom_tests/</code></a> in the repository for a working example.
           </p>
+        </section>
+
+        <section id="uninstalling">
+          <h2>Uninstalling</h2>
+          <p>
+            When you are done with VIP, preview what will be removed. By default
+            <code>vip uninstall</code> prints a dry-run plan &mdash; the Chromium
+            browser, system libraries, and other artifacts that
+            <code>vip install</code> added &mdash; without changing anything:
+          </p>
+          <pre><code>vip uninstall</code></pre>
+          <p>
+            Pass <code>--yes</code> to execute the plan, then remove the package
+            itself:
+          </p>
+          <pre><code>vip uninstall --yes
+uv pip uninstall posit-vip</code></pre>
         </section>
       </article>
     </div>

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -32,48 +32,49 @@ import Footer from "../components/Footer.astro";
         <section id="quick-start">
           <h2>Quick start</h2>
           <p>
-            VIP verifies Posit Team across standalone and Snowflake Native App
-            deployments.
+            VIP verifies Posit Team across standalone deployments.
           </p>
-          <p>Install VIP, then point it at your server:</p>
+          <p>Install VIP to start:</p>
           <pre><code>uv pip install posit-vip
-uv run vip install</code></pre>
+vip install</code></pre>
           <p>
             <code>vip install</code> installs Playwright's Chromium browser
-            and the system libraries it needs. These can be later removed safely,
-            along with other test artifacts, with <code>vip uninstall</code>
+            and the system libraries it needs. These can later be removed
+            safely, along with other test artifacts, with
+            <code>vip uninstall</code>.
           </p>
-
-          <h3>Using RStudio or Positron?</h3>
           <p>
-            You can set up VIP as an RStudio project instead. Go to
-            <em>File &rarr; New Project &rarr; Version Control &rarr; Git</em>
-            and enter <code>https://github.com/posit-dev/vip.git</code> as
-            the Repository URL. Then install dependencies from the Terminal tab:
+            Run your first VIP test against Posit Public Package Manager:
           </p>
-          <pre><code>uv sync
-uv run vip install</code></pre>
-
-          <p>Run your first test against a Connect server:</p>
+          <pre><code>vip verify --package-manager-url https://p3m.dev --filter 'not test_product_does_not_expose_sensitive_headers and not test_prometheus_metrics'</code></pre>
+          <p>The above command should finish in under a minute and show a
+          successful run with some tests skipped.</p>
+          <p>Now it is time to run against one of your own servers. If you have
+          Connect set up, you can run against it like this:</p>
           <pre><code>vip verify --connect-url https://connect.example.com --interactive-auth</code></pre>
           <p>
             The <code>--interactive-auth</code> flag opens a Chromium window so
             you can log in. After authentication completes, VIP runs the test
             suite headlessly and cleans up the session automatically.
           </p>
-          <p>Check product health without running the full test suite:</p>
-          <pre><code>vip status</code></pre>
-
-          <p>Already have an API key? Skip browser auth entirely with <code>--api-auth</code>:</p>
+          <p>
+            If you have an API key, you can skip browser auth entirely with <code>--api-auth</code>:</p>
           <pre><code>export VIP_CONNECT_API_KEY="your-api-key"
 vip verify --connect-url https://connect.example.com --api-auth</code></pre>
 
-          <p>Test multiple products at once:</p>
-          <pre><code>vip verify \
-  --connect-url https://connect.example.com \
-  --workbench-url https://workbench.example.com \
-  --package-manager-url https://packagemanager.example.com \
-  --interactive-auth</code></pre>
+          <p>There are more authentication options, including headless auth with OIDC,
+          explained below.</p>
+          <p>At this point, you may see some tests failing and want to fix what
+          isn't right and then try again. You can rerun just those tests with the
+          <code>--filter</code> flag:</p>
+          <pre><code>vip verify --connect-url https://connect.example.com --interactive-auth --filter test_deploy_shiny</code></pre>
+          <p>
+            As you get comfortable with how one server is running, you can move
+            on to others using not just <code>--connect-url</code> but also
+            <code>--workbench-url</code> and <code>--package-manager-url</code>.
+            You can also see what other options are available by reading below or
+            running <code>vip --help</code>.
+          </p>
         </section>
 
         <section id="authentication">

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -340,17 +340,20 @@ extension_dirs = ["/opt/vip-custom-tests"]</code></pre>
         <section id="uninstalling">
           <h2>Uninstalling</h2>
           <p>
-            When you are done with VIP, preview what will be removed. By default
-            <code>vip uninstall</code> prints a dry-run plan &mdash; the Chromium
-            browser, system libraries, and other artifacts that
-            <code>vip install</code> added &mdash; without changing anything:
+            When you are done with VIP, run <code>vip uninstall</code> to preview
+            what will be removed. It prints a dry-run plan &mdash; the Chromium
+            browser cache and other test artifacts &mdash; without changing
+            anything:
           </p>
           <pre><code>vip uninstall</code></pre>
           <p>
-            Pass <code>--yes</code> to execute the plan, then remove the package
-            itself:
+            Pass <code>--yes</code> to remove those artifacts. On Linux, VIP does
+            not remove the system libraries it installed; instead it prints a
+            <code>sudo</code> command for you to run. Complete the uninstall in
+            this order:
           </p>
           <pre><code>vip uninstall --yes
+# then run the sudo removal command that vip uninstall prints, if any
 uv pip uninstall posit-vip</code></pre>
         </section>
       </article>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -89,7 +89,7 @@ const categories = [
           <span class="step-number">1</span>
           <div>
             <h4>Install</h4>
-            <p><code>uv pip install posit-vip</code></p>
+            <p><code>uv tool install posit-vip</code></p>
             <p><code>vip install</code></p>
           </div>
         </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,7 +23,7 @@ const products = [
   {
     name: "Package Manager",
     flag: "package-manager-url",
-    description: "CRAN, PyPI, Bioconductor, and OpenVSX mirrors, repository configuration, and authenticated/private package access",
+    description: "CRAN, PyPI, Bioconductor, and OpenVSX mirrors, repository configuration, and private package access",
     logo: `${base}logo-packagemanager.svg`,
     testsId: "package_manager",
   },
@@ -45,7 +45,7 @@ const categories = [
       <p class="hero-label">Open Source</p>
       <h1>Verified Installation<br />of Posit Team</h1>
       <p class="hero-subtitle">
-        An extensible BDD test suite that validates your Posit Team deployment is installed correctly
+        An extensible test suite that validates your Posit Team deployment is installed correctly
         and functioning properly.
       </p>
       <div class="hero-actions">
@@ -115,8 +115,8 @@ const categories = [
     <div class="container">
       <h2 class="section-title">What VIP validates</h2>
       <p class="section-subtitle">
-        VIP tests Connect, Workbench, and Package Manager using pytest-bdd with Gherkin feature
-        files and Playwright for browser automation.
+        VIP tests Connect, Workbench, and Package Manager using open source testing software:
+        pytest-bdd with Gherkin feature files and Playwright for browser automation.
       </p>
 
       <div class="product-grid">

--- a/website/src/pages/report.astro
+++ b/website/src/pages/report.astro
@@ -17,8 +17,8 @@ const base = import.meta.env.BASE_URL;
         This report is rebuilt automatically whenever the website is deployed.
       </p>
       <p class="how-to">
-        Generate your own: run <code>vip verify --report report/results.json</code> to
-        save test results, then <code>vip report</code> to render the report.
+        Generate your own: run <code>vip verify</code> to save test results to
+        <code>report/results.json</code>, then <code>vip report</code> to render the report.
         Note: <code>vip report</code> runs Quarto under the hood, so you must
         have the <a href="https://quarto.org/docs/download/">quarto CLI</a> installed.
       </p>


### PR DESCRIPTION
Website content updates across the Getting Started, Feature Matrix, Report, and homepage pages, plus a simpler documented install flow.

Closes #465

## Changes

Install flow (`README.md`, `website/src/pages/index.astro`, `website/src/pages/getting-started.astro`) — addresses #465
- Recommend `uv tool install posit-vip` (pipx-style) instead of the `uv venv` + `source activate` + `uv pip install` + `uv run` flow, so `vip` lands on PATH with no venv to activate.
- Switched the uninstall docs to the matching `uv tool uninstall posit-vip`.
- Scope is the end-user install-from-PyPI docs only; the source-tree developer flow (`uv sync` / `uv run vip ...` in the justfile, Dockerfiles, and CI) is unchanged, since that runs from a checkout.

Feature Matrix (`website/src/pages/feature-matrix.astro`, `scripts/generate-feature-matrix.py`)
- Removed the "Deployment Environments" section.
- Dropped "Flightdeck" and "Package Manager admin UI" from "Not Yet Covered" (edited the generator, not the generated JSON).

Report page (`website/src/pages/report.astro`)
- Clarified the "Generate your own" instructions: `vip verify` to save results to `report/results.json`, then `vip report` to render.

Homepage (`website/src/pages/index.astro`)
- Minor copy refinements to the Package Manager description, hero subtitle, and "What VIP validates" text.

Getting Started (`website/src/pages/getting-started.astro`)
- Fixed markup bugs in the Quick start section (unclosed `<code>`/`<p>` tags, markdown backticks that don't render as code in HTML, a dropped `</section>`) plus typos and grammar.
- Expanded the end of Quick start with `vip --help` guidance.
- Moved the uninstall steps into their own "Uninstalling" section (after "Extending VIP"), with a matching table-of-contents entry.
- Clarified that `vip uninstall` is dry-run by default and that `--yes` removes user-space artifacts but prints (does not run) the `sudo` command for system-library removal.

## Verification
- `npm run build` succeeds for the Astro site (5 pages).
- Feature-matrix / test-catalog JSON regenerated from the test suite (`scripts/generate-*.py`); note these files are gitignored and generated at build time.
- Rendered HTML spot-checked: balanced `<section>` tags, correct TOC/section ordering, removed sections absent, no leftover markdown backticks, install snippets now show `uv tool install`.
- Confirmed `posit-vip` exposes a `vip` console script (`[project.scripts]` in `pyproject.toml`), so `uv tool install posit-vip` puts `vip` on PATH.
