### PR TITLE
fix(connect): redact license and job keys from system check report

### DIFF
--- a/selftests/test_system_checks.py
+++ b/selftests/test_system_checks.py
@@ -1,0 +1,144 @@
+"""Tests for the license-output redaction helpers in test_system_checks."""
+
+from __future__ import annotations
+
+import pytest
+
+from vip_tests.connect.test_system_checks import (
+    _REDACTED,
+    _redact_license_outputs,
+    _scrub_license_keys,
+)
+
+# A realistic Posit product key shape (seven groups of four).
+_SAMPLE_KEY = "A33R-D4BT-JFGA-NBA3-A6VF-AUGQ-PSTA"
+
+
+def _make_result(group: str, test: str, output: str = "data", error: str = "") -> dict:
+    return {"group": {"name": group}, "test": {"name": test}, "output": output, "error": error}
+
+
+class TestRedactLicenseOutputs:
+    def test_license_group_is_redacted(self):
+        results = [_make_result("License", "activation check", output="key=SECRET")]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == _REDACTED
+        assert redacted[0]["error"] == _REDACTED
+
+    def test_license_in_test_name_is_redacted(self):
+        results = [_make_result("System", "license validity", output="key=SECRET")]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == _REDACTED
+        assert redacted[0]["error"] == _REDACTED
+
+    def test_connect_license_check_is_redacted(self):
+        # This is the real check that leaked the key in the example report.
+        results = [_make_result("server", "connect-license", output=f"Product-Key: {_SAMPLE_KEY}")]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == _REDACTED
+
+    def test_non_license_check_is_not_redacted(self):
+        results = [_make_result("Database", "connection", output="ok", error="")]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == "ok"
+        assert redacted[0]["error"] == ""
+
+    def test_case_insensitive_group_match(self):
+        results = [_make_result("LICENSE", "check", output="secret")]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == _REDACTED
+
+    def test_case_insensitive_test_name_match(self):
+        results = [_make_result("System", "LICENSE_CHECK", output="secret")]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == _REDACTED
+
+    def test_mixed_results_selective_redaction(self):
+        results = [
+            _make_result("License", "key", output="ABC-123"),
+            _make_result("Runtime", "r_version", output="4.3.1"),
+            _make_result("License", "expiry", output="2030-01-01"),
+        ]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == _REDACTED
+        assert redacted[1]["output"] == "4.3.1"
+        assert redacted[2]["output"] == _REDACTED
+
+    def test_original_results_are_not_mutated(self):
+        original = [_make_result("License", "key", output="SECRET")]
+        _redact_license_outputs(original)
+        assert original[0]["output"] == "SECRET"
+
+    def test_original_results_not_mutated_by_pattern_scrub(self):
+        original = [_make_result("Database", "status", output=f"key {_SAMPLE_KEY}")]
+        _redact_license_outputs(original)
+        assert original[0]["output"] == f"key {_SAMPLE_KEY}"
+
+    def test_empty_list(self):
+        assert _redact_license_outputs([]) == []
+
+    def test_missing_group_key(self):
+        result = {"test": {"name": "license check"}, "output": "key=X", "error": ""}
+        redacted = _redact_license_outputs([result])
+        assert redacted[0]["output"] == _REDACTED
+
+    def test_missing_test_key(self):
+        result = {"group": {"name": "License"}, "output": "key=X", "error": ""}
+        redacted = _redact_license_outputs([result])
+        assert redacted[0]["output"] == _REDACTED
+
+    @pytest.mark.parametrize(
+        "group,test",
+        [
+            ("", ""),
+            ("Runtime", "r_version"),
+            ("Database", "postgres"),
+        ],
+    )
+    def test_non_license_checks_pass_through(self, group, test):
+        results = [_make_result(group, test, output="some output", error="some error")]
+        redacted = _redact_license_outputs(results)
+        assert redacted[0]["output"] == "some output"
+        assert redacted[0]["error"] == "some error"
+
+    def test_key_in_non_license_check_output_is_scrubbed(self):
+        # Defense in depth: a key surfacing in a check whose name does not
+        # mention "license" is still scrubbed, without wiping the whole field.
+        results = [_make_result("server", "config-dump", output=f"license = {_SAMPLE_KEY}\nok")]
+        redacted = _redact_license_outputs(results)
+        assert _SAMPLE_KEY not in redacted[0]["output"]
+        assert _REDACTED in redacted[0]["output"]
+        assert "ok" in redacted[0]["output"]
+
+    def test_key_in_non_license_check_error_is_scrubbed(self):
+        results = [_make_result("server", "config-dump", output="", error=f"bad key {_SAMPLE_KEY}")]
+        redacted = _redact_license_outputs(results)
+        assert _SAMPLE_KEY not in redacted[0]["error"]
+        assert _REDACTED in redacted[0]["error"]
+
+
+class TestScrubLicenseKeys:
+    def test_exact_key_is_scrubbed(self):
+        assert _scrub_license_keys(_SAMPLE_KEY) == _REDACTED
+
+    def test_key_embedded_in_text_is_scrubbed(self):
+        assert _scrub_license_keys(f"Product-Key: {_SAMPLE_KEY} Has-Key: Yes") == (
+            f"Product-Key: {_REDACTED} Has-Key: Yes"
+        )
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "4.3.1",
+            "ABC-123",
+            "no keys here",
+            "AAAA-BBBB-CCCC",  # too few groups
+            "",
+        ],
+    )
+    def test_non_key_text_is_left_alone(self, text):
+        assert _scrub_license_keys(text) == text
+
+    def test_non_string_values_pass_through(self):
+        assert _scrub_license_keys(None) is None
+        assert _scrub_license_keys(42) == 42

