### PR TITLE
fix(workbench): start Positron console session before gating on it

### DIFF
--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -434,10 +434,13 @@ class TestDetectIde:
 
 
 class _FakeKeyboard:
-    def __init__(self):
+    def __init__(self, raises=False):
         self.pressed: list[str] = []
+        self._raises = raises
 
     def press(self, key):
+        if self._raises:
+            raise RuntimeError("keyboard detached")
         self.pressed.append(key)
 
 
@@ -470,6 +473,8 @@ class _EnsureFakeLocator:
         if self._selector == PositronSession.START_CONSOLE_BUTTON:
             self._page.start_clicked += 1
         elif self._selector == PositronSession.INTERPRETER_QUICKPICK_ROW:
+            if self._page.row_click_raises:
+                raise RuntimeError("row detached")
             self._page.rows_clicked += 1
             self._page.interpreter_selected = True
 
@@ -491,16 +496,19 @@ class _EnsureFakePage:
         has_start_button=True,
         quickpick_after=0,
         console_renders=True,
+        row_click_raises=False,
+        keyboard_raises=False,
     ):
         self.has_console_panel = has_console_panel
         self.has_start_button = has_start_button
         self.quickpick_after = quickpick_after
         self.console_renders = console_renders
+        self.row_click_raises = row_click_raises
         self.polls = 0
         self.interpreter_selected = False
         self.start_clicked = 0
         self.rows_clicked = 0
-        self.keyboard = _FakeKeyboard()
+        self.keyboard = _FakeKeyboard(raises=keyboard_raises)
 
     def locator(self, selector):
         return _EnsureFakeLocator(self, selector)
@@ -539,6 +547,26 @@ class TestEnsurePositronConsole:
         page = _EnsureFakePage(quickpick_after=0, console_renders=False)
         assert ensure_positron_console(page, timeout=3_000) is False
         assert page.interpreter_selected is True
+
+    def test_never_raises_when_both_row_click_and_enter_fail(self):
+        """Honour the "never raises" contract: if selecting the interpreter row
+        fails AND the Enter keyboard fallback also raises, return False."""
+        page = _EnsureFakePage(
+            quickpick_after=0,
+            console_renders=False,
+            row_click_raises=True,
+            keyboard_raises=True,
+        )
+        assert ensure_positron_console(page, timeout=2_000) is False
+
+    def test_total_wait_bounded_by_timeout(self):
+        """The poll budget is SHARED across discovery + render, so total waits
+        never exceed ~timeout (not ~2x). Interpreter resolves after 2 polls but
+        the console never renders; with timeout=5000ms / 1000ms poll the total
+        wait cycles must stay <= 5 (a per-loop budget would allow ~7)."""
+        page = _EnsureFakePage(quickpick_after=2, console_renders=False)
+        assert ensure_positron_console(page, timeout=5_000) is False
+        assert page.polls <= 5
 
 
 # ---------------------------------------------------------------------------

--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -33,6 +33,7 @@ from vip_tests.workbench.exec import (
     _strip_r_index,
     _wrap_python_expr,
     _wrap_r_expr,
+    ensure_positron_console,
     file_exists,
     read_file,
 )
@@ -411,6 +412,13 @@ class TestDetectIde:
         page = _make_page_mock({PositronSession.CONSOLE_PANEL, VSCodeSession.WORKBENCH})
         assert _detect_ide(page) == "positron"
 
+    def test_positron_detected_via_variables_pane_without_console(self):
+        """Positron opens without an auto-started console (issue #477): the console
+        panel is absent on the Welcome page, but ``.positron-variables`` is always
+        present, so detection must not depend on a running console."""
+        page = _make_page_mock({PositronSession.VARIABLES_PANE, VSCodeSession.WORKBENCH})
+        assert _detect_ide(page) == "positron"
+
     def test_vscode_detected_without_positron_console(self):
         page = _make_page_mock({VSCodeSession.WORKBENCH})
         assert _detect_ide(page) == "vscode"
@@ -418,6 +426,119 @@ class TestDetectIde:
     def test_unknown_when_nothing_present(self):
         page = _make_page_mock(set())
         assert _detect_ide(page) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# ensure_positron_console
