### PR TITLE
fix(workbench): wait for homepage logo so cleanup sweep finds sessions

### DIFF
--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -384,7 +384,14 @@ class _FakeLocator:
         return None
 
     def wait_for(self, *, state=None, timeout=None):
-        # Only selectors registered as present "appear"; others time out.
+        from vip_tests.workbench.pages import Homepage
+
+        # The Posit logo is the authenticated-homepage marker (see is_visible);
+        # _complete_sso_if_needed now wait_for()s it rather than snapshotting,
+        # so model it as present. Other selectors "appear" only when registered
+        # as a present dialog; otherwise they time out.
+        if self._selector == Homepage.POSIT_LOGO:
+            return
         if self._selector not in self._page.present_dialogs:
             raise RuntimeError(f"locator not visible: {self._selector}")
 
@@ -619,6 +626,62 @@ def test_complete_sso_false_when_not_on_login_page():
     # No logo and not a login URL — nothing we can do.
     page = _SsoFakePage(url="https://wb.example.com/some/other/page", sso_visible=False)
     assert _complete_sso_if_needed(page) is False
+
+
+class _DelayedLogoLocator:
+    """Logo a one-shot is_visible() snapshot misses but a bounded wait_for()
+    catches -- models the shadcn SPA mounting the logo a few seconds after the
+    page ``load`` event (issue #491)."""
+
+    def __init__(self):
+        self.waited = False
+
+    @property
+    def first(self):
+        return self
+
+    def is_visible(self):
+        return False  # snapshot loses the hydration race
+
+    def wait_for(self, *, state=None, timeout=None):
+        self.waited = True  # bounded wait catches the logo once it mounts
+
+    def click(self, timeout=None):
+        pass
+
+
+class _HydrationRacePage:
+    """Authenticated homepage whose logo mounts after ``load``; Workbench has
+    redirected the root URL into an active session's workspace (issue #491)."""
+
+    def __init__(self, url="https://wb.example.com/s/abc123/workspaces/"):
+        self.url = url
+        self.logo = _DelayedLogoLocator()
+
+    def locator(self, selector):
+        from vip_tests.workbench.pages import Homepage
+
+        if selector == Homepage.POSIT_LOGO:
+            return self.logo
+        return _SsoFakeLocator(lambda: False)
+
+    def get_by_role(self, role, name=None):
+        return _SsoFakeLocator(lambda: False)  # no SSO button should be reached
+
+
+def test_complete_sso_true_when_logo_mounts_after_load():
+    """Regression for #491: the authenticated homepage's logo mounts a few
+    seconds after ``load`` (shadcn hydration), and Workbench redirects the root
+    URL into an active session's workspace. A one-shot ``is_visible()`` snapshot
+    raced hydration and returned False, aborting the cleanup sweep with a
+    misleading expired-session warning even though the session list was
+    reachable. A bounded ``wait_for`` must detect the logo and report
+    authenticated."""
+    from vip.workbench_ui import _complete_sso_if_needed
+
+    page = _HydrationRacePage()
+    assert _complete_sso_if_needed(page) is True
+    assert page.logo.waited is True  # used the bounded wait, not a snapshot
 
 
 # ---------------------------------------------------------------------------

--- a/selftests/test_workbench_cleanup.py
+++ b/selftests/test_workbench_cleanup.py
@@ -421,9 +421,14 @@ class _FakeHomepage:
         self.quit_clicks = 0
         self.reloads = 0
         self.goto_urls: list[str] = []
+        # Authenticated homepage URL (Workbench redirects the root into an
+        # active session's workspace); not a login page, so _complete_sso_if_needed
+        # takes the bounded-logo-wait path.
+        self.url = "https://wb.example.com/s/abc123/workspaces/"
 
     def goto(self, url, *args, **kwargs):
         self.goto_urls.append(url)
+        self.url = url
 
     def reload(self, *args, **kwargs):
         self.reloads += 1

--- a/src/vip/workbench_ui.py
+++ b/src/vip/workbench_ui.py
@@ -90,8 +90,16 @@ def _complete_sso_if_needed(page: Page) -> bool:
     """
     logo = page.locator(Homepage.POSIT_LOGO)
     try:
-        if logo.is_visible():
-            return True  # already authenticated (e.g. the in-test page)
+        # Bounded wait, not a one-shot is_visible(): the 2026.05+ homepage is a
+        # shadcn SPA that mounts the logo a few seconds after the `load` event
+        # (and Workbench redirects the root URL into an active session's
+        # workspace when sessions exist). A snapshot check races hydration and
+        # wrongly concludes "not authenticated", aborting the sweep with a
+        # misleading expired-session warning even though the session list is
+        # reachable -- the same race _wait_for_session_list already guards
+        # against for the row checkboxes (issue #491).
+        logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)
+        return True  # already authenticated (e.g. the in-test page)
     except Exception:
         pass
     try:

--- a/src/vip/workbench_ui.py
+++ b/src/vip/workbench_ui.py
@@ -89,24 +89,29 @@ def _complete_sso_if_needed(page: Page) -> bool:
     session itself has expired).  Best-effort: never raises.
     """
     logo = page.locator(Homepage.POSIT_LOGO)