--- a/selftests/test_system_checks.py
+++ b/selftests/test_system_checks.py
@@ -7,11 +7,16 @@ import pytest
 from vip_tests.connect.test_system_checks import (
     _REDACTED,
     _redact_license_outputs,
+    _scrub_job_keys,
     _scrub_license_keys,
 )
 
 # A realistic Posit product key shape (seven groups of four).
 _SAMPLE_KEY = "A33R-D4BT-JFGA-NBA3-A6VF-AUGQ-PSTA"
+
+# A Connect session job key as printed by the connect-session process, e.g.
+# "[connect-session] Job Key: ZbPLlfduV5wlvLb1".
+_SAMPLE_JOB_KEY = "ZbPLlfduV5wlvLb1"
 
 
 def _make_result(group: str, test: str, output: str = "data", error: str = "") -> dict:
@@ -116,6 +121,30 @@ class TestRedactLicenseOutputs:
         assert _SAMPLE_KEY not in redacted[0]["error"]
         assert _REDACTED in redacted[0]["error"]
 
+    def test_job_key_in_non_license_check_is_scrubbed(self):
+        # The rmarkdown-sandbox check echoes the connect-session job key, which
+        # is neither a "license" check nor a license-key-shaped token, so it must
+        # be scrubbed by its own layer while leaving the surrounding log intact.
+        output = f"[connect-session] Job Key: {_SAMPLE_JOB_KEY}\nJob started"
+        results = [_make_result("rmarkdown-sandbox", "mounts", output=output)]
+        redacted = _redact_license_outputs(results)
+        assert _SAMPLE_JOB_KEY not in redacted[0]["output"]
+        assert _REDACTED in redacted[0]["output"]
+        assert "Job started" in redacted[0]["output"]
+
+    def test_job_key_in_non_license_check_error_is_scrubbed(self):
+        error = f"Job Key: {_SAMPLE_JOB_KEY}"
+        results = [_make_result("rmarkdown-sandbox", "mounts", output="", error=error)]
+        redacted = _redact_license_outputs(results)
+        assert _SAMPLE_JOB_KEY not in redacted[0]["error"]
+        assert _REDACTED in redacted[0]["error"]
+
+    def test_original_results_not_mutated_by_job_key_scrub(self):
+        output = f"Job Key: {_SAMPLE_JOB_KEY}"
+        original = [_make_result("rmarkdown-sandbox", "mounts", output=output)]
+        _redact_license_outputs(original)
+        assert original[0]["output"] == output
+
 
 class TestScrubLicenseKeys:
     def test_exact_key_is_scrubbed(self):
