### PR TITLE
feat(plugin): truncate test node paths in verify output unless verbose

### DIFF
--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 import pytest
 
-from vip.plugin import _extract_exception_info, _format_concise_error
+from vip.plugin import (
+    _extract_exception_info,
+    _format_concise_error,
+    _shorten_location_line,
+)
 
 
 class TestFormatConciseError:
@@ -156,6 +160,32 @@ class TestExtractExceptionInfo:
         assert "Connect: /metrics returned 403" in exc_message
 
 
+class TestShortenLocationLine:
+    def test_strips_site_packages_prefix(self):
+        line = (
+            "../../../../.local/share/uv/tools/posit-vip/lib/python3.13/"
+            "site-packages/vip_tests/connect/test_auth.py::test_connect_login_ui "
+        )
+        assert _shorten_location_line(line) == "connect/test_auth.py::test_connect_login_ui "
+
+    def test_keeps_relative_suffix_and_trailing_space(self):
+        line = "vip_tests/prerequisites/test_components.py::test_reachable[Connect] "
+        assert (
+            _shorten_location_line(line)
+            == "prerequisites/test_components.py::test_reachable[Connect] "
+        )
+
+    def test_passes_through_line_without_marker(self):
+        line = "my_extension/test_health.py::test_ping "
+        assert _shorten_location_line(line) == line
+
+    def test_uses_last_marker_occurrence(self):
+        # A path that itself contains the marker earlier must not win over the
+        # real package root.
+        line = "/home/vip_tests/checkout/site-packages/vip_tests/security/test_tls.py::test_https "
+        assert _shorten_location_line(line) == "security/test_tls.py::test_https "
+
+
 class TestPluginIntegration:
     """Integration tests using pytester to exercise the plugin end-to-end.
 
@@ -184,6 +214,27 @@ class TestPluginIntegration:
         result = selftest_pytester.runpytest("--vip-config=vip.toml", "-v")
         result.assert_outcomes()
         result.stdout.fnmatch_lines(["*1 deselected*"])
+
+    def test_location_line_shortened_in_concise_mode(self, selftest_pytester):
+        """A test collected under a vip_tests/ package shows a truncated path."""
+        pkg = selftest_pytester.mkpydir("vip_tests")
+        (pkg / "test_sample.py").write_text("def test_ok():\n    assert True\n")
+        result = selftest_pytester.runpytest_subprocess(
+            "--vip-config=vip.toml", "-v", str(pkg / "test_sample.py")
+        )
+        result.assert_outcomes(passed=1)
+        result.stdout.fnmatch_lines(["test_sample.py::test_ok*"])
+        result.stdout.no_fnmatch_line("*vip_tests/test_sample.py::test_ok*")
+
+    def test_location_line_full_path_when_verbose(self, selftest_pytester):
+        """--vip-verbose keeps the full node path so debugging is unaffected."""
+        pkg = selftest_pytester.mkpydir("vip_tests")
+        (pkg / "test_sample.py").write_text("def test_ok():\n    assert True\n")
+        result = selftest_pytester.runpytest_subprocess(
+            "--vip-config=vip.toml", "--vip-verbose", "-v", str(pkg / "test_sample.py")
+        )
+        result.assert_outcomes(passed=1)
+        result.stdout.fnmatch_lines(["*vip_tests/test_sample.py::test_ok*"])
 
     def test_pytest_bdd_removed_in10_warning_suppressed(self, selftest_pytester):
         """pytest-bdd's fixture injection emits PytestRemovedIn10Warning on

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -360,9 +360,67 @@ def pytest_configure_node(node) -> None:
         node.workerinput["vip_workbench_auth_error"] = auth.workbench_auth_error or ""
 
 