+# ---------------------------------------------------------------------------
+
+
+class _FakeKeyboard:
+    def __init__(self):
+        self.pressed: list[str] = []
+
+    def press(self, key):
+        self.pressed.append(key)
+
+
+class _EnsureFakeLocator:
+    """Locator whose count()/click() reflect the parent fake page's state."""
+
+    def __init__(self, page, selector):
+        self._page = page
+        self._selector = selector
+
+    @property
+    def first(self):
+        return self
+
+    def count(self):
+        p = self._page
+        if self._selector == PositronSession.CONSOLE_PANEL:
+            if p.has_console_panel:
+                return 1
+            return 1 if (p.interpreter_selected and p.console_renders) else 0
+        if self._selector == PositronSession.START_CONSOLE_BUTTON:
+            return 1 if p.has_start_button else 0
+        if self._selector == PositronSession.INTERPRETER_QUICKPICK_ROW:
+            if p.quickpick_after is None:
+                return 0
+            return 1 if p.polls >= p.quickpick_after else 0
+        return 0
+
+    def click(self, timeout=None):
+        if self._selector == PositronSession.START_CONSOLE_BUTTON:
+            self._page.start_clicked += 1
+        elif self._selector == PositronSession.INTERPRETER_QUICKPICK_ROW:
+            self._page.rows_clicked += 1
+            self._page.interpreter_selected = True
+
+
+class _EnsureFakePage:
+    """Scriptable fake Positron page for ensure_positron_console tests.
+
+    - ``has_console_panel``: a console is already running.
+    - ``has_start_button``: the "Start New Console Session" button is present.
+    - ``quickpick_after``: number of poll cycles before the interpreter quickpick
+      populates (``None`` = never, i.e. no interpreter resolves).
+    - ``console_renders``: whether the console appears after selecting an interpreter.
+    """
+
+    def __init__(
+        self,
+        *,
+        has_console_panel=False,
+        has_start_button=True,
+        quickpick_after=0,
+        console_renders=True,
+    ):
+        self.has_console_panel = has_console_panel
+        self.has_start_button = has_start_button
+        self.quickpick_after = quickpick_after
+        self.console_renders = console_renders
+        self.polls = 0
+        self.interpreter_selected = False
+        self.start_clicked = 0
+        self.rows_clicked = 0
+        self.keyboard = _FakeKeyboard()
+
+    def locator(self, selector):
+        return _EnsureFakeLocator(self, selector)
+
+    def wait_for_timeout(self, ms):
+        self.polls += 1
+
+
+class TestEnsurePositronConsole:
+    def test_returns_true_without_clicking_when_console_already_running(self):
+        page = _EnsureFakePage(has_console_panel=True)
+        assert ensure_positron_console(page) is True
+        assert page.start_clicked == 0
+
+    def test_returns_false_when_no_start_button(self):
+        page = _EnsureFakePage(has_console_panel=False, has_start_button=False)
+        assert ensure_positron_console(page) is False
+
+    def test_starts_console_when_quickpick_populates_asynchronously(self):
+        """Interpreter discovery lags the Start click (~10s live). ensure must
+        poll the quickpick, then select an interpreter and confirm the console."""
+        page = _EnsureFakePage(quickpick_after=2, console_renders=True)
+        assert ensure_positron_console(page, timeout=10_000) is True
+        assert page.start_clicked == 1
+        assert page.rows_clicked == 1
+        assert page.interpreter_selected is True
+
+    def test_returns_false_when_no_interpreter_resolves(self):
+        """Genuinely no interpreter available: quickpick never populates → False
+        (caller decides on an accurate skip, not a misleading 'not installed')."""
+        page = _EnsureFakePage(quickpick_after=None)
+        assert ensure_positron_console(page, timeout=3_000) is False
+        assert page.rows_clicked == 0
+
+    def test_returns_false_when_console_never_renders_after_select(self):
+        page = _EnsureFakePage(quickpick_after=0, console_renders=False)
+        assert ensure_positron_console(page, timeout=3_000) is False
+        assert page.interpreter_selected is True
 
 
 # ---------------------------------------------------------------------------

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -248,6 +248,69 @@ _POSITRON_CONSOLE_READY = f"{PositronSession.ACTIVE_CONSOLE} .active-line-number
 # The Console and Terminal share the bottom panel; a prior terminal_run leaves
 # the Terminal tab selected, hiding the console. Activate the Console tab first.
 _POSITRON_CONSOLE_TAB = PositronSession.CONSOLE_TAB