+    # Decide the login state first. The homepage logo can never appear on the
+    # OIDC sign-in page, so only pages that are NOT a login page get the bounded
+    # logo wait below -- otherwise every expired-auth cleanup attempt would burn
+    # TIMEOUT_QUICK waiting for a logo that will never show (PR #492 review).
     try:
-        # Bounded wait, not a one-shot is_visible(): the 2026.05+ homepage is a
-        # shadcn SPA that mounts the logo a few seconds after the `load` event
-        # (and Workbench redirects the root URL into an active session's
-        # workspace when sessions exist). A snapshot check races hydration and
-        # wrongly concludes "not authenticated", aborting the sweep with a
-        # misleading expired-session warning even though the session list is
-        # reachable -- the same race _wait_for_session_list already guards
-        # against for the row checkboxes (issue #491).
-        logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)
-        return True  # already authenticated (e.g. the in-test page)
-    except Exception:
-        pass
-    try:
-        if not any(kw in page.url.lower() for kw in _LOGIN_URL_KEYWORDS):
-            return False  # not on a login page, but no homepage either
+        on_login_page = any(kw in page.url.lower() for kw in _LOGIN_URL_KEYWORDS)
     except Exception:
         return False
+    if not on_login_page:
+        # Not a login page -> this is (or is becoming) the authenticated
+        # homepage. The 2026.05+ dashboard is a shadcn SPA that mounts the logo
+        # a few seconds after the `load` event (and Workbench redirects the root
+        # URL into an active session's workspace when sessions exist), so use a
+        # bounded wait, not a one-shot is_visible(): a snapshot races hydration
+        # and wrongly concludes "not authenticated", aborting the sweep with a
+        # misleading expired-session warning even though the session list is
+        # reachable -- the same race _wait_for_session_list guards against for
+        # the row checkboxes (issue #491).
+        try:
+            logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)
+            return True  # already authenticated (e.g. the in-test page)
+        except Exception:
+            return False  # not a login page, but no homepage logo either
     # The OIDC sign-in page renders a "Sign in with OpenID" button. Wait briefly
     # so a slow sign-in page is detected reliably rather than raced.
     try:

--- a/validation_docs/demo-491-cleanup-logo-race.md
+++ b/validation_docs/demo-491-cleanup-logo-race.md
@@ -1,0 +1,48 @@
+# Fix #491: cleanup sweep waits for homepage logo (SPA hydration race)
+
+*2026-07-17T04:02:42Z by Showboat 0.6.1*
+<!-- showboat-id: e8b349b8-76a1-45db-bd1a-981ee1125620 -->
+
+The orphaned-session cleanup sweep (vip cleanup --workbench-url and the in-test teardown) was quitting 0 sessions even with valid auth and sessions clearly present. Root cause: _complete_sso_if_needed detected the authenticated homepage with a one-shot logo.is_visible(). The 2026.05+ dashboard is a shadcn SPA that mounts the #posit-logo ~3s after the page 'load' event, so the snapshot raced hydration, returned False, and the sweep aborted with a misleading 'could not reach an authenticated homepage / may have expired' warning. Fix: a bounded logo.wait_for(state='visible', timeout=TIMEOUT_QUICK), mirroring the SSO-button wait already in the same function and _wait_for_session_list's existing SPA-timing guard.
+
+The fix: one-shot is_visible() replaced by a bounded wait_for on the homepage logo.
+
+```bash
+grep -n "logo.wait_for(state=\"visible\", timeout=TIMEOUT_QUICK)" src/vip/workbench_ui.py
+```
+
+```output
+101:        logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)
+```
+
+New regression test reproduces the race (logo missed by a snapshot is_visible() but caught by a bounded wait_for) — it fails on the old code and passes on the fix:
+
+```bash
+env -u UV_PROJECT uv run --frozen --no-sync --project . pytest "selftests/test_workbench_cleanup.py::test_complete_sso_true_when_logo_mounts_after_load" -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+1 passed
+```
+
+Full workbench-cleanup selftest module stays green:
+
+```bash
+env -u UV_PROJECT uv run --frozen --no-sync --project . pytest selftests/test_workbench_cleanup.py -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
+```
+
+```output
+49 passed
+```
+
+Lint clean:
+
+```bash
+env -u UV_PROJECT uv run --frozen --no-sync --project . ruff check src/vip/workbench_ui.py selftests/test_workbench_cleanup.py
+```
+
+```output
+All checks passed!
+```
+
+Live validation (dev.demo.posit.team, not re-runnable here — requires a live deployment + browser auth): with 6 orphaned VIP sessions Active, vip cleanup --workbench-url https://dev.demo.posit.team reported 'quit 6 VIP session(s) (10 row(s) visible)' / 'Quit 6 VIP Workbench session(s) via the UI'. Before this fix the same command quit 0 despite the sessions being present and auth valid.