+# The installed test package root.  pytest node paths are "/"-normalized
+# (see _pytest.terminal._locationline), so the marker uses a forward slash on
+# every platform.
+_TEST_PKG_MARKER = "vip_tests/"
+
+
+def _shorten_location_line(line: str) -> str:
+    """Drop the install-path prefix from a pytest ``-v`` location line.
+
+    ``vip verify`` runs pytest with ``-v``, so every result line is prefixed
+    with the node's path.  When VIP is installed as a tool that path is the
+    long site-packages location, e.g.::
+
+        ../../../.local/share/uv/tools/posit-vip/lib/python3.13/site-packages/vip_tests/connect/test_auth.py::test_connect_login_ui
+
+    Keeping only the portion after the ``vip_tests/`` package root puts the
+    meaningful part first::
+
+        connect/test_auth.py::test_connect_login_ui
+
+    Lines without the marker (e.g. user extension tests collected from an
+    arbitrary directory) are returned unchanged.  Uses ``rfind`` so a marker
+    substring appearing earlier in an install path never wins over the real
+    package root.
+    """
+    idx = line.rfind(_TEST_PKG_MARKER)
+    if idx == -1:
+        return line
+    return line[idx + len(_TEST_PKG_MARKER) :]
+
+
+def _install_location_shortener(config: pytest.Config) -> None:
+    """Wrap the terminal reporter's ``_locationline`` to truncate node paths.
+
+    Only active in concise (non-``--vip-verbose``) mode.  There is no public
+    hook for the per-test location string, so we wrap the bound method on the
+    registered reporter instance.  Under xdist this runs on the controller,
+    which is where result lines are rendered, so worker output is covered too.
+    """
+    if config.getoption("--vip-verbose", default=False):
+        return
+    tr = config.pluginmanager.get_plugin("terminalreporter")
+    if tr is None:
+        return
+    original = tr._locationline
+
+    def shortened(*args: Any, **kwargs: Any) -> str:
+        return _shorten_location_line(original(*args, **kwargs))
+
+    tr._locationline = shortened  # type: ignore[method-assign]
+
+
 def pytest_sessionstart(session: pytest.Session) -> None:
     """Add extension directories to sys.path so their conftest / modules
-    are importable, and register them for collection."""
+    are importable, register them for collection, and shorten node paths."""
+    # Wrap the terminal reporter here rather than in pytest_configure: the
+    # builtin terminal plugin registers "terminalreporter" in its own
+    # pytest_configure, which pluggy may call after ours.  By sessionstart the
+    # reporter is guaranteed to exist.
+    _install_location_shortener(session.config)
+
     ext_dirs = session.config.stash.get(_ext_dirs_key, [])
     for d in ext_dirs:
         p = Path(d).resolve()


### PR DESCRIPTION
## Summary

Closes #502.

`vip verify` always runs pytest with `-v` (`cli.py:456`), so every result line is prefixed with the node's path. When VIP is installed as a tool (`uv tool install posit-vip`), that path is the long site-packages location:

```
../../../../.local/share/uv/tools/posit-vip/lib/python3.13/site-packages/vip_tests/connect/test_auth.py::test_connect_login_ui PASSED [  6%]
```

This buries the only part that matters. After this change, the default (non-verbose) run shows:

```
connect/test_auth.py::test_connect_login_ui PASSED [  6%]
```

## How

There is no public pytest hook for the per-test location string, so the fix wraps the terminal reporter's `_locationline` method on the registered instance, keeping only the portion after the `vip_tests/` package root. The wrap is installed in `pytest_sessionstart` (the reporter is guaranteed registered by then) and under xdist runs on the controller, where result lines are rendered.

- **Gated on verbosity:** wrapping is skipped when `--vip-verbose` is set, so the full path is preserved for debugging.
- **Extension tests:** lines with no `vip_tests/` marker (user extensions collected from arbitrary dirs) pass through unchanged.
- **`rfind`** is used so a `vip_tests/` substring earlier in an install path never wins over the real package root.

This is the near-term fix described in the issue. The longer-term goal — friendly per-test display names — is left for a follow-up.

## Test plan

- New unit tests for `_shorten_location_line` (prefix strip, passthrough, trailing-space preservation, last-occurrence wins).
- New `pytester` integration tests: truncated path in concise mode, full path under `--vip-verbose`.
- `uv run pytest selftests/test_plugin.py` → 85 passed.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)