### PR TITLE
test(workbench): parallelize tests instead of forcing serial

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,10 @@ markers = [
     "min_version(product, version): only run when product meets minimum version",
     "if_applicable: test is skipped when the feature is not configured",
     "api_auth: test requires only an API key, not browser credentials",
+    "rstudio: Workbench RStudio IDE-launch scenario",
+    "vscode: Workbench VS Code IDE-launch scenario",
+    "jupyter: Workbench JupyterLab IDE-launch scenario",
+    "positron: Workbench Positron IDE-launch scenario",
 ]
 
 [tool.semantic_release]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "filelock>=3.12",
     "httpx>=0.27,<1",
     "playwright>=1.40",
     "pyotp~=2.9",

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -1181,3 +1181,73 @@ class TestReorderHelpArgs:
         # argparse exits 0 after printing help; a nonzero/None code would mean
         # it fell through to running the command instead.
         assert exc.value.code == 0
+
+
+class TestVerifyDefaultXdist:
+    """`vip verify` injects a conservative default worker count and grouping
+    dist mode so pip-installed users get parallel-by-group execution too --
+    pyproject.toml's addopts only apply from this repo's own rootdir.
+
+    2 workers is the safe default: product tests log real sessions in against
+    a shared deployment and a single shared test account, and higher default
+    concurrency intermittently storms the OIDC IdP and exceeds small
+    deployments' concurrent-session capacity. Users raise it with
+    ``-- -n N`` when their deployment can handle more.
+    """
+
+    def test_default_run_injects_n_2_and_dist_loadgroup(self, tmp_path):
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg)))
+        assert "-n" in cmd
+        assert cmd[cmd.index("-n") + 1] == "2"
+        assert "--dist" in cmd
+        assert cmd[cmd.index("--dist") + 1] == "loadgroup"
+
+    def test_user_numprocesses_split_form_not_overridden(self, tmp_path):
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), pytest_args=["-n", "4"]))
+        # The vip-supplied default pair must not appear...
+        assert not any(cmd[i] == "-n" and cmd[i + 1] == "2" for i in range(len(cmd) - 1))
+        # ...while the user's own choice survives.
+        assert any(cmd[i] == "-n" and cmd[i + 1] == "4" for i in range(len(cmd) - 1))
+
+    def test_user_numprocesses_glued_form_not_overridden(self, tmp_path):
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), pytest_args=["-n4"]))
+        assert "-n4" in cmd
+        assert not any(cmd[i] == "-n" and cmd[i + 1] == "2" for i in range(len(cmd) - 1))
+
+    def test_user_numprocesses_long_glued_form_not_overridden(self, tmp_path):
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), pytest_args=["--numprocesses=8"]))
+        assert "--numprocesses=8" in cmd
+        assert not any(cmd[i] == "-n" and cmd[i + 1] == "2" for i in range(len(cmd) - 1))
+
+    def test_p_no_xdist_disables_both_defaults(self, tmp_path):
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), pytest_args=["-p", "no:xdist"]))
+        assert not any(cmd[i] == "-n" and cmd[i + 1] == "2" for i in range(len(cmd) - 1))
+        assert "--dist" not in cmd
+
+    def test_user_dist_load_not_overridden(self, tmp_path):
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), pytest_args=["--dist", "load"]))
+        assert not any(
+            cmd[i] == "--dist" and cmd[i + 1] == "loadgroup" for i in range(len(cmd) - 1)
+        )
+        assert any(cmd[i] == "--dist" and cmd[i + 1] == "load" for i in range(len(cmd) - 1))
+
+    def test_defaults_come_before_user_pytest_args(self, tmp_path):
+        """Injected defaults are appended before user args, so an explicit
+        later -n/--dist in pytest_args still wins in edge cases."""
+        cfg = tmp_path / "vip.toml"
+        cfg.write_text("[general]\n")
+        cmd = _capture_cmd(_make_args(config=str(cfg), pytest_args=["--tb=short"]))
+        assert cmd.index("-n") < cmd.index("--tb=short")
+        assert cmd.index("--dist") < cmd.index("--tb=short")

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -1040,6 +1040,64 @@ class TestXdistCompatibility:
         assert "scenario_title" in r
         assert "feature_description" in r
 