@@ -142,3 +171,40 @@ class TestScrubLicenseKeys:
     def test_non_string_values_pass_through(self):
         assert _scrub_license_keys(None) is None
         assert _scrub_license_keys(42) == 42
+
+
+class TestScrubJobKeys:
+    def test_job_key_after_label_is_scrubbed(self):
+        line = f"[connect-session] Job Key: {_SAMPLE_JOB_KEY}"
+        assert _scrub_job_keys(line) == "[connect-session] Job Key: [redacted]"
+
+    def test_label_is_preserved(self):
+        result = _scrub_job_keys(f"Job Key: {_SAMPLE_JOB_KEY}")
+        assert result == f"Job Key: {_REDACTED}"
+        assert _SAMPLE_JOB_KEY not in result
+
+    def test_multiline_output_only_key_scrubbed(self):
+        text = f"line one\n[connect-session] Job Key: {_SAMPLE_JOB_KEY}\nJob started"
+        scrubbed = _scrub_job_keys(text)
+        assert _SAMPLE_JOB_KEY not in scrubbed
+        assert "line one" in scrubbed
+        assert "Job started" in scrubbed
+
+    def test_case_insensitive_label_match(self):
+        assert _scrub_job_keys(f"job key: {_SAMPLE_JOB_KEY}") == f"job key: {_REDACTED}"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "no job key here",
+            "Jobs Key: value",  # not the "Job Key:" label
+            "4.3.1",
+            "",
+        ],
+    )
+    def test_text_without_job_key_label_is_left_alone(self, text):
+        assert _scrub_job_keys(text) == text
+
+    def test_non_string_values_pass_through(self):
+        assert _scrub_job_keys(None) is None
+        assert _scrub_job_keys(42) == 42