--- a/validation_docs/demo-491-cleanup-logo-race.md
+++ b/validation_docs/demo-491-cleanup-logo-race.md
@@ -12,7 +12,7 @@ grep -n "logo.wait_for(state=\"visible\", timeout=TIMEOUT_QUICK)" src/vip/workbe
 ```
 
 ```output
-101:        logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)
+111:            logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)
 ```
 
 New regression test reproduces the race (logo missed by a snapshot is_visible() but caught by a bounded wait_for) — it fails on the old code and passes on the fix:


### PR DESCRIPTION
## Summary

Fixes #491 — `vip cleanup` and the in-test teardown sweep quit 0 orphaned
Workbench sessions despite valid auth, so VIP test sessions piled up.

## Root cause (one bug, three symptoms)

`_complete_sso_if_needed` used a one-shot `logo.is_visible()` to detect the
authenticated homepage. The 2026.05+ dashboard is a shadcn SPA that mounts the
logo ~3s after `load`, so the snapshot raced hydration, returned False, and the
sweep aborted with a misleading "could not reach an authenticated homepage /
may have expired" warning — quitting 0 even though the session list was fully
reachable. The teardown-leak and cache-reuse symptoms in #491 were the same
race misreporting valid auth as expired.

## Fix

Bounded `logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)`, mirroring the
SSO-button wait already in the same function and `_wait_for_session_list`'s
existing SPA-timing guard.

## Live validation (dev.demo.posit.team)

`vip cleanup --workbench-url ...` now: `quit 6 VIP session(s) (10 rows visible)`
— was quitting 0 with 6 sessions present.

## Test plan

- New regression test `test_complete_sso_true_when_logo_mounts_after_load`
  (fails on the old `is_visible()`, passes on `wait_for`)
- ruff + mypy clean; full selftests green (941, `-n0`)

## Demo

# Fix #491: cleanup sweep waits for homepage logo (SPA hydration race)

The orphaned-session cleanup sweep (vip cleanup --workbench-url and the in-test teardown) was quitting 0 sessions even with valid auth and sessions clearly present. Root cause: _complete_sso_if_needed detected the authenticated homepage with a one-shot logo.is_visible(). The 2026.05+ dashboard is a shadcn SPA that mounts the #posit-logo ~3s after the page 'load' event, so the snapshot raced hydration, returned False, and the sweep aborted with a misleading 'could not reach an authenticated homepage / may have expired' warning. Fix: a bounded logo.wait_for(state='visible', timeout=TIMEOUT_QUICK), mirroring the SSO-button wait already in the same function and _wait_for_session_list's existing SPA-timing guard.

The fix: one-shot is_visible() replaced by a bounded wait_for on the homepage logo.

```bash
grep -n "logo.wait_for(state=\"visible\", timeout=TIMEOUT_QUICK)" src/vip/workbench_ui.py
```

```output
101:        logo.wait_for(state="visible", timeout=TIMEOUT_QUICK)
```

New regression test reproduces the race (logo missed by a snapshot is_visible() but caught by a bounded wait_for) — it fails on the old code and passes on the fix:

```bash
env -u UV_PROJECT uv run --frozen --no-sync --project . pytest "selftests/test_workbench_cleanup.py::test_complete_sso_true_when_logo_mounts_after_load" -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
```

```output
1 passed
```

Full workbench-cleanup selftest module stays green:

```bash
env -u UV_PROJECT uv run --frozen --no-sync --project . pytest selftests/test_workbench_cleanup.py -q 2>&1 | grep -E "passed|failed|error" | sed "s/ in [0-9.]*s//"
```

```output
49 passed
```

Lint clean:

```bash
env -u UV_PROJECT uv run --frozen --no-sync --project . ruff check src/vip/workbench_ui.py selftests/test_workbench_cleanup.py
```

```output
All checks passed!
```

Live validation (dev.demo.posit.team, not re-runnable here — requires a live deployment + browser auth): with 6 orphaned VIP sessions Active, vip cleanup --workbench-url https://dev.demo.posit.team reported 'quit 6 VIP session(s) (10 row(s) visible)' / 'Quit 6 VIP Workbench session(s) via the UI'. Before this fix the same command quit 0 despite the sessions being present and auth valid.