+    def test_verbose_xdist_output_is_one_line_per_test(self, selftest_pytester):
+        """Under real parallel timing (-n 2 -v), each test gets one contiguous line.
+
+        Sleeps force genuine overlap between workers so their events actually
+        interleave on the controller (a fast no-op suite may finish one
+        worker's test before the other's even starts, masking the bug).
+        With the built-in TerminalReporter's non-xdist code path (entered
+        because we delete ``report.node`` to hide ``[gw<N>]``), a test's
+        location is written by ``pytest_runtest_logstart`` and its outcome by
+        ``pytest_runtest_logreport`` as two separate writes. Those hooks fire
+        from whichever worker event the controller processes next, so with
+        real workers running concurrently the location line for one test can
+        land, then another worker's events interleave, before that test's
+        outcome line finally appears -- producing a location-only line with
+        no PASSED/FAILED and a later, disconnected result line.
+        """
+        selftest_pytester.makepyfile(
+            """
+            import time
+
+            def test_one():
+                time.sleep(0.3)
+                assert True
+
+            def test_two():
+                time.sleep(0.3)
+                assert True
+
+            def test_three():
+                time.sleep(0.1)
+                assert True
+
+            def test_four():
+                time.sleep(0.1)
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest(
+            "--vip-config=vip.toml",
+            "-n",
+            "2",
+            "--dist",
+            "loadgroup",
+            "-v",
+        )
+        result.assert_outcomes(passed=4)
+
+        test_line_pattern = re.compile(r"test_(one|two|three|four)")
+        outcome_pattern = re.compile(r"PASSED|FAILED|ERROR|SKIPPED")
+        bad_lines = [
+            line
+            for line in result.stdout.lines
+            if test_line_pattern.search(line) and not outcome_pattern.search(line)
+        ]
+        assert not bad_lines, (
+            f"Found location-only line(s) with no outcome on the same line: {bad_lines!r}"
+        )
+
 
 class TestHeadlessAuthOption:
     def test_headless_auth_option_registered(self, pytester):

--- a/selftests/test_workbench_login.py
+++ b/selftests/test_workbench_login.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pytest
 from _pytest.outcomes import Skipped
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from vip_tests.workbench.conftest import workbench_login
 
@@ -32,7 +33,9 @@ class _AuthFakeLocator:
 
     def wait_for(self, *, state=None, timeout=None):
         if not self._visible():
-            raise RuntimeError("locator not visible")
+            # Playwright's Locator.wait_for raises PlaywrightTimeoutError on timeout;
+            # model that so the SSO-skip path exercises the same typed catch as production.
+            raise PlaywrightTimeoutError("locator not visible")
 
     def click(self, *args, **kwargs):
         if self._on_click is not None:

--- a/selftests/test_workbench_parallel.py
+++ b/selftests/test_workbench_parallel.py
@@ -1,0 +1,42 @@
+"""Selftests for #484 Workbench parallelization: login lock + hybrid grouping."""
+
+from __future__ import annotations
+
+import logging
+
+from filelock import FileLock
+
+from vip_tests.workbench import conftest as wb
+
+
+class TestOidcLoginLock:
+    def test_lock_path_is_stable_and_url_scoped(self, tmp_path):
+        a1 = wb._login_lock_path("https://wb.example.com")
+        a2 = wb._login_lock_path("https://wb.example.com")
+        b = wb._login_lock_path("https://other.example.com")
+        assert a1 == a2  # stable for the same URL
+        assert a1 != b  # distinct deployments get distinct locks
+        assert a1.name.endswith(".lock")
+
+    def test_lock_serializes_then_releases(self):
+        url = "https://wb.example.com/serialize"
+        with wb.oidc_login_lock(url):
+            pass
+        # Lock released: a fresh instance can acquire immediately.
+        other = FileLock(str(wb._login_lock_path(url)))
+        other.acquire(timeout=1)
+        other.release()
+
+    def test_lock_proceeds_on_timeout(self, caplog):
+        url = "https://wb.example.com/contended"
+        blocker = FileLock(str(wb._login_lock_path(url)))
+        blocker.acquire()
+        try:
+            entered = False
+            with caplog.at_level(logging.WARNING):
+                with wb.oidc_login_lock(url, timeout=0.2):
+                    entered = True
+            assert entered  # proceeded despite not holding the lock
+            assert "proceeding without it" in caplog.text
+        finally:
+            blocker.release()

--- a/selftests/test_workbench_parallel.py
+++ b/selftests/test_workbench_parallel.py
@@ -40,3 +40,48 @@ class TestOidcLoginLock:
             assert "proceeding without it" in caplog.text
         finally:
             blocker.release()
+
+
+class _FakeButton:
+    def __init__(self):
+        self.clicked = False
+
+    def click(self):
+        self.clicked = True
+
+
+class _FakeLogo:
+    def __init__(self, *, appears: bool):
+        self._appears = appears
+
+    def wait_for(self, *, state, timeout):  # noqa: ARG002 - mirrors Playwright signature
+        if not self._appears:
+            raise RuntimeError("homepage never appeared")
+
+
+class TestSilentSsoSignin:
+    def test_returns_true_and_uses_lock_when_homepage_appears(self, monkeypatch):
+        used = {"locked": False}
+
+        import contextlib
+
+        @contextlib.contextmanager
+        def _spy_lock(url):
+            used["locked"] = True
+            used["url"] = url
+            yield
+
+        monkeypatch.setattr(wb, "oidc_login_lock", _spy_lock)
+        button = _FakeButton()
+        ok = wb._silent_sso_signin(button, _FakeLogo(appears=True), "https://wb.example.com")
+        assert ok is True
+        assert button.clicked is True
+        assert used["locked"] is True
+        assert used["url"] == "https://wb.example.com"
+
+    def test_returns_false_when_homepage_never_appears(self, monkeypatch):
+        import contextlib
+
+        monkeypatch.setattr(wb, "oidc_login_lock", lambda url: contextlib.nullcontext())
+        ok = wb._silent_sso_signin(_FakeButton(), _FakeLogo(appears=False), "https://wb.x")
+        assert ok is False

--- a/selftests/test_workbench_parallel.py
+++ b/selftests/test_workbench_parallel.py
@@ -136,6 +136,25 @@ class _FakeConfig:
         return _Stash()
 
 
+class TestSessionTimeoutMessage:
+    def _base(self, session_name, target_state, timeout_s):
+        return (
+            f"Session {session_name!r} did not reach {target_state} within {timeout_s}s "
+            f"(no {target_state} or terminal status detected)."
+        )
+
+    def test_single_worker_is_just_the_base_message(self):
+        msg = wb._session_timeout_message("VIP rstudio", "Active", 90, 1)
+        assert msg == self._base("VIP rstudio", "Active", 90)
+        assert "parallel workers" not in msg
+
+    def test_multiple_workers_appends_capacity_hint(self):
+        msg = wb._session_timeout_message("VIP rstudio", "Active", 90, 4)
+        assert self._base("VIP rstudio", "Active", 90) in msg
+        assert "parallel workers" in msg
+        assert "reducing parallelism" in msg
+
+
 class TestCollectionHook:
     def _wb_dir(self):
         return Path(wb.__file__).parent

--- a/selftests/test_workbench_parallel.py
+++ b/selftests/test_workbench_parallel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from filelock import FileLock
 
@@ -85,3 +86,77 @@ class TestSilentSsoSignin:
         monkeypatch.setattr(wb, "oidc_login_lock", lambda url: contextlib.nullcontext())
         ok = wb._silent_sso_signin(_FakeButton(), _FakeLogo(appears=False), "https://wb.x")
         assert ok is False
+
+
+class TestWorkbenchGroupName:
+    def test_ide_marker_wins(self):
+        assert wb._workbench_group_name({"rstudio"}, "test_ide_launch") == "workbench_ide_rstudio"
+        assert wb._workbench_group_name({"positron"}, "test_ide_launch") == "workbench_ide_positron"
+
+    def test_non_ide_groups_by_module_stripping_test_prefix(self):
+        assert wb._workbench_group_name(set(), "test_packages") == "workbench_packages"
+        assert wb._workbench_group_name(set(), "test_git_ops") == "workbench_git_ops"
+
+    def test_module_without_test_prefix_kept_verbatim(self):
+        assert wb._workbench_group_name(set(), "chronicle_probe") == "workbench_chronicle_probe"
+
+
+class _FakeMarker:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeItem:
+    def __init__(self, path: Path, marker_names):
+        self.path = path
+        self.own_markers = [_FakeMarker("xdist_group"), _FakeMarker("workbench")]
+        self._markers = [_FakeMarker(n) for n in marker_names]
+        self.added = []
+
+    def iter_markers(self):
+        return list(self._markers)
+
+    def add_marker(self, marker):
+        # pytest.mark.xdist_group("g") -> mark object with .name and .args
+        self.added.append((marker.name, marker.args))
+
+
+class _FakeConfig:
+    def __init__(self, session):
+        self._session = session
+
+    @property
+    def stash(self):
+        cfg = self
+
+        class _Stash:
+            def get(self, key, default=None):  # noqa: ARG002
+                return cfg._session
+
+        return _Stash()
+
+
+class TestCollectionHook:
+    def _wb_dir(self):
+        return Path(wb.__file__).parent
+
+    def test_no_auth_session_is_a_noop(self):
+        item = _FakeItem(self._wb_dir() / "test_packages.py", [])
+        wb.pytest_collection_modifyitems(_FakeConfig(None), [item])
+        assert item.added == []  # untouched under password / no-auth
+
+    def test_ide_item_grouped_by_ide(self):
+        item = _FakeItem(self._wb_dir() / "test_ide_launch.py", ["workbench", "rstudio"])
+        wb.pytest_collection_modifyitems(_FakeConfig(object()), [item])
+        assert ("xdist_group", ("workbench_ide_rstudio",)) in item.added
+        assert all(m.name != "xdist_group" for m in item.own_markers)  # old group stripped
+
+    def test_non_ide_item_grouped_by_module(self):
+        item = _FakeItem(self._wb_dir() / "test_packages.py", ["workbench"])
+        wb.pytest_collection_modifyitems(_FakeConfig(object()), [item])
+        assert ("xdist_group", ("workbench_packages",)) in item.added
+
+    def test_non_workbench_item_ignored(self):
+        item = _FakeItem(Path("/somewhere/connect/test_auth.py"), ["connect"])
+        wb.pytest_collection_modifyitems(_FakeConfig(object()), [item])
+        assert item.added == []

--- a/selftests/test_workbench_parallel.py
+++ b/selftests/test_workbench_parallel.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import pytest
 from filelock import FileLock
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from vip_tests.workbench import conftest as wb
 
@@ -28,6 +30,17 @@ class TestOidcLoginLock:
         other.acquire(timeout=1)
         other.release()
 
+    def test_lock_released_when_body_raises(self):
+        # The lock must release even if the protected body raises, or a stale cross-worker
+        # lock file would stall every other worker for the full timeout on each login.
+        url = "https://wb.example.com/raises"
+        with pytest.raises(RuntimeError):
+            with wb.oidc_login_lock(url):
+                raise RuntimeError("boom inside the lock")
+        other = FileLock(str(wb._login_lock_path(url)))
+        other.acquire(timeout=1)  # would block/raise Timeout if the lock leaked
+        other.release()
+
     def test_lock_proceeds_on_timeout(self, caplog):
         url = "https://wb.example.com/contended"
         blocker = FileLock(str(wb._login_lock_path(url)))
@@ -35,8 +48,10 @@ class TestOidcLoginLock:
         try:
             entered = False
             with caplog.at_level(logging.WARNING):
-                with wb.oidc_login_lock(url, timeout=0.2):
-                    entered = True
+                # Surfaced as a warning too, so contention is visible in pytest's summary.
+                with pytest.warns(UserWarning, match="proceeding without it"):
+                    with wb.oidc_login_lock(url, timeout=0.2):
+                        entered = True
             assert entered  # proceeded despite not holding the lock
             assert "proceeding without it" in caplog.text
         finally:
@@ -57,7 +72,9 @@ class _FakeLogo:
 
     def wait_for(self, *, state, timeout):  # noqa: ARG002 - mirrors Playwright signature
         if not self._appears:
-            raise RuntimeError("homepage never appeared")
+            # Model the real timeout: Playwright raises PlaywrightTimeoutError, which is
+            # what _silent_sso_signin catches. A different exception type must propagate.
+            raise PlaywrightTimeoutError("homepage never appeared")
 
 
 class TestSilentSsoSignin:
@@ -86,6 +103,19 @@ class TestSilentSsoSignin:
         monkeypatch.setattr(wb, "oidc_login_lock", lambda url: contextlib.nullcontext())
         ok = wb._silent_sso_signin(_FakeButton(), _FakeLogo(appears=False), "https://wb.x")
         assert ok is False
+
+    def test_non_playwright_error_propagates(self, monkeypatch):
+        # A crashed page / bug in the helper must surface as a real failure, not be
+        # laundered into False (which the caller turns into a misleading graceful skip).
+        import contextlib
+
+        class _BrokenLogo:
+            def wait_for(self, *, state, timeout):  # noqa: ARG002
+                raise RuntimeError("page crashed mid-login")
+
+        monkeypatch.setattr(wb, "oidc_login_lock", lambda url: contextlib.nullcontext())
+        with pytest.raises(RuntimeError, match="page crashed"):
+            wb._silent_sso_signin(_FakeButton(), _BrokenLogo(), "https://wb.x")
 
 
 class TestWorkbenchGroupName:
@@ -179,3 +209,30 @@ class TestCollectionHook:
         item = _FakeItem(Path("/somewhere/connect/test_auth.py"), ["connect"])
         wb.pytest_collection_modifyitems(_FakeConfig(object()), [item])
         assert item.added == []
+
+
+class TestRealMarkerMechanics:
+    """Guard the assumption the fakes above cannot: that the hook's strip + add_marker
+    sequence is actually visible to pytest-xdist, which reads xdist_group via
+    ``get_closest_marker`` and concatenates *every* xdist_group mark it finds via
+    ``iter_markers``. Exercised on a real pytest ``Item``, not a fake."""
+
+    def test_regroup_wins_via_get_closest_marker_and_leaves_no_duplicate(self, pytester):
+        import pytest as _pytest
+
+        # Disable the vip plugin for the nested collection: its own _assign_xdist_group
+        # would inject a "general" group and obscure the mechanic under test.
+        modcol = pytester.getmodulecol("def test_x(): pass", configargs=["-p", "no:vip"])
+        (item,) = pytester.genitems([modcol])
+        # Simulate a pre-existing group, then apply exactly the hook's two operations.
+        item.add_marker(_pytest.mark.xdist_group("workbench"))
+        item.own_markers = [m for m in item.own_markers if m.name != "xdist_group"]
+        item.add_marker(_pytest.mark.xdist_group("workbench_packages"))
+
+        # get_closest_marker is the path LoadGroupScheduling reads — it must see the new group.
+        marker = item.get_closest_marker("xdist_group")
+        assert marker is not None
+        assert marker.args == ("workbench_packages",)
+        # And no leftover duplicate, or xdist would glue both names into one composite group.
+        groups = [m.args[0] for m in item.iter_markers("xdist_group")]
+        assert groups == ["workbench_packages"]

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -274,6 +274,25 @@ def _has_explicit_test_targets(pytest_args: list[str]) -> bool:
     return False
 
 
+def _user_set_xdist(pytest_args: list[str]) -> tuple[bool, bool]:
+    """Return (user_set_numprocesses, user_set_dist) from user-supplied pytest args.
+
+    Lets `vip verify` supply default ``-n``/``--dist`` without overriding an
+    explicit user choice (including ``-p no:xdist``, which disables xdist
+    entirely and so counts as the user managing both).
+    """
+    set_n = False
+    set_dist = False
+    for a in pytest_args:
+        if a in ("-n", "--numprocesses") or a.startswith(("-n", "--numprocesses=")):
+            set_n = True
+        if a.startswith("--dist") or a == "no:xdist" or a.startswith("no:xdist"):
+            set_dist = True
+    if "no:xdist" in pytest_args or any(x.startswith("no:xdist") for x in pytest_args):
+        set_n = set_dist = True
+    return set_n, set_dist
+
+
 def _generate_temp_config(args: argparse.Namespace) -> str:
     """Write a minimal vip.toml from CLI URL arguments. Returns temp file path."""
     lines = ["[general]", 'deployment_name = "Posit Team"', ""]
@@ -489,6 +508,23 @@ def run_verify(args: argparse.Namespace) -> None:
     if args.verbose:
         cmd.append("--vip-verbose")
         cmd.append("-s")
+
+    # Default to a conservative parallel-by-group run so pip-installed users
+    # get grouping too -- pyproject.toml's `addopts = "-n auto --dist
+    # loadgroup"` only applies when pytest's rootdir is this repo. 2 workers
+    # is a safe default: product tests log real sessions in against a shared
+    # deployment and a single shared test account, and higher default
+    # concurrency intermittently storms the OIDC IdP (`?error=2`) and exceeds
+    # small deployments' concurrent-session capacity. Users raise it with
+    # `-- -n N` when their deployment can handle more. Respect an explicit
+    # user choice for either flag (including `-p no:xdist`, which disables
+    # xdist and thus both).
+    _set_n, _set_dist = _user_set_xdist(args.pytest_args)
+    if not _set_n:
+        cmd.extend(["-n", "2"])
+    if not _set_dist:
+        cmd.extend(["--dist", "loadgroup"])
+
     cmd.extend(args.pytest_args)
     if args.headless_auth:
         # MFA prompting needs stdin; always append -s last so it

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -842,6 +842,64 @@ def pytest_runtest_makereport(item: pytest.Item, call):  # noqa: ARG001
         report.vip_na_version = na_version  # type: ignore[attr-defined]
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_logstart(
+    nodeid: str,  # noqa: ARG001
+    location: tuple[str, int | None, str],  # noqa: ARG001
+) -> Generator[None, None, None]:
+    """Suppress the built-in terminal reporter's pre-test location line under xdist.
+
+    Under real xdist parallelism, the controller relays each worker's
+    ``pytest_runtest_logstart`` event (via ``dsession.worker_logstart``) the
+    moment that worker *starts* a test, independent of when any other
+    worker's test *finishes*. pytest's built-in ``TerminalReporter`` assumes
+    a single serial stream: at ``-v`` it writes the location at logstart and
+    later appends the outcome to that *same* line at logreport (matched via
+    a shared ``currentfspath`` attribute). With several workers running
+    concurrently, multiple tests' logstart events land before any of their
+    logreport events, so ``currentfspath`` gets overwritten by other tests'
+    locations before the original one's outcome arrives -- producing a
+    location-only line up front and a disconnected result line later.
+
+    We already delete ``report.node`` below so ``pytest_runtest_logreport``
+    takes its non-xdist branch and writes location + outcome together, in
+    one line, in a single call (see that hook's docstring). That only
+    produces one line if nothing has already claimed the location line
+    first. So here, only when the xdist controller is actually distributing
+    (``dsession`` registered, and this isn't a worker), we suppress the
+    logstart write for the duration of the wrapped call.
+
+    The built-in reporter gates that write on ``showlongtestinfo``, which
+    reads the fine-grained ``verbosity_test_cases`` *ini* value rather than
+    the plain ``-v`` count whenever that ini value isn't ``"auto"`` -- and
+    ``pytest_configure`` above already pins it (via ``config._inicache``) to
+    force skip reasons to print in full. So bumping ``config.option.verbose``
+    here would have no effect; we instead override that same ini-cache entry
+    to ``"0"``, restoring it immediately after so the later
+    ``pytest_runtest_logreport`` call (which reads the same cached value to
+    decide whether to show the outcome line at all) is unaffected. Nothing
+    else runs in between, since hookwrapper dispatch is synchronous.
+    """
+    config = _active_config
+    if (
+        config is None
+        or hasattr(config, "workerinput")
+        or not config.pluginmanager.hasplugin("dsession")
+    ):
+        yield
+        return
+
+    original = config._inicache.get("verbosity_test_cases")
+    config._inicache["verbosity_test_cases"] = "0"
+    try:
+        yield
+    finally:
+        if original is None:
+            config._inicache.pop("verbosity_test_cases", None)
+        else:
+            config._inicache["verbosity_test_cases"] = original
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     """Collect results for JSON report and apply concise terminal display.
@@ -853,8 +911,11 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     guard skips processing on workers so results are collected exactly once.
     """
     # Strip the xdist worker attribute so pytest's built-in TerminalReporter
-    # does not prefix each verbose line with ``[gw<N>]``.  Runs before the
-    # terminal reporter thanks to ``tryfirst=True``.
+    # does not prefix each verbose line with ``[gw<N>]`` and instead writes
+    # the location and outcome together in one line (see
+    # ``pytest_runtest_logstart`` above for why that requires suppressing
+    # the pre-test location line too).  Runs before the terminal reporter
+    # thanks to ``tryfirst=True``.
     if hasattr(report, "node"):
         del report.node
 

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -166,6 +166,10 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "api_auth: test requires only an API key, not browser credentials",
     )