+_POSITRON_START_BUTTON = PositronSession.START_CONSOLE_BUTTON
+_POSITRON_QUICKPICK_ROW = PositronSession.INTERPRETER_QUICKPICK_ROW
+# Poll cadence for the "start a console" flow. Interpreter discovery is async
+# (~10s live on a cold session), so we poll rather than assume immediacy.
+_POSITRON_POLL_MS = 1_000
+
+
+def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
+    """Ensure a Positron console session is running on *page*.
+
+    Positron (Workbench 2026+) opens to a Welcome page with **no auto-started
+    console** — ``.positron-console`` and its input do not exist until a console
+    session is started (issue #477). This clicks "Start New Console Session",
+    polls for the asynchronously-discovered interpreter quickpick, selects the
+    first interpreter, and waits for the console to render.
+
+    Idempotent: returns immediately if a console is already present. Never
+    raises — returns ``True`` when a console is running (already-open or freshly
+    started) and ``False`` when none could be started (no Start button, or no
+    interpreter resolved within *timeout*). Callers decide whether ``False`` is
+    an accurate skip or a failure.
+
+    Args:
+        page: Playwright page for an active Positron session.
+        timeout: Max milliseconds to wait for both interpreter discovery and the
+            console to render.
+
+    Returns:
+        ``True`` if a console is running, ``False`` otherwise.
+    """
+    if page.locator(PositronSession.CONSOLE_PANEL).count() > 0:
+        return True
+
+    start = page.locator(_POSITRON_START_BUTTON)
+    if start.count() == 0:
+        return False
+    try:
+        start.first.click()
+    except Exception:
+        return False
+
+    max_polls = max(1, timeout // _POSITRON_POLL_MS)
+
+    # Poll the interpreter quickpick — discovery lags the click on a cold session.
+    for _ in range(max_polls):
+        if page.locator(_POSITRON_QUICKPICK_ROW).count() > 0:
+            break
+        page.wait_for_timeout(_POSITRON_POLL_MS)
+    rows = page.locator(_POSITRON_QUICKPICK_ROW)
+    if rows.count() == 0:
+        return False
+
+    try:
+        rows.first.click()
+    except Exception:
+        page.keyboard.press("Enter")
+
+    # Wait for the console panel to render after the interpreter is selected.
+    for _ in range(max_polls):
+        if page.locator(PositronSession.CONSOLE_PANEL).count() > 0:
+            return True
+        page.wait_for_timeout(_POSITRON_POLL_MS)
+    return page.locator(PositronSession.CONSOLE_PANEL).count() > 0
 
 
 def _activate_positron_console(page: Page) -> None:
@@ -290,6 +353,11 @@ def positron_eval_r(page: Page, expr: str, timeout: int = 30_000) -> str:
     start, end = _make_sentinels()
     wrapped = _wrap_r_expr(expr, start, end)
 
+    if not ensure_positron_console(page, timeout=timeout):
+        raise ExecError(
+            "No Positron console could be started (no R/Python interpreter "
+            "resolved); cannot evaluate the expression."
+        )
     _activate_positron_console(page)
     active = page.locator(_POSITRON_ACTIVE_CONSOLE)
     expect(active.first).to_be_visible(timeout=timeout)
@@ -336,6 +404,11 @@ def positron_eval_python(page: Page, expr: str, timeout: int = 30_000) -> str:
     start, end = _make_sentinels()
     wrapped = _wrap_python_expr(expr, start, end)
 
+    if not ensure_positron_console(page, timeout=timeout):
+        raise ExecError(
+            "No Positron console could be started (no R/Python interpreter "
+            "resolved); cannot evaluate the expression."
+        )
     _activate_positron_console(page)
     active = page.locator(_POSITRON_ACTIVE_CONSOLE)
     expect(active.first).to_be_visible(timeout=timeout)
@@ -545,12 +618,18 @@ def _detect_ide(page: Page) -> str:
     """Identify which IDE is rendered on *page*.
 
     Positron and VS Code both render ``.monaco-workbench``; Positron is
-    distinguished first by its unique ``.positron-console`` panel. Returns one
-    of ``"rstudio"``, ``"positron"``, ``"vscode"``, or ``"unknown"``.
+    distinguished by its unique ``.positron-variables`` pane, which is present
+    even on the Welcome page before any console starts (``.positron-console`` is
+    console-gated and absent until a console session is started — issue #477).
+    ``.positron-console`` is accepted as a fallback. Returns one of
+    ``"rstudio"``, ``"positron"``, ``"vscode"``, or ``"unknown"``.
     """
     if page.locator(RStudioSession.CONTAINER).count() > 0:
         return "rstudio"
-    if page.locator(PositronSession.CONSOLE_PANEL).count() > 0:
+    if (
+        page.locator(PositronSession.VARIABLES_PANE).count() > 0
+        or page.locator(PositronSession.CONSOLE_PANEL).count() > 0
+    ):
         return "positron"
     if page.locator(VSCodeSession.WORKBENCH).count() > 0:
         return "vscode"

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -266,14 +266,14 @@ def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
 
     Idempotent: returns immediately if a console is already present. Never
     raises — returns ``True`` when a console is running (already-open or freshly
-    started) and ``False`` when none could be started (no Start button, or no
-    interpreter resolved within *timeout*). Callers decide whether ``False`` is
-    an accurate skip or a failure.
+    started) and ``False`` when none could be started (no/unclickable Start
+    button, no interpreter resolved, or the console never rendered within
+    *timeout*). Callers decide whether ``False`` is an accurate skip or a failure.
 
     Args:
         page: Playwright page for an active Positron session.