--- a/selftests/test_system_checks.py
+++ b/selftests/test_system_checks.py
@@ -1,4 +1,4 @@
-"""Tests for the license-output redaction helpers in test_system_checks."""
+"""Tests for the secret redaction helpers in test_system_checks."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import pytest
 
 from vip_tests.connect.test_system_checks import (
     _REDACTED,
-    _redact_license_outputs,
+    _redact_sensitive_outputs,
     _scrub_job_keys,
     _scrub_license_keys,
 )
@@ -26,36 +26,36 @@ def _make_result(group: str, test: str, output: str = "data", error: str = "") -
 class TestRedactLicenseOutputs:
     def test_license_group_is_redacted(self):
         results = [_make_result("License", "activation check", output="key=SECRET")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == _REDACTED
         assert redacted[0]["error"] == _REDACTED
 
     def test_license_in_test_name_is_redacted(self):
         results = [_make_result("System", "license validity", output="key=SECRET")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == _REDACTED
         assert redacted[0]["error"] == _REDACTED
 
     def test_connect_license_check_is_redacted(self):
         # This is the real check that leaked the key in the example report.
         results = [_make_result("server", "connect-license", output=f"Product-Key: {_SAMPLE_KEY}")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == _REDACTED
 
     def test_non_license_check_is_not_redacted(self):
         results = [_make_result("Database", "connection", output="ok", error="")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == "ok"
         assert redacted[0]["error"] == ""
 
     def test_case_insensitive_group_match(self):
         results = [_make_result("LICENSE", "check", output="secret")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == _REDACTED
 
     def test_case_insensitive_test_name_match(self):
         results = [_make_result("System", "LICENSE_CHECK", output="secret")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == _REDACTED
 
     def test_mixed_results_selective_redaction(self):
@@ -64,32 +64,32 @@ class TestRedactLicenseOutputs:
             _make_result("Runtime", "r_version", output="4.3.1"),
             _make_result("License", "expiry", output="2030-01-01"),
         ]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == _REDACTED
         assert redacted[1]["output"] == "4.3.1"
         assert redacted[2]["output"] == _REDACTED
 
     def test_original_results_are_not_mutated(self):
         original = [_make_result("License", "key", output="SECRET")]
-        _redact_license_outputs(original)
+        _redact_sensitive_outputs(original)
         assert original[0]["output"] == "SECRET"
 
     def test_original_results_not_mutated_by_pattern_scrub(self):
         original = [_make_result("Database", "status", output=f"key {_SAMPLE_KEY}")]
-        _redact_license_outputs(original)
+        _redact_sensitive_outputs(original)
         assert original[0]["output"] == f"key {_SAMPLE_KEY}"
 
     def test_empty_list(self):
-        assert _redact_license_outputs([]) == []
+        assert _redact_sensitive_outputs([]) == []
 
     def test_missing_group_key(self):
         result = {"test": {"name": "license check"}, "output": "key=X", "error": ""}
-        redacted = _redact_license_outputs([result])
+        redacted = _redact_sensitive_outputs([result])
         assert redacted[0]["output"] == _REDACTED
 
     def test_missing_test_key(self):
         result = {"group": {"name": "License"}, "output": "key=X", "error": ""}
-        redacted = _redact_license_outputs([result])
+        redacted = _redact_sensitive_outputs([result])
         assert redacted[0]["output"] == _REDACTED
 
     @pytest.mark.parametrize(
@@ -102,7 +102,7 @@ class TestRedactLicenseOutputs:
     )
     def test_non_license_checks_pass_through(self, group, test):
         results = [_make_result(group, test, output="some output", error="some error")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert redacted[0]["output"] == "some output"
         assert redacted[0]["error"] == "some error"
 
@@ -110,14 +110,14 @@ class TestRedactLicenseOutputs:
         # Defense in depth: a key surfacing in a check whose name does not
         # mention "license" is still scrubbed, without wiping the whole field.
         results = [_make_result("server", "config-dump", output=f"license = {_SAMPLE_KEY}\nok")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert _SAMPLE_KEY not in redacted[0]["output"]
         assert _REDACTED in redacted[0]["output"]
         assert "ok" in redacted[0]["output"]
 
     def test_key_in_non_license_check_error_is_scrubbed(self):
         results = [_make_result("server", "config-dump", output="", error=f"bad key {_SAMPLE_KEY}")]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert _SAMPLE_KEY not in redacted[0]["error"]
         assert _REDACTED in redacted[0]["error"]
 
@@ -127,7 +127,7 @@ class TestRedactLicenseOutputs:
         # be scrubbed by its own layer while leaving the surrounding log intact.
         output = f"[connect-session] Job Key: {_SAMPLE_JOB_KEY}\nJob started"
         results = [_make_result("rmarkdown-sandbox", "mounts", output=output)]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert _SAMPLE_JOB_KEY not in redacted[0]["output"]
         assert _REDACTED in redacted[0]["output"]
         assert "Job started" in redacted[0]["output"]
@@ -135,14 +135,14 @@ class TestRedactLicenseOutputs:
     def test_job_key_in_non_license_check_error_is_scrubbed(self):
         error = f"Job Key: {_SAMPLE_JOB_KEY}"
         results = [_make_result("rmarkdown-sandbox", "mounts", output="", error=error)]
-        redacted = _redact_license_outputs(results)
+        redacted = _redact_sensitive_outputs(results)
         assert _SAMPLE_JOB_KEY not in redacted[0]["error"]
         assert _REDACTED in redacted[0]["error"]
 
     def test_original_results_not_mutated_by_job_key_scrub(self):
         output = f"Job Key: {_SAMPLE_JOB_KEY}"
         original = [_make_result("rmarkdown-sandbox", "mounts", output=output)]
-        _redact_license_outputs(original)
+        _redact_sensitive_outputs(original)
         assert original[0]["output"] == output
 
 

--- a/src/vip_tests/connect/test_system_checks.py
+++ b/src/vip_tests/connect/test_system_checks.py
@@ -43,7 +43,7 @@ def _scrub_secrets(value: Any) -> Any:
     return _scrub_job_keys(_scrub_license_keys(value))
 
 
-def _redact_license_outputs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _redact_sensitive_outputs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return a copy of *results* with sensitive data removed.
 
     Connect system check results echo the running configuration, and some checks
@@ -120,7 +120,7 @@ def download_report_artifact(connect_client, system_check, pytestconfig):
     if vip_report:
         safe_results = {
             **results,
-            "results": _redact_license_outputs(results.get("results", [])),
+            "results": _redact_sensitive_outputs(results.get("results") or []),
         }
         artifact_path = Path(vip_report).parent / "connect_system_checks.json"
         artifact_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/vip_tests/connect/test_system_checks.py
+++ b/src/vip_tests/connect/test_system_checks.py
@@ -3,9 +3,54 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
+from typing import Any
 
 from pytest_bdd import scenario, then, when
+
+_REDACTED = "[redacted]"
+
+# Posit license keys are seven hyphen-separated groups of four uppercase
+# alphanumerics (e.g. ABCD-1234-EFGH-5678-IJKL-9012-MNOP). Scrub anything of
+# this shape so a key never reaches the report even if it surfaces in a check
+# whose name does not mention "license".
+_LICENSE_KEY_RE = re.compile(r"\b[A-Z0-9]{4}(?:-[A-Z0-9]{4}){6}\b")
+
+
+def _scrub_license_keys(value: Any) -> Any:
+    """Replace Posit-license-key-shaped tokens in *value* if it is a string."""
+    if isinstance(value, str):
+        return _LICENSE_KEY_RE.sub(_REDACTED, value)
+    return value
+
+
+def _redact_license_outputs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of *results* with license data removed.
+
+    Connect system check results echo the running configuration, and the
+    license checks (e.g. ``connect-license`` runs ``license-manager status``)
+    print the activated product key. Two layers guard against that key reaching
+    the saved artifact or the rendered report:
+
+    * Any check whose group or test name mentions "license" has its ``output``
+      and ``error`` fully redacted.
+    * Every other ``output``/``error`` is scrubbed for anything shaped like a
+      Posit license key, as defense in depth for unexpectedly named checks.
+
+    The input is not mutated.
+    """
+    redacted = []
+    for r in results:
+        group_name = (r.get("group") or {}).get("name", "")
+        test_name = (r.get("test") or {}).get("name", "")
+        if "license" in group_name.lower() or "license" in test_name.lower():
+            r = {**r, "output": _REDACTED, "error": _REDACTED}
+        else:
+            scrubbed = {k: _scrub_license_keys(r[k]) for k in ("output", "error") if k in r}
+            r = {**r, **scrubbed}
+        redacted.append(r)
+    return redacted
 
 
 @scenario(
@@ -49,11 +94,17 @@ def download_report_artifact(connect_client, system_check, pytestconfig):
     assert results, f"System check results for id={check_id!r} were empty"
 
     # Persist alongside results.json so the Quarto report can embed it.
+    # Redact license check output/error before writing so that license keys
+    # never appear in the saved artifact or the rendered report.
     vip_report = pytestconfig.getoption("--vip-report")
     if vip_report:
+        safe_results = {
+            **results,
+            "results": _redact_license_outputs(results.get("results", [])),
+        }
         artifact_path = Path(vip_report).parent / "connect_system_checks.json"
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
         artifact_path.write_text(
-            json.dumps(results, indent=2) + "\n",
+            json.dumps(safe_results, indent=2) + "\n",
             encoding="utf-8",
         )

--- a/src/vip_tests/connect/test_system_checks.py
+++ b/src/vip_tests/connect/test_system_checks.py
@@ -17,6 +17,12 @@ _REDACTED = "[redacted]"
 # whose name does not mention "license".
 _LICENSE_KEY_RE = re.compile(r"\b[A-Z0-9]{4}(?:-[A-Z0-9]{4}){6}\b")
 
+# Connect session checks (e.g. rmarkdown-sandbox) echo the session job key on a
+# line like "[connect-session] Job Key: ZbPLlfduV5wlvLb1". The key itself has no
+# fixed shape, so anchor on the "Job Key:" label and redact only the token that
+# follows, leaving the rest of the diagnostic log intact.
+_JOB_KEY_RE = re.compile(r"(Job Key:\s*)(\S+)", re.IGNORECASE)
+
 
 def _scrub_license_keys(value: Any) -> Any:
     """Replace Posit-license-key-shaped tokens in *value* if it is a string."""
@@ -25,18 +31,32 @@ def _scrub_license_keys(value: Any) -> Any:
     return value
 
 
-def _redact_license_outputs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Return a copy of *results* with license data removed.
+def _scrub_job_keys(value: Any) -> Any:
+    """Redact the token following a ``Job Key:`` label if *value* is a string."""
+    if isinstance(value, str):
+        return _JOB_KEY_RE.sub(rf"\g<1>{_REDACTED}", value)
+    return value
 
-    Connect system check results echo the running configuration, and the
-    license checks (e.g. ``connect-license`` runs ``license-manager status``)
-    print the activated product key. Two layers guard against that key reaching
-    the saved artifact or the rendered report:
+
+def _scrub_secrets(value: Any) -> Any:
+    """Scrub license keys and session job keys from a string value."""
+    return _scrub_job_keys(_scrub_license_keys(value))
+
+
+def _redact_license_outputs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of *results* with sensitive data removed.
+
+    Connect system check results echo the running configuration, and some checks
+    print secrets: the license checks (e.g. ``connect-license`` runs
+    ``license-manager status``) print the activated product key, and session
+    checks (e.g. ``rmarkdown-sandbox``) print the connect-session job key.
+    Layers guard against those reaching the saved artifact or rendered report:
 
     * Any check whose group or test name mentions "license" has its ``output``
       and ``error`` fully redacted.
     * Every other ``output``/``error`` is scrubbed for anything shaped like a
-      Posit license key, as defense in depth for unexpectedly named checks.
+      Posit license key or following a ``Job Key:`` label, as defense in depth
+      for unexpectedly named checks.
 
     The input is not mutated.
     """
@@ -47,7 +67,7 @@ def _redact_license_outputs(results: list[dict[str, Any]]) -> list[dict[str, Any
         if "license" in group_name.lower() or "license" in test_name.lower():
             r = {**r, "output": _REDACTED, "error": _REDACTED}
         else:
-            scrubbed = {k: _scrub_license_keys(r[k]) for k in ("output", "error") if k in r}
+            scrubbed = {k: _scrub_secrets(r[k]) for k in ("output", "error") if k in r}
             r = {**r, **scrubbed}
         redacted.append(r)
     return redacted


### PR DESCRIPTION
## Problem

Connect system check results echo the running configuration and we don't want all of this in there:

- `connect-license` runs `license-manager status`, which prints the activated `Product-Key`.
- session checks such as `rmarkdown-sandbox` print the connect-session `Job Key`.  (This isn't really a problem but triggers GitHub security scanning)

`test_system_checks.py` wrote those results verbatim to `connect_system_checks.json`, which the Quarto report embeds. The rendered report is published to the public `gh-pages` site (as `example-report/` and in every PR-preview snapshot), so the license key was exposed publicly and flagged by secret scanning.

## Fix

Redact before persisting the artifact, in layers:

- Fully redact `output`/`error` for any check whose group or test name mentions "license" (covers `connect-license`).
- Scrub anything shaped like a Posit product key (seven hyphen-separated groups of four) from all other check output, as defense in depth for unexpectedly named checks.
- Redact the token following a `Job Key:` label, leaving the rest of the diagnostic log intact.

The report and the example-report workflow are unchanged; once this lands, the regenerated report shows `[redacted]`.

## Testing

- `uvx ruff@0.15.0 check` / `format --check` clean.
- `uv run pytest selftests/test_system_checks.py` — 37 passed (both redaction layers, non-mutation of inputs, non-key text left alone).
- Full selftest suite green; the product test still collects.