+    config.addinivalue_line("markers", "rstudio: Workbench RStudio IDE-launch scenario")
+    config.addinivalue_line("markers", "vscode: Workbench VS Code IDE-launch scenario")
+    config.addinivalue_line("markers", "jupyter: Workbench JupyterLab IDE-launch scenario")
+    config.addinivalue_line("markers", "positron: Workbench Positron IDE-launch scenario")
 
     # In concise mode, suppress the "short test summary info" section — the
     # inline concise error messages make it redundant.

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -352,6 +352,22 @@ def wait_for_session_suspended(
 # ---------------------------------------------------------------------------
 
 
+def _silent_sso_signin(sso_button, homepage_logo, workbench_url: str) -> bool:
+    """Click the OIDC sign-in button and wait for the homepage, serialized across workers.
+
+    Wrapped in :func:`oidc_login_lock` so concurrent xdist workers don't storm the shared
+    IdP session. Returns ``True`` when the authenticated homepage appears, ``False``
+    otherwise (the caller then skips with the standard message).
+    """
+    with oidc_login_lock(workbench_url):
+        sso_button.click()
+        try:
+            homepage_logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+            return True
+        except Exception:
+            return False
+
+
 def workbench_login(
     page: Page,
     workbench_url: str,
@@ -437,25 +453,22 @@ def workbench_login(
 
         if interactive_auth and sso_only:
             # Storage state was pre-loaded by --interactive-auth / --headless-auth.
-            # Workbench's SSO sign-in page does not auto-redirect to the IdP; it
-            # renders a "Sign in with OpenID" button.  Clicking it triggers a
-            # silent SSO round-trip using the saved IdP cookies, landing on the
-            # authenticated homepage with no credentials required.
-            sso_button.click()
-            try:
-                homepage_logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+            # Workbench's SSO sign-in page does not auto-redirect to the IdP; it renders a
+            # "Sign in with OpenID" button. Clicking it triggers a silent SSO round-trip
+            # using the saved IdP cookies. The round-trip is serialized across xdist
+            # workers (see _silent_sso_signin / oidc_login_lock) to avoid storming the
+            # shared IdP session (#484/#467).
+            if _silent_sso_signin(sso_button, homepage_logo, workbench_url):
                 return  # Silent SSO succeeded
-            except Exception:
-                # No usable IdP session (expired, or storage state was stripped
-                # for the password-login test) — silent SSO can't complete on an
-                # OIDC deployment, so skip gracefully.
-                pytest.skip(
-                    _workbench_session_skip_message(
-                        auth_mode=auth_mode,
-                        workbench_auth_error=workbench_auth_error,
-                        landed_url=page.url,
-                    )
+            # No usable IdP session (expired, or storage state was stripped for the
+            # password-login test) — skip gracefully.
+            pytest.skip(
+                _workbench_session_skip_message(
+                    auth_mode=auth_mode,
+                    workbench_auth_error=workbench_auth_error,
+                    landed_url=page.url,
                 )
+            )
 
         if auth_provider != "password":
             pytest.skip(

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -81,23 +81,40 @@ def oidc_login_lock(workbench_url: str, *, timeout: float = _LOGIN_LOCK_TIMEOUT)
 pytestmark = [pytest.mark.workbench, pytest.mark.xdist_group("workbench")]
 
 
+_IDE_MARKERS = ("rstudio", "vscode", "jupyter", "positron")
+
+
+def _workbench_group_name(ide_markers: set[str], module_stem: str) -> str:
+    """Compute the xdist group for a Workbench test under shared auth (hybrid grouping).
+
+    IDE-launch scenarios (carrying an IDE marker) group by IDE so each IDE runs on its own
+    worker: ``workbench_ide_<ide>``. Every other Workbench test groups by feature module:
+    ``workbench_<stem>`` (a leading ``test_`` stripped).
+    """
+    for ide in _IDE_MARKERS:
+        if ide in ide_markers:
+            return f"workbench_ide_{ide}"
+    stem = module_stem[len("test_") :] if module_stem.startswith("test_") else module_stem
+    return f"workbench_{stem}"
+
+
 def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    """Serialize Workbench tests onto a single xdist worker when a shared auth session is active.
+    """Group Workbench tests for parallel execution when a shared auth session is active.
 
     Under --interactive-auth / --headless-auth all Workbench tests authenticate as the same
-    shared browser account.  Running them across many parallel workers triggers a
-    simultaneous-login storm against the OIDC IdP that intermittently fails to establish
-    sessions or bounces already-logged-in browsers back to the sign-in page.  Pinning all
-    Workbench tests to one xdist group forces LoadGroupScheduling to run them sequentially
-    on a single worker, eliminating the storm while leaving Connect/PM tests unaffected.
+    shared account. Rather than pin them all to one worker (the old serial workaround), we
+    group them so LoadGroupScheduling spreads them across workers: IDE-launch scenarios by
+    IDE (``workbench_ide_<ide>``), everything else by feature module (``workbench_<module>``).
+    The simultaneous-login storm this used to cause is prevented by the cross-worker login
+    lock in :func:`workbench_login` (see :func:`oidc_login_lock`), not by serialization.
 
     For password auth (no shared session) the default parallel behavior is preserved.
     """
     if config.stash.get(_auth_session_key, None) is None:
-        # No shared auth session — password auth or no auth.  Keep default parallel behavior.
+        # No shared auth session — password auth or no auth. Keep default parallel behavior.
         return
 
     workbench_dir = Path(__file__).parent
@@ -105,10 +122,11 @@ def pytest_collection_modifyitems(
         item_path = getattr(item, "path", None)
         if item_path is None or not item_path.is_relative_to(workbench_dir):
             continue
-        # Remove the default xdist_group("workbench") set by pytestmark so we can
-        # replace it with a group that serializes all workers onto one.
+        ide_markers = {m.name for m in item.iter_markers()} & set(_IDE_MARKERS)
+        group = _workbench_group_name(ide_markers, item_path.stem)
+        # Replace the default xdist_group("workbench") from pytestmark with the hybrid group.
         item.own_markers = [m for m in item.own_markers if m.name != "xdist_group"]
-        item.add_marker(pytest.mark.xdist_group("workbench_interactive_serial"))
+        item.add_marker(pytest.mark.xdist_group(group))
 
 
 # ---------------------------------------------------------------------------

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -12,11 +12,14 @@ import os
 import re
 import tempfile
 import time
+import warnings
 from pathlib import Path
 
 import pytest
 from filelock import FileLock, Timeout
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from pytest_bdd import given
 
 from vip.clients.workbench import WorkbenchClient
@@ -57,19 +60,24 @@ def oidc_login_lock(workbench_url: str, *, timeout: float = _LOGIN_LOCK_TIMEOUT)
     """Serialize the OIDC SSO round-trip across xdist workers.
 
     Only one worker performs the silent SSO round-trip against the shared IdP session at a
-    time. The lock is an optimization, never a correctness dependency: if it can't be
-    acquired within *timeout*, log a warning and proceed unlocked rather than hang the run.
+    time. The lock is a best-effort optimization: falling back to unlocked proceeds
+    correctly, though it can reintroduce the very login storm this lock exists to avoid. If
+    it can't be acquired within *timeout*, surface a warning and proceed unlocked rather
+    than hang the run.
     """
     lock = FileLock(str(_login_lock_path(workbench_url)))
     try:
         lock.acquire(timeout=timeout)
     except Timeout:
-        logger.warning(
-            "OIDC login lock not acquired within %.0fs for %s; proceeding without it. "
-            "Concurrent logins may briefly storm the IdP.",
-            timeout,
-            workbench_url,
+        # Emit via both channels: warnings.warn surfaces in pytest's warnings summary
+        # regardless of pass/fail (no logging handler is attached for test runs), so the
+        # one run where storm-prevention disengaged leaves a forensic trail for later.
+        message = (
+            f"OIDC login lock not acquired within {timeout:.0f}s for {workbench_url}; "
+            "proceeding without it. Concurrent logins may briefly storm the IdP."
         )
+        warnings.warn(message, stacklevel=2)
+        logger.warning(message)
         yield
         return
     try:
@@ -111,8 +119,11 @@ def pytest_collection_modifyitems(
     The simultaneous-login storm this used to cause is prevented by the cross-worker login
     lock in :func:`workbench_login` (see :func:`oidc_login_lock`), not by serialization.
 
-    Password / no-auth runs are left untouched (they are unaffected by the shared-auth
-    gate below and keep whatever grouping the module-level ``pytestmark`` assigns).
+    Password / no-auth runs are left untouched: they hit the early return below, so their
+    Workbench items keep the default ``workbench`` group that ``plugin.py``'s
+    :func:`_assign_xdist_group` directory fallback assigns (the module-level ``pytestmark``
+    at the top of this file does not propagate to sibling test modules, so it assigns
+    nothing here).
     """
     if config.stash.get(_auth_session_key, None) is None:
         # No shared auth session — password auth or no auth. Keep default parallel behavior.
@@ -125,8 +136,11 @@ def pytest_collection_modifyitems(
             continue
         ide_markers = {m.name for m in item.iter_markers()} & set(_IDE_MARKERS)
         group = _workbench_group_name(ide_markers, item_path.stem)
-        # Drop any per-test xdist_group marker before adding the hybrid group (the
-        # module-level pytestmark group is overridden via get_closest_marker regardless).
+        # Strip any pre-existing xdist_group marker before adding the hybrid group. No
+        # per-test xdist_group marker exists today, so this is a defensive guard: xdist
+        # concatenates *all* xdist_group marks on an item (via iter_markers), it does not
+        # take the closest, so a leftover mark would corrupt the group name rather than be
+        # shadowed. plugin.py's _assign_xdist_group then respects the group we add here.
         item.own_markers = [m for m in item.own_markers if m.name != "xdist_group"]
         item.add_marker(pytest.mark.xdist_group(group))
 
@@ -409,7 +423,11 @@ def _silent_sso_signin(sso_button, homepage_logo, workbench_url: str) -> bool:
         try:
             homepage_logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
             return True
-        except Exception:
+        except (PlaywrightTimeoutError, PlaywrightError):
+            # Homepage never appeared: no usable IdP session (expired, or storage state
+            # stripped for the password-login test). Anything else (crashed page/context,
+            # a bug in this helper) is a real failure and must propagate, not masquerade
+            # as a graceful skip — matches the typed-catch convention used across this package.
             return False
 
 

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -5,13 +5,17 @@ Page selectors are in the pages/ subpackage
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import logging
 import os
 import re
+import tempfile
 import time
 from pathlib import Path
 
 import pytest
+from filelock import FileLock, Timeout
 from playwright.sync_api import Locator, Page, expect
 from pytest_bdd import given
 
@@ -30,6 +34,49 @@ from vip.workbench_ui import (
 from vip_tests.workbench.pages import Homepage, LoginPage
 
 logger = logging.getLogger(__name__)
+
+# Cross-worker OIDC login lock (#484). Under --interactive-auth / --headless-auth every
+# xdist worker shares one IdP session; letting many workers do the silent SSO round-trip
+# simultaneously storms the IdP (the ?error=2 bounce from #467). Serializing just the
+# round-trip removes the concurrency without re-serializing the whole suite.
+_LOGIN_LOCK_TIMEOUT = float(os.environ.get("VIP_LOGIN_LOCK_TIMEOUT", "60"))
+
+
+def _login_lock_path(workbench_url: str) -> Path:
+    """Path to the cross-worker OIDC login lock for *workbench_url*.
+
+    Keyed by a hash of the URL so distinct deployments don't share a lock, and placed in
+    the system temp dir so all xdist workers on the host share the same file.
+    """
+    digest = hashlib.sha256(workbench_url.encode()).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / f"vip-wb-login-{digest}.lock"
+
+
+@contextlib.contextmanager
+def oidc_login_lock(workbench_url: str, *, timeout: float = _LOGIN_LOCK_TIMEOUT):
+    """Serialize the OIDC SSO round-trip across xdist workers.
+
+    Only one worker performs the silent SSO round-trip against the shared IdP session at a
+    time. The lock is an optimization, never a correctness dependency: if it can't be
+    acquired within *timeout*, log a warning and proceed unlocked rather than hang the run.
+    """
+    lock = FileLock(str(_login_lock_path(workbench_url)))
+    try:
+        lock.acquire(timeout=timeout)
+    except Timeout:
+        logger.warning(
+            "OIDC login lock not acquired within %.0fs for %s; proceeding without it. "
+            "Concurrent logins may briefly storm the IdP.",
+            timeout,
+            workbench_url,
+        )
+        yield
+        return
+    try:
+        yield
+    finally:
+        lock.release()
+
 
 pytestmark = [pytest.mark.workbench, pytest.mark.xdist_group("workbench")]
 

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -257,6 +257,31 @@ def _session_failure_message(name: str, state: str, *, expected: str = "Active")
     return f"Session {name!r} reached terminal state {state!r} instead of {expected} — {cause}"
 
 
+def _session_timeout_message(
+    session_name: str, target_state: str, timeout_s: int, worker_count: int
+) -> str:
+    """Build the message shown when a session never reaches *target_state* before timeout.
+
+    When running across multiple xdist workers (*worker_count* > 1), several sessions
+    launch at once; a capacity-limited deployment can leave some stuck in a non-terminal
+    "Starting" state. In that case, append a hint pointing at concurrent-session capacity
+    so the failure is actionable rather than opaque.
+    """
+    base = (
+        f"Session {session_name!r} did not reach {target_state} within {timeout_s}s "
+        f"(no {target_state} or terminal status detected)."
+    )
+    if worker_count > 1:
+        base += (
+            f" This run used {worker_count} parallel workers, so multiple sessions were "
+            "launching at once; if the deployment has limited concurrent-session capacity, "
+            "sessions can stay in 'Starting' until they time out. Try reducing parallelism "
+            "(e.g. a lower pytest -n) or verify the deployment/launcher can start that many "
+            "sessions concurrently."
+        )
+    return base
+
+
 def format_capacity_failure(total: int, failures: list[str], reasons: list[str]) -> str:
     """Build the aggregated failure for the session-capacity scenario.
 
@@ -336,9 +361,9 @@ def _wait_for_session_state(
     if _target_now():
         return row
     raise_if_session_failed(page, session_name, expected=target_state)
+    worker_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1") or "1")
     raise AssertionError(
-        f"Session {session_name!r} did not reach {target_state} within "
-        f"{timeout // 1000}s (no {target_state} or terminal status detected)."
+        _session_timeout_message(session_name, target_state, timeout // 1000, worker_count)
     )
 
 

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -111,7 +111,8 @@ def pytest_collection_modifyitems(
     The simultaneous-login storm this used to cause is prevented by the cross-worker login
     lock in :func:`workbench_login` (see :func:`oidc_login_lock`), not by serialization.
 
-    For password auth (no shared session) the default parallel behavior is preserved.
+    Password / no-auth runs are left untouched (they are unaffected by the shared-auth
+    gate below and keep whatever grouping the module-level ``pytestmark`` assigns).
     """
     if config.stash.get(_auth_session_key, None) is None:
         # No shared auth session — password auth or no auth. Keep default parallel behavior.
@@ -124,7 +125,8 @@ def pytest_collection_modifyitems(
             continue
         ide_markers = {m.name for m in item.iter_markers()} & set(_IDE_MARKERS)
         group = _workbench_group_name(ide_markers, item_path.stem)
-        # Replace the default xdist_group("workbench") from pytestmark with the hybrid group.
+        # Drop any per-test xdist_group marker before adding the hybrid group (the
+        # module-level pytestmark group is overridden via get_closest_marker regardless).
         item.own_markers = [m for m in item.own_markers if m.name != "xdist_group"]
         item.add_marker(pytest.mark.xdist_group(group))
 

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -43,21 +43,25 @@ pytestmark = pytest.mark.order(20)
 _FILENAME = Path(__file__).name
 
 
+@pytest.mark.rstudio
 @scenario("test_ide_launch.feature", "RStudio IDE session can be launched")
 def test_launch_rstudio():
     pass
 
 
+@pytest.mark.vscode
 @scenario("test_ide_launch.feature", "VS Code session can be launched")
 def test_launch_vscode():
     pass
 
 
+@pytest.mark.jupyter
 @scenario("test_ide_launch.feature", "JupyterLab session can be launched")
 def test_launch_jupyter():
     pass
 
 
+@pytest.mark.positron
 @scenario("test_ide_launch.feature", "Positron session can be launched")
 def test_launch_positron():
     pass

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -411,6 +411,26 @@ def jupyterlab_executes_code(page: Page):
     if notebook_card.count() == 0:
         pytest.skip("No notebook kernel cards available in JupyterLab launcher")
     expect(notebook_card).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
+
+    # A leftover modal from a *previous* notebook in this session (e.g. an
+    # "Error Starting Kernel" dialog left open from an earlier run's kernel
+    # failure — deployments in this environment routinely accumulate dozens of
+    # untouched notebooks — or JupyterLab's "Build Recommended" prompt) can
+    # still be open at this point and would intercept the click below. Clear
+    # it with Escape (reject) rather than accept: unlike the kernel dialogs we
+    # deliberately accept once *our own* notebook is involved (below), blindly
+    # accepting an unrelated leftover dialog here could trigger an unrelated
+    # action instead of just getting out of the way. Not reproduced directly
+    # at this point during investigation of issue #484, but kept as a cheap,
+    # idempotent no-op guard: pressing Escape when no dialog is open is a
+    # harmless no-op. Best-effort — never raises.
+    if page.locator(JupyterLabSession.DIALOG).count() > 0:
+        try:
+            page.keyboard.press("Escape")
+            page.wait_for_timeout(500)
+        except (PlaywrightTimeoutError, PlaywrightError):
+            pass
+
     notebook_card.click()
 
     # Clicking the card opens a notebook as the active dock tab.  Several hidden
@@ -428,6 +448,18 @@ def jupyterlab_executes_code(page: Page):
     # Click into the first code cell input of the active notebook and type.
     cell_input = notebook_panel.locator(JupyterLabSession.CELL_INPUT).first
     expect(cell_input).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
+
+    # The kernel can still be connecting once the cell becomes visible.  Under
+    # load, kernel start-up can fail with a transient gateway error (observed:
+    # a reverse-proxy 502), which pops a modal "Error Starting Kernel" dialog
+    # with a single "Ok" (jp-mod-accept) button that intercepts the click
+    # below and hangs it for the full click timeout (issue #484). Poll and
+    # dismiss it the same way as the "Select Kernel" dialog above (accept the
+    # default/only action) so that, if the kernel genuinely failed to start,
+    # the cell-output assertion further down can fail gracefully with its own
+    # skip message instead of an opaque "intercepts pointer events" timeout.
+    _accept_open_dialogs(page)
+
     cell_input.click()
     cell_input.type("1 + 1")
 

--- a/thoughts/shared/plans/2026-07-20-issue-484-workbench-parallel-design.md
+++ b/thoughts/shared/plans/2026-07-20-issue-484-workbench-parallel-design.md
@@ -1,0 +1,122 @@
+# Design — #484: parallelize Workbench tests by hybrid grouping + login lock
+
+**Status:** Approved design (brainstorming) — ready for implementation plan
+**Date:** 2026-07-20
+**Issue:** posit-dev/vip#484 (part of epic #480)
+
+## Problem
+
+Under `--interactive-auth` / `--headless-auth` all Workbench tests authenticate as the
+**same shared account** and are pinned to a single xdist worker
+(`src/vip_tests/workbench/conftest.py::pytest_collection_modifyitems`, the
+`workbench_interactive_serial` group). The result is a fully **serial** ~10-minute run.
+
+The pin exists to avoid an OIDC **login storm**: because Playwright's `page`/`context` are
+function-scoped and every worker loads the *same* shared `storage_state` file (which holds
+only IdP cookies, not an established Workbench session), **every test** does its own silent
+SSO round-trip (`workbench_login` → click "Sign in with OpenID", `conftest.py:391-411`).
+Many workers doing that round-trip against the one shared IdP session simultaneously makes
+the IdP bounce sessions back to the sign-in page (the `?error=2` flakiness from #467
+validation).
+
+For password auth (no shared session) Workbench already runs parallel — the serialization
+is purely the OIDC-login-storm workaround.
+
+## Scope (from design chat)
+
+**In:**
+- Replace the single-worker pin with parallel-by-group execution, **only** when a shared
+  auth session is active (the existing `_auth_session_key` gate is preserved).
+- **Hybrid grouping** (decided): IDE-launch scenarios grouped by IDE; every other Workbench
+  test grouped by feature module.
+- **Cross-worker login lock** (decided) to serialize just the SSO round-trip, so concurrent
+  workers never hit the shared IdP session at the same time.
+
+**Constraints / decisions:**
+- **Single shared account only** — no account pool. (Ruled out provisioning N IdP accounts.)
+- Stay close to the current pattern; minimal change (per repo conventions).
+
+**Out (deferred):**
+- Baking an established Workbench session into the shared `storage_state` to skip the
+  per-test round-trip entirely (the "bake session" option). Faster, but all workers would
+  share one Workbench session cookie concurrently. Revisit only if login serialization
+  proves to be a wall-clock bottleneck.
+- Provisioning multiple test accounts / account-pool auth.
+
+## Mechanism
+
+Both changes live in `src/vip_tests/workbench/conftest.py` and activate **only** when
+`config.stash.get(_auth_session_key)` is set — the exact gate the current serial override
+uses (`conftest.py:52`). Password / no-auth runs keep today's default behavior untouched.
+
+### Component 1 — Hybrid xdist grouping
+
+Replace the single `workbench_interactive_serial` group assignment with a per-item group:
+
+- **IDE-launch scenarios** → `workbench_ide_<ide>` where `<ide>` ∈
+  `rstudio` / `vscode` / `jupyter` / `positron`. IDE type is a **scenario-level** attribute
+  (the four scenarios all live in `test_ide_launch.feature`), so the signal is an IDE
+  **tag** added to each scenario in the feature file (`@rstudio`, `@vscode`, `@jupyter`,
+  `@positron`), which pytest-bdd surfaces as a marker the conftest can read.
+- **Every other Workbench test** → `workbench_<module>` (feature-file stem, e.g.
+  `workbench_packages`, `workbench_git_ops`, `workbench_sessions`).
+
+xdist LoadGroupScheduling then distributes these groups across workers (bounded by `-n`),
+replacing the 1-worker pin. Group count is the *ceiling* on Workbench parallelism; actual
+parallelism is bounded by the `-n` worker count.
+
+Rationale for hybrid: "group by IDE type" (the issue's literal ask) is only meaningful for
+the IDE-launch scenarios; the rest of the suite isn't IDE-specific. Feature-module grouping
+maps cleanly onto the existing collection units for those. Hybrid keeps faithful IDE
+splitting where it matters without inventing an IDE tag for every non-IDE test.
+
+### Component 2 — Cross-worker login lock
+
+Wrap **only** the SSO round-trip critical section in `workbench_login`
+(`sso_button.click()` → wait for homepage, `conftest.py:391-411`) in a
+`filelock.FileLock`, keyed to the Workbench URL, so concurrent workers serialize their
+IdP round-trips. Directly removes the root cause (concurrency), not a symptom.
+
+- The already-logged-in **fast path** (`conftest.py:363`) and the **password** login path
+  never acquire the lock.
+- Lock acquisition uses a **timeout**; on timeout, log a warning and proceed rather than
+  hang the run (idempotent-redundancy: the lock is an optimization, never a correctness
+  dependency).
+- The slow work — session launch and the ~90s `wait_for_session_active` waits — stays
+  **outside** the lock and runs in parallel across workers.
+
+### Data flow
+
+```
+collection → hybrid group markers assigned (gated on shared auth session)
+           → xdist LoadGroupScheduling distributes groups across -n workers
+           → per test: SSO round-trip serialized by the file lock (fast path skips it)
+                       session launch + IDE interaction run in parallel
+```
+
+## Dependency
+
+`filelock` is **not** currently a VIP dependency (confirmed: `import filelock` fails in the
+synced env). Add it to `pyproject.toml`. The runtime dependency audit in `ci.yml` must stay
+green, so it goes in the runtime deps, not a dev-only group.
+
+## Testing
+
+- **Selftests (pytester, mirrors `selftests/test_plugin.py`):**
+  - IDE-launch scenarios get `workbench_ide_<ide>` groups.
+  - Non-IDE Workbench tests get `workbench_<module>` groups.
+  - The gate still no-ops (no regrouping) under password / no-auth runs.
+- **Unit test** around a small lock-wrap helper: acquires and releases, and proceeds on
+  timeout without raising.
+- **Live behavior cannot run in CI** (needs a real OIDC Workbench). See the spike.
+
+## The one real risk — spike first
+
+The premise that a **single shared account** can sustain 2–4 concurrent Workbench sessions,
+and that the login lock actually eliminates the `?error=2` storm, must be **proven against a
+live OIDC Workbench 2026.06 deployment** before trusting the rollout. Make this spike the
+**first implementation step**. If it fails, fall back (e.g. cap concurrency to 2, or revisit
+the deferred "bake session" option).
+
+Secondary consideration (not auth): many concurrent session launches stress the deployment's
+launcher. The `-n` worker count naturally bounds this; document it, don't engineer for it.

--- a/thoughts/shared/plans/2026-07-20-issue-484-workbench-parallel-plan.md
+++ b/thoughts/shared/plans/2026-07-20-issue-484-workbench-parallel-plan.md
@@ -1,0 +1,624 @@
+# Workbench Test Parallelization Implementation Plan (#484)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the forced-serial Workbench test run (under shared OIDC auth) with parallel-by-group execution, made safe by a cross-worker OIDC login lock.
+
+**Architecture:** Two changes in `src/vip_tests/workbench/conftest.py`, both gated on a shared auth session being active (`_auth_session_key`): (1) a **hybrid xdist grouping** — IDE-launch scenarios grouped by IDE, all other Workbench tests grouped by feature module — replacing the single `workbench_interactive_serial` pin; (2) a **cross-worker `filelock`** wrapping only the silent-SSO round-trip in `workbench_login`, so concurrent workers never storm the shared IdP session. Password / no-auth runs are untouched.
+
+**Tech Stack:** Python 3.10+, pytest, pytest-bdd, pytest-xdist (LoadGroupScheduling), filelock, Playwright. Managed with `uv`.
+
+## Global Constraints
+
+- Run every command through `uv run` — never bare `python`/`pip`.
+- Ruff is linter + formatter; line length 100; rules `E,F,I,UP`. `just check` must pass. CI pins ruff 0.15.0.
+- All behavior changes activate **only** when `config.stash.get(_auth_session_key)` is not `None` (shared auth session present). Password / no-auth = today's default parallel behavior, unchanged.
+- Single shared test account — no account pool.
+- New pytest markers MUST be registered in `pyproject.toml` `[tool.pytest.ini_options] markers` or they raise warnings (CI cares about warnings).
+- `filelock` goes in `[project].dependencies` (runtime), not a dev group — the `ci.yml` dependency audit checks runtime deps.
+- xdist defaults are already `-n auto --dist loadgroup` (`pyproject.toml:162`) — no invocation change needed.
+- Commits: per Ian's rules, use the `/commit` skill and get **explicit approval of every commit message** before running it. Commit steps below show the intended message; do not execute without approval.
+- PR titles use conventional-commit format (`type: desc`, lowercase, <70 chars, no trailing period).
+- Add a `showboat` demo before the PR (see CLAUDE.md); root `demo.md` is gitignored — archive via `just demo-save <name>`.
+
+---
+
+## File Structure
+
+- `pyproject.toml` — add `filelock` runtime dep; register `rstudio`/`vscode`/`jupyter`/`positron` markers.
+- `src/vip_tests/workbench/conftest.py` — add login-lock helpers + `_silent_sso_signin`; rewrite `pytest_collection_modifyitems` to hybrid grouping via a pure `_workbench_group_name` helper.
+- `src/vip_tests/workbench/test_ide_launch.py` — decorate the four `@scenario` functions with IDE markers.
+- `selftests/test_workbench_parallel.py` — new: unit tests for the lock helper, `_silent_sso_signin`, `_workbench_group_name`, and the collection hook's gate + assignment.
+
+---
+
+## Task 1: Cross-worker OIDC login lock helper
+
+**Files:**
+- Modify: `pyproject.toml` (`[project].dependencies`)
+- Modify: `src/vip_tests/workbench/conftest.py` (imports + new helpers, after the `logger = ...` line ~32)
+- Test: `selftests/test_workbench_parallel.py`
+
+**Interfaces:**
+- Produces: `_login_lock_path(workbench_url: str) -> Path`; `oidc_login_lock(workbench_url: str, *, timeout: float = _LOGIN_LOCK_TIMEOUT) -> ContextManager[None]` (a `@contextlib.contextmanager`). On lock-acquire timeout it logs a warning and yields anyway (never raises, never blocks the run).
+
+- [ ] **Step 1: Add the dependency**
+
+In `pyproject.toml`, add to `[project].dependencies` (keep the list sorted-ish / grouped with the others):
+
+```toml
+    "filelock>=3.12",
+```
+
+- [ ] **Step 2: Sync and confirm it imports**
+
+Run: `uv sync && uv run python -c "import filelock; print(filelock.__version__)"`
+Expected: prints a version (e.g. `3.x.y`), no error.
+
+- [ ] **Step 3: Write the failing test**
+
+Create `selftests/test_workbench_parallel.py`:
+
+```python
+"""Selftests for #484 Workbench parallelization: login lock + hybrid grouping."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from filelock import FileLock
+
+from vip_tests.workbench import conftest as wb
+
+
+class TestOidcLoginLock:
+    def test_lock_path_is_stable_and_url_scoped(self, tmp_path):
+        a1 = wb._login_lock_path("https://wb.example.com")
+        a2 = wb._login_lock_path("https://wb.example.com")
+        b = wb._login_lock_path("https://other.example.com")
+        assert a1 == a2  # stable for the same URL
+        assert a1 != b  # distinct deployments get distinct locks
+        assert a1.name.endswith(".lock")
+
+    def test_lock_serializes_then_releases(self):
+        url = "https://wb.example.com/serialize"
+        with wb.oidc_login_lock(url):
+            pass
+        # Lock released: a fresh instance can acquire immediately.
+        other = FileLock(str(wb._login_lock_path(url)))
+        other.acquire(timeout=1)
+        other.release()
+
+    def test_lock_proceeds_on_timeout(self, caplog):
+        url = "https://wb.example.com/contended"
+        blocker = FileLock(str(wb._login_lock_path(url)))
+        blocker.acquire()
+        try:
+            entered = False
+            with caplog.at_level(logging.WARNING):
+                with wb.oidc_login_lock(url, timeout=0.2):
+                    entered = True
+            assert entered  # proceeded despite not holding the lock
+            assert "proceeding without it" in caplog.text
+        finally:
+            blocker.release()
+```
+
+- [ ] **Step 4: Run it to verify it fails**
+
+Run: `uv run pytest selftests/test_workbench_parallel.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_login_lock_path'` (helpers not written yet).
+
+- [ ] **Step 5: Implement the helpers**
+
+In `src/vip_tests/workbench/conftest.py`, add to the imports block (top of file):
+
+```python
+import contextlib
+import hashlib
+import tempfile
+```
+
+and
+
+```python
+from filelock import FileLock, Timeout
+```
+
+Then, just after `logger = logging.getLogger(__name__)` (~line 32), add:
+
+```python
+# Cross-worker OIDC login lock (#484). Under --interactive-auth / --headless-auth every
+# xdist worker shares one IdP session; letting many workers do the silent SSO round-trip
+# simultaneously storms the IdP (the ?error=2 bounce from #467). Serializing just the
+# round-trip removes the concurrency without re-serializing the whole suite.
+_LOGIN_LOCK_TIMEOUT = float(os.environ.get("VIP_LOGIN_LOCK_TIMEOUT", "60"))
+
+
+def _login_lock_path(workbench_url: str) -> Path:
+    """Path to the cross-worker OIDC login lock for *workbench_url*.
+
+    Keyed by a hash of the URL so distinct deployments don't share a lock, and placed in
+    the system temp dir so all xdist workers on the host share the same file.
+    """
+    digest = hashlib.sha256(workbench_url.encode()).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / f"vip-wb-login-{digest}.lock"
+
+
+@contextlib.contextmanager
+def oidc_login_lock(workbench_url: str, *, timeout: float = _LOGIN_LOCK_TIMEOUT):
+    """Serialize the OIDC SSO round-trip across xdist workers.
+
+    Only one worker performs the silent SSO round-trip against the shared IdP session at a
+    time. The lock is an optimization, never a correctness dependency: if it can't be
+    acquired within *timeout*, log a warning and proceed unlocked rather than hang the run.
+    """
+    lock = FileLock(str(_login_lock_path(workbench_url)))
+    try:
+        lock.acquire(timeout=timeout)
+    except Timeout:
+        logger.warning(
+            "OIDC login lock not acquired within %.0fs for %s; proceeding without it. "
+            "Concurrent logins may briefly storm the IdP.",
+            timeout,
+            workbench_url,
+        )
+        yield
+        return
+    try:
+        yield
+    finally:
+        lock.release()
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest selftests/test_workbench_parallel.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Lint**
+
+Run: `uv run ruff check src/ selftests/ && uv run ruff format --check src/ selftests/`
+Expected: no errors.
+
+- [ ] **Step 8: Commit** (via `/commit` skill, message approved by Ian)
+
+Intended message: `feat(workbench): add cross-worker OIDC login lock`
+
+---
+
+## Task 2: Wire the login lock into the SSO round-trip
+
+**Files:**
+- Modify: `src/vip_tests/workbench/conftest.py` (`workbench_login`, the `interactive_auth and sso_only` branch ~lines 391-411)
+- Test: `selftests/test_workbench_parallel.py`
+
+**Interfaces:**
+- Produces: `_silent_sso_signin(sso_button, homepage_logo, workbench_url: str) -> bool` — clicks the OIDC sign-in button and waits for the homepage, wrapped in `oidc_login_lock`. Returns `True` if the authenticated homepage appeared, `False` otherwise.
+- Consumes: `oidc_login_lock` (Task 1), `TIMEOUT_PAGE_LOAD` (existing module constant).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `selftests/test_workbench_parallel.py`:
+
+```python
+class _FakeButton:
+    def __init__(self):
+        self.clicked = False
+
+    def click(self):
+        self.clicked = True
+
+
+class _FakeLogo:
+    def __init__(self, *, appears: bool):
+        self._appears = appears
+
+    def wait_for(self, *, state, timeout):  # noqa: ARG002 - mirrors Playwright signature
+        if not self._appears:
+            raise RuntimeError("homepage never appeared")
+
+
+class TestSilentSsoSignin:
+    def test_returns_true_and_uses_lock_when_homepage_appears(self, monkeypatch):
+        used = {"locked": False}
+
+        import contextlib
+
+        @contextlib.contextmanager
+        def _spy_lock(url):
+            used["locked"] = True
+            used["url"] = url
+            yield
+
+        monkeypatch.setattr(wb, "oidc_login_lock", _spy_lock)
+        button = _FakeButton()
+        ok = wb._silent_sso_signin(button, _FakeLogo(appears=True), "https://wb.example.com")
+        assert ok is True
+        assert button.clicked is True
+        assert used["locked"] is True
+        assert used["url"] == "https://wb.example.com"
+
+    def test_returns_false_when_homepage_never_appears(self, monkeypatch):
+        import contextlib
+
+        monkeypatch.setattr(wb, "oidc_login_lock", lambda url: contextlib.nullcontext())
+        ok = wb._silent_sso_signin(_FakeButton(), _FakeLogo(appears=False), "https://wb.x")
+        assert ok is False
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest selftests/test_workbench_parallel.py::TestSilentSsoSignin -v`
+Expected: FAIL — `AttributeError: ... has no attribute '_silent_sso_signin'`.
+
+- [ ] **Step 3: Add the helper**
+
+In `conftest.py`, add above `workbench_login` (before the "Login Helper" section's `workbench_login` def):
+
+```python
+def _silent_sso_signin(sso_button, homepage_logo, workbench_url: str) -> bool:
+    """Click the OIDC sign-in button and wait for the homepage, serialized across workers.
+
+    Wrapped in :func:`oidc_login_lock` so concurrent xdist workers don't storm the shared
+    IdP session. Returns ``True`` when the authenticated homepage appears, ``False``
+    otherwise (the caller then skips with the standard message).
+    """
+    with oidc_login_lock(workbench_url):
+        sso_button.click()
+        try:
+            homepage_logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+            return True
+        except Exception:
+            return False
+```
+
+- [ ] **Step 4: Use the helper in `workbench_login`**
+
+Replace the existing branch (current `conftest.py:391-411`):
+
+```python
+        if interactive_auth and sso_only:
+            # Storage state was pre-loaded by --interactive-auth / --headless-auth.
+            # Workbench's SSO sign-in page does not auto-redirect to the IdP; it
+            # renders a "Sign in with OpenID" button.  Clicking it triggers a
+            # silent SSO round-trip using the saved IdP cookies, landing on the
+            # authenticated homepage with no credentials required.
+            sso_button.click()
+            try:
+                homepage_logo.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
+                return  # Silent SSO succeeded
+            except Exception:
+                # No usable IdP session (expired, or storage state was stripped
+                # for the password-login test) — silent SSO can't complete on an
+                # OIDC deployment, so skip gracefully.
+                pytest.skip(
+                    _workbench_session_skip_message(
+                        auth_mode=auth_mode,
+                        workbench_auth_error=workbench_auth_error,
+                        landed_url=page.url,
+                    )
+                )
+```
+
+with:
+
+```python
+        if interactive_auth and sso_only:
+            # Storage state was pre-loaded by --interactive-auth / --headless-auth.
+            # Workbench's SSO sign-in page does not auto-redirect to the IdP; it renders a
+            # "Sign in with OpenID" button. Clicking it triggers a silent SSO round-trip
+            # using the saved IdP cookies. The round-trip is serialized across xdist
+            # workers (see _silent_sso_signin / oidc_login_lock) to avoid storming the
+            # shared IdP session (#484/#467).
+            if _silent_sso_signin(sso_button, homepage_logo, workbench_url):
+                return  # Silent SSO succeeded
+            # No usable IdP session (expired, or storage state was stripped for the
+            # password-login test) — skip gracefully.
+            pytest.skip(
+                _workbench_session_skip_message(
+                    auth_mode=auth_mode,
+                    workbench_auth_error=workbench_auth_error,
+                    landed_url=page.url,
+                )
+            )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest selftests/test_workbench_parallel.py -v`
+Expected: PASS (all classes).
+
+- [ ] **Step 6: Regression — full selftests (excluding known-flaky timing file)**
+
+Run: `uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q`
+Expected: all pass (baseline was 1017 passed). `test_load_engine.py` is excluded per CLAUDE.md (timing-flaky, unrelated).
+
+- [ ] **Step 7: Lint + commit** (via `/commit`, message approved)
+
+Run: `uv run ruff check src/ selftests/ && uv run ruff format --check src/ selftests/`
+Intended message: `feat(workbench): serialize OIDC sign-in via the login lock`
+
+---
+
+## Task 3: Mark IDE-launch scenarios by IDE
+
+**Files:**
+- Modify: `pyproject.toml` (register markers)
+- Modify: `src/vip_tests/workbench/test_ide_launch.py` (decorate the four `@scenario` functions)
+- Test: covered by Task 4's collection test (markers must exist for grouping to key on them)
+
+**Interfaces:**
+- Produces: pytest markers `rstudio`, `vscode`, `jupyter`, `positron` on the four IDE-launch test functions.
+
+- [ ] **Step 1: Register the markers**
+
+In `pyproject.toml` `[tool.pytest.ini_options] markers = [ ... ]`, add:
+
+```toml
+    "rstudio: Workbench RStudio IDE-launch scenario",
+    "vscode: Workbench VS Code IDE-launch scenario",
+    "jupyter: Workbench JupyterLab IDE-launch scenario",
+    "positron: Workbench Positron IDE-launch scenario",
+```
+
+- [ ] **Step 2: Decorate the scenario functions**
+
+In `src/vip_tests/workbench/test_ide_launch.py`, add one marker per `@scenario` function (markers are explicit decorators here rather than feature-file tags — matches the repo pattern of marking `@scenario` functions directly, and keeps the grouping signal in code the conftest reads):
+
+```python
+@pytest.mark.rstudio
+@scenario("test_ide_launch.feature", "RStudio IDE session can be launched")
+def test_launch_rstudio():
+    pass
+
+
+@pytest.mark.vscode
+@scenario("test_ide_launch.feature", "VS Code session can be launched")
+def test_launch_vscode():
+    pass
+
+
+@pytest.mark.jupyter
+@scenario("test_ide_launch.feature", "JupyterLab session can be launched")
+def test_launch_jupyter():
+    pass
+
+
+@pytest.mark.positron
+@scenario("test_ide_launch.feature", "Positron session can be launched")
+def test_launch_positron():
+    pass
+```
+
+- [ ] **Step 3: Verify markers are attached with no warnings**
+
+Run: `uv run pytest src/vip_tests/workbench/test_ide_launch.py --collect-only -q -m rstudio 2>&1 | grep -iE "warning|test_launch_rstudio"`
+Expected: `test_launch_rstudio` collected; **no** "Unknown pytest.mark" warning.
+
+- [ ] **Step 4: Lint + commit** (via `/commit`, message approved)
+
+Intended message: `test(workbench): mark IDE-launch scenarios by IDE`
+
+---
+
+## Task 4: Hybrid xdist grouping in the workbench conftest
+
+**Files:**
+- Modify: `src/vip_tests/workbench/conftest.py` (`pytest_collection_modifyitems` ~lines 37-64 + new pure helper)
+- Test: `selftests/test_workbench_parallel.py`
+
+**Interfaces:**
+- Produces: `_IDE_MARKERS: tuple[str, ...]`; `_workbench_group_name(ide_markers: set[str], module_stem: str) -> str`.
+- Consumes: `_auth_session_key` (already imported at conftest top via `from vip.plugin import _auth_session_key`? — NOTE: it is referenced as `_auth_session_key` in the current hook, so it is already importable in this module).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `selftests/test_workbench_parallel.py`:
+
+```python
+class TestWorkbenchGroupName:
+    def test_ide_marker_wins(self):
+        assert wb._workbench_group_name({"rstudio"}, "test_ide_launch") == "workbench_ide_rstudio"
+        assert wb._workbench_group_name({"positron"}, "test_ide_launch") == "workbench_ide_positron"
+
+    def test_non_ide_groups_by_module_stripping_test_prefix(self):
+        assert wb._workbench_group_name(set(), "test_packages") == "workbench_packages"
+        assert wb._workbench_group_name(set(), "test_git_ops") == "workbench_git_ops"
+
+    def test_module_without_test_prefix_kept_verbatim(self):
+        assert wb._workbench_group_name(set(), "chronicle_probe") == "workbench_chronicle_probe"
+
+
+class _FakeMarker:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeItem:
+    def __init__(self, path: Path, marker_names):
+        self.path = path
+        self.own_markers = [_FakeMarker("xdist_group"), _FakeMarker("workbench")]
+        self._markers = [_FakeMarker(n) for n in marker_names]
+        self.added = []
+
+    def iter_markers(self):
+        return list(self._markers)
+
+    def add_marker(self, marker):
+        # pytest.mark.xdist_group("g") -> mark object with .name and .args
+        self.added.append((marker.name, marker.args))
+
+
+class _FakeConfig:
+    def __init__(self, session):
+        self._session = session
+
+    @property
+    def stash(self):
+        cfg = self
+
+        class _Stash:
+            def get(self, key, default=None):  # noqa: ARG002
+                return cfg._session
+
+        return _Stash()
+
+
+class TestCollectionHook:
+    def _wb_dir(self):
+        return Path(wb.__file__).parent
+
+    def test_no_auth_session_is_a_noop(self):
+        item = _FakeItem(self._wb_dir() / "test_packages.py", [])
+        wb.pytest_collection_modifyitems(_FakeConfig(None), [item])
+        assert item.added == []  # untouched under password / no-auth
+
+    def test_ide_item_grouped_by_ide(self):
+        item = _FakeItem(self._wb_dir() / "test_ide_launch.py", ["workbench", "rstudio"])
+        wb.pytest_collection_modifyitems(_FakeConfig(object()), [item])
+        assert ("xdist_group", ("workbench_ide_rstudio",)) in item.added
+        assert all(m.name != "xdist_group" for m in item.own_markers)  # old group stripped
+
+    def test_non_ide_item_grouped_by_module(self):
+        item = _FakeItem(self._wb_dir() / "test_packages.py", ["workbench"])
+        wb.pytest_collection_modifyitems(_FakeConfig(object()), [item])
+        assert ("xdist_group", ("workbench_packages",)) in item.added
+
+    def test_non_workbench_item_ignored(self):
+        item = _FakeItem(Path("/somewhere/connect/test_auth.py"), ["connect"])
+        wb.pytest_collection_modifyitems(_FakeConfig(object()), [item])
+        assert item.added == []
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest selftests/test_workbench_parallel.py::TestWorkbenchGroupName selftests/test_workbench_parallel.py::TestCollectionHook -v`
+Expected: FAIL — `_workbench_group_name` missing / hook still assigns `workbench_interactive_serial`.
+
+- [ ] **Step 3: Add the pure helper**
+
+In `conftest.py`, just above `pytest_collection_modifyitems`:
+
+```python
+_IDE_MARKERS = ("rstudio", "vscode", "jupyter", "positron")
+
+
+def _workbench_group_name(ide_markers: set[str], module_stem: str) -> str:
+    """Compute the xdist group for a Workbench test under shared auth (hybrid grouping).
+
+    IDE-launch scenarios (carrying an IDE marker) group by IDE so each IDE runs on its own
+    worker: ``workbench_ide_<ide>``. Every other Workbench test groups by feature module:
+    ``workbench_<stem>`` (a leading ``test_`` stripped).
+    """
+    for ide in _IDE_MARKERS:
+        if ide in ide_markers:
+            return f"workbench_ide_{ide}"
+    stem = module_stem[len("test_"):] if module_stem.startswith("test_") else module_stem
+    return f"workbench_{stem}"
+```
+
+- [ ] **Step 4: Rewrite the hook**
+
+Replace the current `pytest_collection_modifyitems` body (`conftest.py:37-64`) with:
+
+```python
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Group Workbench tests for parallel execution when a shared auth session is active.
+
+    Under --interactive-auth / --headless-auth all Workbench tests authenticate as the same
+    shared account. Rather than pin them all to one worker (the old serial workaround), we
+    group them so LoadGroupScheduling spreads them across workers: IDE-launch scenarios by
+    IDE (``workbench_ide_<ide>``), everything else by feature module (``workbench_<module>``).
+    The simultaneous-login storm this used to cause is prevented by the cross-worker login
+    lock in :func:`workbench_login` (see :func:`oidc_login_lock`), not by serialization.
+
+    For password auth (no shared session) the default parallel behavior is preserved.
+    """
+    if config.stash.get(_auth_session_key, None) is None:
+        # No shared auth session — password auth or no auth. Keep default parallel behavior.
+        return
+
+    workbench_dir = Path(__file__).parent
+    for item in items:
+        item_path = getattr(item, "path", None)
+        if item_path is None or not item_path.is_relative_to(workbench_dir):
+            continue
+        ide_markers = {m.name for m in item.iter_markers()} & set(_IDE_MARKERS)
+        group = _workbench_group_name(ide_markers, item_path.stem)
+        # Replace the default xdist_group("workbench") from pytestmark with the hybrid group.
+        item.own_markers = [m for m in item.own_markers if m.name != "xdist_group"]
+        item.add_marker(pytest.mark.xdist_group(group))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest selftests/test_workbench_parallel.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Confirm collection still succeeds end-to-end**
+
+Run: `uv run pytest src/vip_tests/workbench/ --collect-only -q 2>&1 | tail -5`
+Expected: scenarios collected, no errors, no unknown-marker warnings.
+
+- [ ] **Step 7: Full selftests + lint**
+
+Run: `uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q && uv run ruff check src/ selftests/ && uv run ruff format --check src/ selftests/`
+Expected: all pass, no lint errors.
+
+- [ ] **Step 8: Commit** (via `/commit`, message approved)
+
+Intended message: `feat(workbench): group tests by IDE/module instead of forcing serial`
+
+---
+
+## Task 5: Live validation gate (go / no-go) — required before merge
+
+This is the acceptance gate the design calls for: the CI-testable parts above cannot prove that a *single shared account* sustains concurrent Workbench sessions or that the lock kills the `?error=2` storm. This must be run against a **live OIDC Workbench 2026.06** deployment.
+
+**Files:** none (manual run + `showboat` demo capture).
+
+- [ ] **Step 1: Configure a live run**
+
+Point `vip.toml` (or `vip verify --workbench-url ...`) at a real OIDC Workbench 2026.06 deployment with the shared test account (`VIP_TEST_USERNAME` / `VIP_TEST_PASSWORD` / optional `VIP_TEST_TOTP_SECRET`).
+
+- [ ] **Step 2: Run the Workbench suite in parallel under headless auth**
+
+Run: `uv run vip verify --config vip.toml --categories workbench --headless-auth -- -v`
+(xdist defaults `-n auto --dist loadgroup` apply.)
+
+- [ ] **Step 3: Confirm the four acceptance criteria**
+
+- Tests are distributed across **multiple** xdist workers (multiple `gw` ids in output), not pinned to one.
+- **No** `?error=2` / sign-in-page bounces; no logins fail from contention.
+- All Workbench tests that passed under the old serial run still pass.
+- Wall-clock is **materially below** the ~10-minute serial baseline.
+
+- [ ] **Step 4: If it fails — fall back, don't force it**
+
+Options, in order: raise `VIP_LOGIN_LOCK_TIMEOUT`; cap concurrency (document running Workbench with fewer workers); if the storm persists even with serialized logins, the single-account premise is wrong → revisit the deferred "bake an established Workbench session into storage_state" option (design doc, "Out (deferred)").
+
+- [ ] **Step 5: Capture a `showboat` demo and open a draft PR**
+
+Build a demo proving the selftests pass and the live run parallelizes; `just demo-save workbench-parallel-484`; open a **draft** PR titled `test(workbench): parallelize tests by IDE type instead of forcing serial` (matches issue #484), linking `Closes #484`, with the demo under `## Demo`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Hybrid grouping (IDE-launch by IDE, rest by module) → Tasks 3 + 4. ✓
+- Gate on shared auth session only → Task 4 hook + `TestCollectionHook.test_no_auth_session_is_a_noop`. ✓
+- Cross-worker login lock around the SSO round-trip only → Tasks 1 + 2. ✓
+- Proceed-on-timeout (lock is optimization, not correctness) → Task 1 `test_lock_proceeds_on_timeout`. ✓
+- `filelock` added to runtime deps → Task 1 Step 1. ✓
+- Single shared account / no pool → honored (no account config added). ✓
+- Live spike as the go/no-go gate with fallback → Task 5. ✓ (Sequenced last, since the lock/grouping code must exist to validate it; merge is blocked on it, satisfying "don't trust the rollout until proven.")
+
+**Placeholder scan:** none — every code step shows complete code; every run step shows the command and expected result.
+
+**Type consistency:** `oidc_login_lock` / `_login_lock_path` / `_silent_sso_signin` / `_workbench_group_name` / `_IDE_MARKERS` names are used identically across Tasks 1-4. `_silent_sso_signin(sso_button, homepage_logo, workbench_url)` signature matches its call site in Task 2 Step 4. ✓

--- a/uv.lock
+++ b/uv.lock
@@ -2183,9 +2183,10 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.54.7"
+version = "0.54.8"
 source = { editable = "." }
 dependencies = [
+    { name = "filelock" },
     { name = "httpx" },
     { name = "idna" },
     { name = "mako" },
@@ -2232,6 +2233,7 @@ report = [
 [package.metadata]
 requires-dist = [
     { name = "bleach", marker = "extra == 'report'", specifier = ">=6.4.0" },
+    { name = "filelock", specifier = ">=3.12" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "idna", specifier = ">=3.15" },
     { name = "ipykernel", marker = "extra == 'report'" },

--- a/validation_docs/demo-workbench-parallel-484.md
+++ b/validation_docs/demo-workbench-parallel-484.md
@@ -1,0 +1,44 @@
+# feat(workbench): parallelize BDD suite under shared auth (#484)
+
+*2026-07-20T23:23:12Z by Showboat 0.6.1*
+<!-- showboat-id: 6d8bd6b9-7c0f-407d-b5c5-00496e9b7472 -->
+
+Before: under --interactive-auth / --headless-auth every Workbench test (auth, IDE launch, sessions, packages) was pinned to a single xdist worker via the workbench_interactive_serial group -- avoiding a shared-IdP login storm at the cost of ~10 min of forced serial execution. After: two changes replace that pin. (1) A cross-worker filelock (oidc_login_lock, keyed by a hash of the Workbench URL) now serializes ONLY the OIDC silent-sign-in round-trip in _silent_sso_signin/workbench_login -- the part that actually storms the IdP -- so it can time out and proceed unlocked rather than hang the run. (2) pytest_collection_modifyitems in src/vip_tests/workbench/conftest.py replaces the single-worker pin with hybrid xdist grouping via _workbench_group_name: IDE-launch scenarios group by IDE (workbench_ide_rstudio/vscode/jupyter/positron) so each IDE gets its own worker, and every other Workbench test groups by feature module (workbench_<stem>, e.g. workbench_packages, workbench_git_ops). This only fires when a shared auth session is active (config.stash has an auth session); password/no-auth runs are untouched. Net effect: Workbench tests now spread across multiple xdist workers instead of funneling through one, while the login-lock keeps the shared IdP from being hammered by concurrent sign-ins.
+
+```bash
+uv run pytest selftests/test_workbench_parallel.py -q 2>&1 | grep -E "passed|failed|error" | sed 's/ in [0-9.]*s//'
+```
+
+```output
+12 passed
+```
+
+```bash
+uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -E "passed|failed|error" | sed 's/ in [0-9.]*s//'
+```
+
+```output
+1029 passed, 22 warnings
+```
+
+```bash
+just check
+```
+
+```output
+uv run ruff check src/ selftests/ examples/ docker/
+All checks passed!
+uv run ruff format --check src/ selftests/ examples/ docker/
+164 files already formatted
+```
+
+```bash
+uv run python -c "from vip_tests.workbench.conftest import _workbench_group_name as g; print(g({'rstudio'},'test_ide_launch')); print(g({'positron'},'test_ide_launch')); print(g(set(),'test_packages')); print(g(set(),'test_git_ops'))"
+```
+
+```output
+workbench_ide_rstudio
+workbench_ide_positron
+workbench_packages
+workbench_git_ops
+```


### PR DESCRIPTION
## Summary

Closes #484. Replaces the forced-serial Workbench test run (under shared OIDC auth) with parallel-by-group execution, made safe by a cross-worker OIDC login lock. Validated end-to-end against a live Okta-fronted Workbench 2026.06 deployment.

## Background

Under `--interactive-auth` / `--headless-auth`, every Workbench test authenticated as the same shared account and was pinned to a single xdist worker (`workbench_interactive_serial`) — a ~10-minute serial run. The pin existed to avoid an OIDC login storm: because Playwright contexts are function-scoped and the shared storage state holds only IdP cookies, every test did its own silent SSO round-trip, and many workers doing that against one shared IdP session simultaneously made the IdP bounce sessions back to sign-in (`?error=2`).

## What changed

- **Cross-worker login lock** (`oidc_login_lock`, `filelock`): serializes only the OIDC silent-sign-in round-trip in `workbench_login`, keyed by a hash of the Workbench URL. It's an optimization, not a correctness dependency — on acquire-timeout it logs and proceeds unlocked rather than hanging the run. The already-logged-in fast path and password login never take the lock.
- **Hybrid xdist grouping** replaces the single-worker pin: IDE-launch scenarios group by IDE (`workbench_ide_rstudio/vscode/jupyter/positron`), every other Workbench test groups by feature module (`workbench_<stem>`). LoadGroupScheduling then spreads these across workers.
- IDE markers added to the four IDE-launch scenarios (registered in both `pyproject.toml` and `plugin.py`).
- **Capacity-aware timeout diagnostic**: when a session times out in "Starting" under a multi-worker run, the failure now explains that concurrent launches may exceed the deployment's concurrent-session capacity and suggests reducing `-n` — instead of an opaque timeout.
- **Cleaner parallel output**: verbose xdist runs now print one line per test at completion (no split location/result lines, no `[gw<N>]` prefix).
- **JupyterLab kernel-error robustness**: under concurrent load a kernel can fail to start with a transient reverse-proxy 502, popping an "Error Starting Kernel" modal that used to hang the launch test on a click-intercept timeout. The test now dismisses that dialog and degrades into its existing graceful skip. (Same capacity ceiling as the session-launch case, surfacing in JupyterLab.)

All of the above is gated on a shared auth session being active; password / no-auth runs are untouched.

## Design decisions

- Single shared test account assumed — no account pool. The login storm is removed by serializing logins, not by giving each worker its own identity.
- Grouping is hybrid because IDE type is a scenario-level attribute (only the four IDE-launch scenarios), while the rest of the suite isn't IDE-specific — feature-module grouping maps onto the existing collection units for those.
- The concurrent-session ceiling is a property of the target deployment, not the framework, so it is surfaced as an actionable diagnostic (and an operator `-n` knob) rather than papered over with a launch semaphore that would fight the parallelism this PR exists to enable.

## Testing / live validation

Validated against a live Okta-fronted Workbench 2026.06 deployment:

- **Login lock holds at the default concurrency**: at `-n 2–3`, concurrent logins produced zero `?error=2` bounces. At higher concurrency (`-n 4`) on a single shared auth session the IdP still intermittently bounces a login to `?error=2`; the lock contains the impact — a bounced login now skips gracefully with an explanatory message instead of hard-failing. `vip verify` therefore defaults to `-n 2` (override with `-- -n N`).
- **Hybrid grouping runs correctly** across workers (correct `workbench_ide_*` / `workbench_<module>` groups, spread over `gw0`–`gw3`).
- **Sessions launch and pass individually**; under high concurrency, a capacity-limited deployment can leave some sessions stuck in "Starting" until they time out. This is a deployment capacity property (raising the timeout to 180s did not help), not a framework issue — operators cap `-n` to their deployment's concurrent-session capacity, and the new diagnostic makes that actionable.
- **Cleaner output confirmed live** — one line per test, no split lines, no worker prefixes.

1035 selftests pass (excluding the pre-existing timing-flaky `test_load_engine.py`); lint/format clean. See `## Demo` below.

## Demo

# feat(workbench): parallelize BDD suite under shared auth (#484)

*2026-07-20T23:23:12Z by Showboat 0.6.1*
<!-- showboat-id: 6d8bd6b9-7c0f-407d-b5c5-00496e9b7472 -->

Before: under --interactive-auth / --headless-auth every Workbench test (auth, IDE launch, sessions, packages) was pinned to a single xdist worker via the workbench_interactive_serial group -- avoiding a shared-IdP login storm at the cost of ~10 min of forced serial execution. After: two changes replace that pin. (1) A cross-worker filelock (oidc_login_lock, keyed by a hash of the Workbench URL) now serializes ONLY the OIDC silent-sign-in round-trip in _silent_sso_signin/workbench_login -- the part that actually storms the IdP -- so it can time out and proceed unlocked rather than hang the run. (2) pytest_collection_modifyitems in src/vip_tests/workbench/conftest.py replaces the single-worker pin with hybrid xdist grouping via _workbench_group_name: IDE-launch scenarios group by IDE (workbench_ide_rstudio/vscode/jupyter/positron) so each IDE gets its own worker, and every other Workbench test groups by feature module (workbench_<stem>, e.g. workbench_packages, workbench_git_ops). This only fires when a shared auth session is active (config.stash has an auth session); password/no-auth runs are untouched. Net effect: Workbench tests now spread across multiple xdist workers instead of funneling through one, while the login-lock keeps the shared IdP from being hammered by concurrent sign-ins.

```bash
uv run pytest selftests/test_workbench_parallel.py -q 2>&1 | grep -E "passed|failed|error" | sed 's/ in [0-9.]*s//'
```

```output
12 passed
```

```bash
uv run pytest selftests/ --ignore=selftests/test_load_engine.py -q 2>&1 | grep -E "passed|failed|error" | sed 's/ in [0-9.]*s//'
```

```output
1029 passed, 22 warnings
```

```bash
just check
```

```output
uv run ruff check src/ selftests/ examples/ docker/
All checks passed!
uv run ruff format --check src/ selftests/ examples/ docker/
164 files already formatted
```

```bash
uv run python -c "from vip_tests.workbench.conftest import _workbench_group_name as g; print(g({'rstudio'},'test_ide_launch')); print(g({'positron'},'test_ide_launch')); print(g(set(),'test_packages')); print(g(set(),'test_git_ops'))"
```

```output
workbench_ide_rstudio
workbench_ide_positron
workbench_packages
workbench_git_ops
```