-        timeout: Max milliseconds to wait for both interpreter discovery and the
-            console to render.
+        timeout: Max total milliseconds to wait, SHARED across interpreter
+            discovery and console rendering (not applied twice).
 
     Returns:
         ``True`` if a console is running, ``False`` otherwise.
@@ -289,27 +289,35 @@ def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
     except Exception:
         return False
 
-    max_polls = max(1, timeout // _POSITRON_POLL_MS)
+    # A single poll budget is shared across both phases below so the total wait
+    # is bounded by *timeout* rather than ~2x it.
+    remaining = max(1, timeout // _POSITRON_POLL_MS)
 
-    # Poll the interpreter quickpick — discovery lags the click on a cold session.
-    for _ in range(max_polls):
-        if page.locator(_POSITRON_QUICKPICK_ROW).count() > 0:
-            break
+    # Phase 1: poll the interpreter quickpick — discovery lags the click on a
+    # cold session (~10s live).
+    while page.locator(_POSITRON_QUICKPICK_ROW).count() == 0 and remaining > 0:
         page.wait_for_timeout(_POSITRON_POLL_MS)
+        remaining -= 1
     rows = page.locator(_POSITRON_QUICKPICK_ROW)
     if rows.count() == 0:
         return False
 
+    # Select the first interpreter; fall back to Enter. Both are best-effort so
+    # the "never raises" contract holds even if the row/keyboard is detached.
     try:
         rows.first.click()
     except Exception:
-        page.keyboard.press("Enter")
+        try:
+            page.keyboard.press("Enter")
+        except Exception:
+            return False
 
-    # Wait for the console panel to render after the interpreter is selected.
-    for _ in range(max_polls):
+    # Phase 2: wait (with the remaining budget) for the console to render.
+    while remaining > 0:
         if page.locator(PositronSession.CONSOLE_PANEL).count() > 0:
             return True
         page.wait_for_timeout(_POSITRON_POLL_MS)
+        remaining -= 1
     return page.locator(PositronSession.CONSOLE_PANEL).count() > 0
 
 

--- a/src/vip_tests/workbench/pages/positron_session.py
+++ b/src/vip_tests/workbench/pages/positron_session.py
@@ -20,14 +20,28 @@ class PositronSession:
 
     # Positron-specific elements
     CONSOLE_PANEL = ".positron-console"
-    # Console tab in the bottom panel (shares the panel with Terminal). Used as
-    # the "Positron is loaded" signal and to re-activate the console after a
-    # terminal_run leaves the Terminal tab selected.
+    # Console tab in the bottom panel (shares the panel with Terminal). Used to
+    # re-activate the console after a terminal_run leaves the Terminal tab
+    # selected. Only present once a console session is running (see below).
     CONSOLE_TAB = 'a.action-label[aria-label="Console"]'
+    # Positron (Workbench 2026+) opens to a Welcome page with NO auto-started
+    # console: CONSOLE_PANEL / CONSOLE_TAB / ACTIVE_CONSOLE / CONSOLE_INPUT do
+    # not exist until a console session is started via this button (its visible
+    # text is "Start Session"; the aria-label is the stable hook). Clicking it
+    # opens the interpreter quickpick. Confirmed live on dev.current (issue #477).
+    START_CONSOLE_BUTTON = 'button[aria-label="Start New Console Session"]'
+    # Interpreter rows in the quickpick opened by START_CONSOLE_BUTTON.
+    # Interpreter discovery is asynchronous (~10s on a cold session), so callers
+    # must POLL this for a populated list before selecting a row.
+    INTERPRETER_QUICKPICK_ROW = (
+        ".quick-input-widget .monaco-list-row, .quick-input-list .monaco-list-row"
+    )
     # Active console instance + its Monaco input (confirmed live; see
     # posit-dev/positron/test/e2e/pages/console.ts and exec.py).
     ACTIVE_CONSOLE = '.console-instance[style*="z-index: auto"]'
     CONSOLE_INPUT = ".console-input"
+    # Present even on the Welcome page (before any console starts), so it is a
+    # console-independent "this is Positron" discriminator for _detect_ide.
     VARIABLES_PANE = ".positron-variables"
     PLOTS_PANE = ".positron-plots"
     HELP_PANE = ".positron-help"

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -458,8 +458,9 @@ def positron_console_accessible(page: Page):
     """
     if not ensure_positron_console(page, timeout=TIMEOUT_IDE_LOAD):
         pytest.skip(
-            "Positron loaded but no console session could be started — no R/Python "
-            "interpreter resolved on this deployment (issue #477)."
+            "Positron loaded but no console session could be started — the "
+            '"Start New Console Session" control was unavailable, no R/Python '
+            "interpreter resolved, or the console did not render (issue #477)."
         )
     expect(page.locator(PositronSession.CONSOLE_PANEL)).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
 

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -27,7 +27,7 @@ from vip_tests.workbench.conftest import (
     wait_for_session_active,
     workbench_login,
 )
-from vip_tests.workbench.exec import rstudio_eval
+from vip_tests.workbench.exec import ensure_positron_console, rstudio_eval
 from vip_tests.workbench.pages import (
     Homepage,
     JupyterLabSession,
@@ -442,29 +442,26 @@ def jupyterlab_executes_code(page: Page):
 
 @then("the Positron console is accessible")
 def positron_console_accessible(page: Page):
-    """Verify the Positron console panel is visible and ready.
+    """Start a Positron console session and verify the console panel renders.
 
-    Positron (VS Code-based) exposes a dedicated console pane.  We assert it
-    is visible, confirming the runtime connection is established without
-    requiring a full code-execution round-trip.  If the console panel
-    selector never appears, the DOM structure may have changed (e.g. a
-    Positron update) — skip rather than hard-fail.
+    Positron (Workbench 2026+) opens to a Welcome page with **no auto-started
+    console**: ``.positron-console`` does not exist until a console session is
+    started and an interpreter is selected (discovery is asynchronous, ~10 s).
+    The previous gate waited for ``.positron-console`` on the Welcome page — where
+    it can never appear — and skipped with a misleading "may not be installed"
+    even though Positron was fully loaded (issue #477).
 
-    Uses ``TIMEOUT_CODE_EXEC`` (30 s) to match the original intent: the
-    console panel should appear promptly once the IDE has loaded.  A
-    console-specific skip message is used to distinguish this failure from
-    the IDE-not-installed skip emitted by the workbench check.
+    ``ensure_positron_console`` clicks "Start New Console Session", waits for the
+    interpreter quickpick, selects an interpreter, and waits for the console.  If
+    Positron loaded but no interpreter could be started, skip with an accurate
+    reason rather than implying Positron is missing.
     """
-    _expect_ide_or_skip(
-        page,
-        PositronSession.CONSOLE_PANEL,
-        "Positron console",
-        timeout=TIMEOUT_CODE_EXEC,
-        skip_reason=(
-            "Positron console element not found within timeout — "
-            "selector may have changed or Positron may not be fully available ({exc})"
-        ),
-    )
+    if not ensure_positron_console(page, timeout=TIMEOUT_IDE_LOAD):
+        pytest.skip(
+            "Positron loaded but no console session could be started — no R/Python "
+            "interpreter resolved on this deployment (issue #477)."
+        )
+    expect(page.locator(PositronSession.CONSOLE_PANEL)).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
 
 
 @then("the session is cleaned up")

--- a/validation_docs/demo-477-positron-console.md
+++ b/validation_docs/demo-477-positron-console.md
@@ -1,47 +1,39 @@
 # fix(workbench): Positron console launch gate (#477)
 
-*2026-07-17T18:26:48Z by Showboat 0.6.1*
-<!-- showboat-id: e19d3e43-916c-452b-b411-4a16b4eba96d -->
+*2026-07-17T18:46:10Z by Showboat 0.6.1*
+<!-- showboat-id: 0213a95f-d688-4362-8af9-9f0e4a424b69 -->
 
 Issue #477: test_launch_positron skipped with 'Positron console element not found ... selector may have changed or Positron may not be fully available', even though Positron was installed and reachable. Root cause (found by live diagnosis on dev.current, NOT selector drift): Positron on Workbench 2026+ opens to a Welcome page with NO auto-started console. The console panel (.positron-console) and its input/tab do not exist until a console session is STARTED and an interpreter is selected -- and interpreter discovery is asynchronous (~10s on a cold session). The old gate waited 30s for .positron-console on the Welcome page, where it can never appear, so it produced a false-negative skip. The same console-gated selectors also broke exec.py's _detect_ide and Positron readback.
 
-Fix: a shared, idempotent ensure_positron_console(page) helper clicks 'Start New Console Session', polls the async interpreter quickpick, selects an interpreter, and waits for the console to render. positron_console_accessible calls it then asserts the console panel (skipping with an ACCURATE reason only if no interpreter resolves). _detect_ide now keys off .positron-variables (present even on the Welcome page) so detection no longer depends on a running console. The existing CONSOLE_* selectors were correct and are unchanged.
+Fix: a shared, idempotent ensure_positron_console(page) helper clicks 'Start New Console Session', polls the async interpreter quickpick (a single poll budget shared across discovery + render so total wait is bounded by timeout, not 2x), selects an interpreter, and waits for the console to render. It never raises -- both the row click and the Enter fallback are best-effort. positron_console_accessible calls it then asserts the console panel, skipping with an accurate reason (Start control unavailable / no interpreter resolved / console did not render) only when a console truly can't be started. _detect_ide now keys off .positron-variables (present even on the Welcome page). The existing CONSOLE_* selectors were correct and are unchanged.
 
 ```bash
-grep -nE 'START_CONSOLE_BUTTON|INTERPRETER_QUICKPICK_ROW' src/vip_tests/workbench/pages/positron_session.py
+grep -E 'START_CONSOLE_BUTTON|INTERPRETER_QUICKPICK_ROW =' src/vip_tests/workbench/pages/positron_session.py
 ```
 
 ```output
-32:    START_CONSOLE_BUTTON = 'button[aria-label="Start New Console Session"]'
-33:    # Interpreter rows in the quickpick opened by START_CONSOLE_BUTTON.
-36:    INTERPRETER_QUICKPICK_ROW = (
+    START_CONSOLE_BUTTON = 'button[aria-label="Start New Console Session"]'
+    # Interpreter rows in the quickpick opened by START_CONSOLE_BUTTON.
+    INTERPRETER_QUICKPICK_ROW = (
 ```
 
 ```bash
-grep -nE 'def ensure_positron_console|VARIABLES_PANE|def _detect_ide|return "positron"' src/vip_tests/workbench/exec.py
+grep -E 'def ensure_positron_console|def _detect_ide|VARIABLES_PANE\).count|return "positron"' src/vip_tests/workbench/exec.py
 ```
 
 ```output
-258:def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
-617:def _detect_ide(page: Page) -> str:
-630:        page.locator(PositronSession.VARIABLES_PANE).count() > 0
-633:        return "positron"
+def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
+def _detect_ide(page: Page) -> str:
+        page.locator(PositronSession.VARIABLES_PANE).count() > 0
+        return "positron"
 ```
 
 ```bash
-grep -nE 'ensure_positron_console|pytest.skip' src/vip_tests/workbench/test_ide_launch.py | head
+grep -c 'ensure_positron_console' src/vip_tests/workbench/test_ide_launch.py
 ```
 
 ```output
-30:from vip_tests.workbench.exec import ensure_positron_console, rstudio_eval
-202:    """Best-effort cancel of the New Session dialog, then ``pytest.skip``.
-221:    pytest.skip(reason)
-284:        pytest.skip(reason)
-406:        pytest.skip("No notebook kernel cards available in JupyterLab launcher")
-437:        pytest.skip(
-454:    ``ensure_positron_console`` clicks "Start New Console Session", waits for the
-459:    if not ensure_positron_console(page, timeout=TIMEOUT_IDE_LOAD):
-460:        pytest.skip(
+3
 ```
 
 ```bash
@@ -49,7 +41,7 @@ env -u UV_PROJECT uv run --frozen --no-sync --project . pytest selftests/test_wo
 ```
 
 ```output
-71 passed
+73 passed
 ```
 
 ```bash

--- a/validation_docs/demo-477-positron-console.md
+++ b/validation_docs/demo-477-positron-console.md
@@ -1,0 +1,63 @@
+# fix(workbench): Positron console launch gate (#477)
+
+*2026-07-17T18:26:48Z by Showboat 0.6.1*
+<!-- showboat-id: e19d3e43-916c-452b-b411-4a16b4eba96d -->
+
+Issue #477: test_launch_positron skipped with 'Positron console element not found ... selector may have changed or Positron may not be fully available', even though Positron was installed and reachable. Root cause (found by live diagnosis on dev.current, NOT selector drift): Positron on Workbench 2026+ opens to a Welcome page with NO auto-started console. The console panel (.positron-console) and its input/tab do not exist until a console session is STARTED and an interpreter is selected -- and interpreter discovery is asynchronous (~10s on a cold session). The old gate waited 30s for .positron-console on the Welcome page, where it can never appear, so it produced a false-negative skip. The same console-gated selectors also broke exec.py's _detect_ide and Positron readback.
+
+Fix: a shared, idempotent ensure_positron_console(page) helper clicks 'Start New Console Session', polls the async interpreter quickpick, selects an interpreter, and waits for the console to render. positron_console_accessible calls it then asserts the console panel (skipping with an ACCURATE reason only if no interpreter resolves). _detect_ide now keys off .positron-variables (present even on the Welcome page) so detection no longer depends on a running console. The existing CONSOLE_* selectors were correct and are unchanged.
+
+```bash
+grep -nE 'START_CONSOLE_BUTTON|INTERPRETER_QUICKPICK_ROW' src/vip_tests/workbench/pages/positron_session.py
+```
+
+```output
+32:    START_CONSOLE_BUTTON = 'button[aria-label="Start New Console Session"]'
+33:    # Interpreter rows in the quickpick opened by START_CONSOLE_BUTTON.
+36:    INTERPRETER_QUICKPICK_ROW = (
+```
+
+```bash
+grep -nE 'def ensure_positron_console|VARIABLES_PANE|def _detect_ide|return "positron"' src/vip_tests/workbench/exec.py
+```
+
+```output
+258:def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
+617:def _detect_ide(page: Page) -> str:
+630:        page.locator(PositronSession.VARIABLES_PANE).count() > 0
+633:        return "positron"
+```
+
+```bash
+grep -nE 'ensure_positron_console|pytest.skip' src/vip_tests/workbench/test_ide_launch.py | head
+```
+
+```output
+30:from vip_tests.workbench.exec import ensure_positron_console, rstudio_eval
+202:    """Best-effort cancel of the New Session dialog, then ``pytest.skip``.
+221:    pytest.skip(reason)
+284:        pytest.skip(reason)
+406:        pytest.skip("No notebook kernel cards available in JupyterLab launcher")
+437:        pytest.skip(
+454:    ``ensure_positron_console`` clicks "Start New Console Session", waits for the
+459:    if not ensure_positron_console(page, timeout=TIMEOUT_IDE_LOAD):
+460:        pytest.skip(
+```
+
+```bash
+env -u UV_PROJECT uv run --frozen --no-sync --project . pytest selftests/test_workbench_exec.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
+```
+
+```output
+71 passed
+```
+
+```bash
+env -u UV_PROJECT uv run --frozen --no-sync --project . ruff check src/vip_tests/workbench/exec.py src/vip_tests/workbench/pages/positron_session.py src/vip_tests/workbench/test_ide_launch.py selftests/test_workbench_exec.py
+```
+
+```output
+All checks passed!
+```
+
+Live validation on dev.current.posit.team (interactive browser auth; not re-runnable here). BEFORE: test_launch_positron[chromium] SKIPPED ('Positron console element not found ... may not be fully available'). AFTER this fix: 'test_launch_positron[chromium] ... PASSED' in a full 'vip verify --workbench-url https://dev.current.posit.team --interactive-auth --categories workbench -- -k test_launch_positron' run -- Positron launches, the console session starts, the Python 3.12 interpreter is discovered (~10s) and selected, the console renders, and the assertion passes.


### PR DESCRIPTION
## Summary

`test_launch_positron` skipped with a false "Positron console element not found … selector may have changed or Positron may not be fully available" even though Positron was installed and reachable. Fixes #477.

## Root cause (live diagnosis on dev.current — NOT selector drift)

Positron on Workbench 2026+ opens to a Welcome page with **no auto-started console**. `.positron-console` (and the console tab/instance/input) do not exist until a console session is *started* and an interpreter is selected — and interpreter discovery is **asynchronous (~10s)** on a cold session. The old gate waited 30s for `.positron-console` on the Welcome page, where it can never appear, so it produced a false-negative skip. The earlier "0 interpreters" finding was this same discovery latency read too early. The console-gated selectors also broke `exec.py`'s `_detect_ide` and Positron readback.

## Fix

- New idempotent `ensure_positron_console(page)`: clicks "Start New Console Session", polls the async interpreter quickpick, selects an interpreter, and waits for the console to render. Never raises.
- `positron_console_accessible` calls it, then asserts the console panel — skipping with an **accurate** reason only when no interpreter resolves.
- `_detect_ide` keys off `.positron-variables` (present on the Welcome page) so detection no longer depends on a running console; `positron_eval_r/python` ensure a console first.
- Existing `CONSOLE_*` selectors were correct and are unchanged.

## Live validation (dev.current.posit.team, interactive auth)

`test_launch_positron[chromium]` now **PASSES** end-to-end (was skipping): launch → start console → discover + select Python 3.12 interpreter (~10s) → console renders → assertion passes.

## Test plan

- TDD: 5 new `ensure_positron_console` selftests + 1 console-independent `_detect_ide` test.
- ruff + format clean; mypy clean; 957 selftests pass.

## Demo

# fix(workbench): Positron console launch gate (#477)

*2026-07-17T18:26:48Z by Showboat 0.6.1*
<!-- showboat-id: e19d3e43-916c-452b-b411-4a16b4eba96d -->

Issue #477: test_launch_positron skipped with 'Positron console element not found ... selector may have changed or Positron may not be fully available', even though Positron was installed and reachable. Root cause (found by live diagnosis on dev.current, NOT selector drift): Positron on Workbench 2026+ opens to a Welcome page with NO auto-started console. The console panel (.positron-console) and its input/tab do not exist until a console session is STARTED and an interpreter is selected -- and interpreter discovery is asynchronous (~10s on a cold session). The old gate waited 30s for .positron-console on the Welcome page, where it can never appear, so it produced a false-negative skip. The same console-gated selectors also broke exec.py's _detect_ide and Positron readback.

Fix: a shared, idempotent ensure_positron_console(page) helper clicks 'Start New Console Session', polls the async interpreter quickpick, selects an interpreter, and waits for the console to render. positron_console_accessible calls it then asserts the console panel (skipping with an ACCURATE reason only if no interpreter resolves). _detect_ide now keys off .positron-variables (present even on the Welcome page) so detection no longer depends on a running console. The existing CONSOLE_* selectors were correct and are unchanged.

```bash
grep -nE 'START_CONSOLE_BUTTON|INTERPRETER_QUICKPICK_ROW' src/vip_tests/workbench/pages/positron_session.py
```

```output
32:    START_CONSOLE_BUTTON = 'button[aria-label="Start New Console Session"]'
33:    # Interpreter rows in the quickpick opened by START_CONSOLE_BUTTON.
36:    INTERPRETER_QUICKPICK_ROW = (
```

```bash
grep -nE 'def ensure_positron_console|VARIABLES_PANE|def _detect_ide|return "positron"' src/vip_tests/workbench/exec.py
```

```output
258:def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
617:def _detect_ide(page: Page) -> str:
630:        page.locator(PositronSession.VARIABLES_PANE).count() > 0
633:        return "positron"
```

```bash
grep -nE 'ensure_positron_console|pytest.skip' src/vip_tests/workbench/test_ide_launch.py | head
```

```output
30:from vip_tests.workbench.exec import ensure_positron_console, rstudio_eval
202:    """Best-effort cancel of the New Session dialog, then ``pytest.skip``.
221:    pytest.skip(reason)
284:        pytest.skip(reason)
406:        pytest.skip("No notebook kernel cards available in JupyterLab launcher")
437:        pytest.skip(
454:    ``ensure_positron_console`` clicks "Start New Console Session", waits for the
459:    if not ensure_positron_console(page, timeout=TIMEOUT_IDE_LOAD):
460:        pytest.skip(
```

```bash
env -u UV_PROJECT uv run --frozen --no-sync --project . pytest selftests/test_workbench_exec.py -q 2>&1 | grep -E 'passed|failed|error' | sed 's/ in [0-9.]*s//'
```

```output
71 passed
```

```bash
env -u UV_PROJECT uv run --frozen --no-sync --project . ruff check src/vip_tests/workbench/exec.py src/vip_tests/workbench/pages/positron_session.py src/vip_tests/workbench/test_ide_launch.py selftests/test_workbench_exec.py
```

```output
All checks passed!
```

Live validation on dev.current.posit.team (interactive browser auth; not re-runnable here). BEFORE: test_launch_positron[chromium] SKIPPED ('Positron console element not found ... may not be fully available'). AFTER this fix: 'test_launch_positron[chromium] ... PASSED' in a full 'vip verify --workbench-url https://dev.current.posit.team --interactive-auth --categories workbench -- -k test_launch_positron' run -- Positron launches, the console session starts, the Python 3.12 interpreter is discovered (~10s) and selected, the console renders, and the assertion passes.
