### PR TITLE
fix(workbench): make Positron console readback reliable on cold sessions

### DIFF
--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -32,6 +32,7 @@ from vip_tests.workbench.exec import (
     _split_marker,
     _strip_r_index,
     _wrap_python_expr,
+    _wrap_python_expr_inline,
     _wrap_r_expr,
     ensure_positron_console,
     file_exists,
@@ -186,6 +187,33 @@ class TestWrapPythonExpr:
         result = _wrap_python_expr("x = 1", start, end)
         last_line = result.splitlines()[-1]
         assert _split_marker(end)[0] in last_line
+
+
+# ---------------------------------------------------------------------------
+# _wrap_python_expr_inline
+# ---------------------------------------------------------------------------
+
+
+class TestWrapPythonExprInline:
+    def test_single_line(self):
+        """Inline wrapping is one line so IPython runs it on a single Enter."""
+        start, end = "<<VIP-START-abc>>", "<<VIP-END-abc>>"
+        result = _wrap_python_expr_inline("print(open('/tmp/x').read())", start, end)
+        assert len(result.splitlines()) == 1
+
+    def test_full_marker_not_contiguous_in_source(self):
+        start, end = "<<VIP-START-abc>>", "<<VIP-END-abc>>"
+        result = _wrap_python_expr_inline("1 + 1", start, end)
+        assert start not in result
+        assert end not in result
+
+    def test_marker_halves_and_expression_present(self):
+        start, end = "<<VIP-START-abc>>", "<<VIP-END-abc>>"
+        expr = "import os; print(os.path.exists('/tmp/x'))"
+        result = _wrap_python_expr_inline(expr, start, end)
+        assert expr in result
+        for half in (*_split_marker(start), *_split_marker(end)):
+            assert half in result
 
 
 # ---------------------------------------------------------------------------
@@ -454,6 +482,17 @@ class _EnsureFakeLocator:
     @property
     def first(self):
         return self
+
+    def nth(self, index):
+        return self
+
+    def text_content(self, timeout=None):
+        # Interpreter rows report an R label so ensure_positron_console's
+        # R-preference selects a row on the first grace poll (these tests
+        # exercise the start/select/render flow, not language routing).
+        if self._selector == PositronSession.INTERPRETER_QUICKPICK_ROW:
+            return "R 4.5.2" if self.count() >= 1 else ""
+        return ""
 
     def count(self):
         p = self._page

--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -598,6 +598,8 @@ class TestFileExistsRouting:
     def test_positron_r_calls_positron_eval_r(self, monkeypatch):
         page = MagicMock()
         monkeypatch.setattr(exec_mod, "_detect_ide", lambda p: "positron")
+        # Positron routes by the started console's language, not the lang arg.
+        monkeypatch.setattr(exec_mod, "_positron_console_language", lambda p, t: "r")
         mock_rstudio_eval = MagicMock()
         mock_positron_eval_r = MagicMock(return_value="TRUE")
         mock_positron_eval_python = MagicMock()
@@ -607,7 +609,7 @@ class TestFileExistsRouting:
         monkeypatch.setattr(exec_mod, "positron_eval_python", mock_positron_eval_python)
         monkeypatch.setattr(exec_mod, "read_file_via_vscode_editor", mock_editor_read)
 
-        result = file_exists(page, "/tmp/foo.txt", lang="r")
+        result = file_exists(page, "/tmp/foo.txt")
 
         assert result is True
         mock_positron_eval_r.assert_called_once()
@@ -618,6 +620,8 @@ class TestFileExistsRouting:
     def test_positron_python_calls_positron_eval_python(self, monkeypatch):
         page = MagicMock()
         monkeypatch.setattr(exec_mod, "_detect_ide", lambda p: "positron")
+        # Positron routes by the started console's language, not the lang arg.
+        monkeypatch.setattr(exec_mod, "_positron_console_language", lambda p, t: "python")
         mock_rstudio_eval = MagicMock()
         mock_positron_eval_r = MagicMock()
         mock_positron_eval_python = MagicMock(return_value="True")
@@ -627,7 +631,7 @@ class TestFileExistsRouting:
         monkeypatch.setattr(exec_mod, "positron_eval_python", mock_positron_eval_python)
         monkeypatch.setattr(exec_mod, "read_file_via_vscode_editor", mock_editor_read)
 
-        result = file_exists(page, "/tmp/foo.txt", lang="python")
+        result = file_exists(page, "/tmp/foo.txt")
 
         assert result is True
         mock_positron_eval_python.assert_called_once()
@@ -704,6 +708,8 @@ class TestReadFileRouting:
     def test_positron_r_calls_positron_eval_r(self, monkeypatch):
         page = MagicMock()
         monkeypatch.setattr(exec_mod, "_detect_ide", lambda p: "positron")
+        # Positron routes by the started console's language, not the lang arg.
+        monkeypatch.setattr(exec_mod, "_positron_console_language", lambda p, t: "r")
         mock_rstudio_eval = MagicMock()
         # cat()'d output is raw -- no "[1]" index, no quoting.
         mock_positron_eval_r = MagicMock(return_value="file contents")
@@ -714,7 +720,7 @@ class TestReadFileRouting:
         monkeypatch.setattr(exec_mod, "positron_eval_python", mock_positron_eval_python)
         monkeypatch.setattr(exec_mod, "read_file_via_vscode_editor", mock_editor_read)
 
-        result = read_file(page, "/tmp/foo.txt", lang="r")
+        result = read_file(page, "/tmp/foo.txt")
 
         assert result == "file contents"
         positron_expr = mock_positron_eval_r.call_args[0][1]
@@ -727,6 +733,8 @@ class TestReadFileRouting:
     def test_positron_python_calls_positron_eval_python(self, monkeypatch):
         page = MagicMock()
         monkeypatch.setattr(exec_mod, "_detect_ide", lambda p: "positron")
+        # Positron routes by the started console's language, not the lang arg.
+        monkeypatch.setattr(exec_mod, "_positron_console_language", lambda p, t: "python")
         mock_rstudio_eval = MagicMock()
         mock_positron_eval_r = MagicMock()
         mock_positron_eval_python = MagicMock(return_value="python file contents")
@@ -736,7 +744,7 @@ class TestReadFileRouting:
         monkeypatch.setattr(exec_mod, "positron_eval_python", mock_positron_eval_python)
         monkeypatch.setattr(exec_mod, "read_file_via_vscode_editor", mock_editor_read)
 
-        result = read_file(page, "/tmp/foo.txt", lang="python")
+        result = read_file(page, "/tmp/foo.txt")
 
         assert result == "python file contents"
         mock_positron_eval_python.assert_called_once()

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -302,10 +302,26 @@ def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
     if rows.count() == 0:
         return False
 
-    # Select the first interpreter; fall back to Enter. Both are best-effort so
-    # the "never raises" contract holds even if the row/keyboard is detached.
+    # Prefer an R interpreter. Its console readback uses a single-line,
+    # semicolon-chained expression that Positron runs on one Enter, whereas the
+    # Python console is IPython, whose multi-line continuation handling makes the
+    # marker-bracketed readback unreliable. Fall back to the first interpreter
+    # when no R is offered.
+    target = rows.first
     try:
-        rows.first.click()
+        for i in range(rows.count()):
+            row = rows.nth(i)
+            label = (row.text_content(timeout=_POSITRON_POLL_MS) or "").strip()
+            if re.match(r"^R\b", label):
+                target = row
+                break
+    except Exception:
+        target = rows.first
+
+    # Select the interpreter; fall back to Enter. Both are best-effort so the
+    # "never raises" contract holds even if the row/keyboard is detached.
+    try:
+        target.click()
     except Exception:
         try:
             page.keyboard.press("Enter")
@@ -336,10 +352,71 @@ def _activate_positron_console(page: Page) -> None:
             pass
 
 
-# Settle wait (ms) after the interpreter's active-line-number is visible.
-# Typing during "R 4.4.0 starting." is silently dropped; this pause lets the
-# REPL reach the interactive prompt before we type the wrapped expression.
-_POSITRON_SETTLE_MS = 3_000
+# Interactive prompt shown on the active console line once the interpreter is
+# ready for input. Typing during "R x.y.z starting." is silently dropped and
+# leaves the REPL at a "+" continuation prompt, so we wait for one of these
+# before typing (mirrors Positron's own e2e Console.waitForReady).
+_POSITRON_PROMPT_R = ">"
+_POSITRON_PROMPT_PYTHON = ">>>"
+_POSITRON_PROMPT_POLL_MS = 500
+
+
+def _wait_for_positron_console_prompt(page: Page, prompt: str, timeout: int) -> None:
+    """Block until the active Positron console shows an interactive *prompt*.
+
+    Positron opens the console while the interpreter is still starting; the
+    active line reads "R x.y.z starting." (or is blank) before it becomes the
+    interactive prompt. Keystrokes typed during startup are dropped or land at a
+    "+" continuation prompt, so the wrapped statement never executes and its end
+    marker never prints. This polls the active line number until it reads the
+    interpreter prompt exactly, re-activating the Console tab each attempt in
+    case a prior ``terminal_run`` left the Terminal focused.
+
+    Raises:
+        ExecError: the prompt did not appear within *timeout* ms.
+    """
+    deadline = time.monotonic() + timeout / 1000.0
+    active_line = page.locator(_POSITRON_CONSOLE_READY).first
+    last = ""
+    while time.monotonic() < deadline:
+        _activate_positron_console(page)
+        try:
+            last = (active_line.text_content(timeout=_POSITRON_PROMPT_POLL_MS) or "").strip()
+        except PlaywrightTimeoutError:
+            last = ""
+        if last == prompt:
+            return
+        page.wait_for_timeout(_POSITRON_PROMPT_POLL_MS)
+    raise ExecError(
+        f"Positron console did not reach an interactive {prompt!r} prompt within "
+        f"{timeout} ms (last active line: {last!r})."
+    )
+
+
+def _positron_console_language(page: Page, timeout: int) -> str:
+    """Return ``"r"`` or ``"python"`` for the started Positron console.
+
+    Positron auto-starts whichever interpreter is the session default (R or
+    Python), so a file-readback must match the console that actually started
+    rather than a language the caller assumed. Starts a console if needed, waits
+    for an interactive prompt, and maps it to a language (``">>>"`` → Python,
+    ``">"`` → R). Falls back to ``"r"`` if no prompt is readable in time.
+    """
+    ensure_positron_console(page, timeout=timeout)
+    active_line = page.locator(_POSITRON_CONSOLE_READY).first
+    deadline = time.monotonic() + timeout / 1000.0
+    while time.monotonic() < deadline:
+        _activate_positron_console(page)
+        try:
+            last = (active_line.text_content(timeout=_POSITRON_PROMPT_POLL_MS) or "").strip()
+        except PlaywrightTimeoutError:
+            last = ""
+        if last == _POSITRON_PROMPT_PYTHON:
+            return "python"
+        if last == _POSITRON_PROMPT_R:
+            return "r"
+        page.wait_for_timeout(_POSITRON_PROMPT_POLL_MS)
+    return "r"
 
 
 def positron_eval_r(page: Page, expr: str, timeout: int = 30_000) -> str:
@@ -370,13 +447,12 @@ def positron_eval_r(page: Page, expr: str, timeout: int = 30_000) -> str:
     active = page.locator(_POSITRON_ACTIVE_CONSOLE)
     expect(active.first).to_be_visible(timeout=timeout)
 
-    # Wait for the interpreter to be INPUT-ready before typing.
-    expect(active.locator(".active-line-number").first).to_be_visible(timeout=timeout)
-    page.wait_for_timeout(_POSITRON_SETTLE_MS)
+    # Wait for the interpreter to reach its interactive prompt before typing.
+    _wait_for_positron_console_prompt(page, _POSITRON_PROMPT_R, timeout)
 
     ci = active.locator(_POSITRON_CONSOLE_INPUT).first
     ci.click()
-    page.keyboard.type(wrapped)
+    page.keyboard.insert_text(wrapped)
     page.keyboard.press("Enter")
 
     # Poll the joined span text until the end marker appears.
@@ -421,15 +497,14 @@ def positron_eval_python(page: Page, expr: str, timeout: int = 30_000) -> str:
     active = page.locator(_POSITRON_ACTIVE_CONSOLE)
     expect(active.first).to_be_visible(timeout=timeout)
 
-    # Wait for the interpreter to be INPUT-ready before typing.
-    expect(active.locator(".active-line-number").first).to_be_visible(timeout=timeout)
-    page.wait_for_timeout(_POSITRON_SETTLE_MS)
+    # Wait for the interpreter to reach its interactive prompt before typing.
+    _wait_for_positron_console_prompt(page, _POSITRON_PROMPT_PYTHON, timeout)
 
     ci = active.locator(_POSITRON_CONSOLE_INPUT).first
     ci.click()
     # Submit each line separately; Enter submits a complete statement in the Python REPL.
     for line in wrapped.splitlines():
-        page.keyboard.type(line)
+        page.keyboard.insert_text(line)
         page.keyboard.press("Enter")
 
     # Poll the joined span text until the end marker appears.
@@ -768,22 +843,27 @@ def terminal_run(
             time.sleep(poll_interval)
     else:
         # RStudio / Positron: poll via DOM console eval (read_file handles routing).
+        # A cold Positron session discovers interpreters and starts its console
+        # asynchronously, so read_file can raise (no console yet / output not
+        # captured) on early polls; treat those as "not ready" and keep polling
+        # until the deadline rather than failing the whole command. Each attempt
+        # gets the remaining budget so the first cold-start console has time to
+        # come up, instead of a fixed few seconds that guarantees failure.
         while time.monotonic() < deadline:
+            remaining_ms = max(1, int((deadline - time.monotonic()) * 1000))
             try:
-                content = read_file(page, tmpfile, timeout=5_000, lang=readback_lang)
-                parsed = _parse_done_marker(content, done_marker)
-                if parsed is not None:
-                    output, exit_code = parsed
-                    if exit_code != 0:
-                        raise ExecError(
-                            f"terminal_run: command {cmd!r} exited with status "
-                            f"{exit_code}: {output}"
-                        )
-                    return output
-            except ExecError:
-                raise
+                content = read_file(page, tmpfile, timeout=remaining_ms, lang=readback_lang)
             except Exception:
-                pass
+                time.sleep(poll_interval)
+                continue
+            parsed = _parse_done_marker(content, done_marker)
+            if parsed is not None:
+                output, exit_code = parsed
+                if exit_code != 0:
+                    raise ExecError(
+                        f"terminal_run: command {cmd!r} exited with status {exit_code}: {output}"
+                    )
+                return output
             time.sleep(poll_interval)
 
     raise ExecError(
@@ -818,7 +898,9 @@ def file_exists(page: Page, path: str, timeout: int = 30_000, *, lang: str = "r"
     """
     ide = _detect_ide(page)
     if ide == "positron":
-        if lang.lower() == "r":
+        # Route to whichever interpreter the console actually started, not the
+        # caller's assumed language (Positron auto-starts R or Python).
+        if _positron_console_language(page, timeout) == "r":
             result = positron_eval_r(page, f'file.exists("{path}")', timeout=timeout)
             return "TRUE" in result
         result = positron_eval_python(
@@ -871,7 +953,9 @@ def read_file(page: Page, path: str, timeout: int = 30_000, *, lang: str = "r") 
     """
     ide = _detect_ide(page)
     if ide == "positron":
-        if lang.lower() == "r":
+        # Route to whichever interpreter the console actually started, not the
+        # caller's assumed language (Positron auto-starts R or Python).
+        if _positron_console_language(page, timeout) == "r":
             return positron_eval_r(page, _read_file_r_expr(path), timeout=timeout)
         return positron_eval_python(
             page, f'with open("{path}") as _f: print(_f.read())', timeout=timeout

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -118,6 +118,25 @@ def _wrap_python_expr(expr: str, start: str, end: str) -> str:
     return f'print("{s1}" "{s2}")\n{expr}\nprint("{e1}" "{e2}")'
 
 
+def _wrap_python_expr_inline(expr: str, start: str, end: str) -> str:
+    """Wrap *expr* as a single-line, semicolon-chained Python statement.
+
+    Positron's Python console is IPython. Typing a multi-line block line by line
+    is submitted inconsistently there -- statements get glued together into a
+    ``SyntaxError`` -- so the console path submits one line that runs on a single
+    Enter, mirroring the R path. *expr* must therefore be simple statements
+    (no compound blocks like ``with``); use an expression such as
+    ``print(open(p).read())`` rather than a ``with`` block.
+
+    The markers are emitted as concatenated string literals (see
+    ``_split_marker``) so the typed source never contains the full contiguous
+    marker, only the printed output does.
+    """
+    s1, s2 = _split_marker(start)
+    e1, e2 = _split_marker(end)
+    return f'print("{s1}" "{s2}"); {expr}; print("{e1}" "{e2}")'
+
+
 def _extract_between_markers(text: str, start: str, end: str) -> str:
     """Return the text between *start* and *end*, stripped of surrounding whitespace.
 
@@ -253,6 +272,11 @@ _POSITRON_QUICKPICK_ROW = PositronSession.INTERPRETER_QUICKPICK_ROW
 # Poll cadence for the "start a console" flow. Interpreter discovery is async
 # (~10s live on a cold session), so we poll rather than assume immediacy.
 _POSITRON_POLL_MS = 1_000
+# Grace polls to wait for an R interpreter to appear in the quickpick once any
+# row is present: discovery is async and R is sometimes listed after Python, so
+# selecting immediately can miss R and fall back to the (less reliable) Python
+# console. Bounded so a genuinely R-less deployment settles quickly.
+_POSITRON_R_GRACE_POLLS = 10
 
 
 def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
@@ -305,18 +329,32 @@ def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
     # Prefer an R interpreter. Its console readback uses a single-line,
     # semicolon-chained expression that Positron runs on one Enter, whereas the
     # Python console is IPython, whose multi-line continuation handling makes the
-    # marker-bracketed readback unreliable. Fall back to the first interpreter
-    # when no R is offered.
-    target = rows.first
-    try:
-        for i in range(rows.count()):
-            row = rows.nth(i)
-            label = (row.text_content(timeout=_POSITRON_POLL_MS) or "").strip()
+    # marker-bracketed readback unreliable. Discovery is async and R can be listed
+    # after Python, so poll a short grace period for an R row before settling on
+    # the first offered interpreter.
+    def _find_r_row():
+        quickpick = page.locator(_POSITRON_QUICKPICK_ROW)
+        for i in range(quickpick.count()):
+            row = quickpick.nth(i)
+            try:
+                label = (row.text_content(timeout=_POSITRON_POLL_MS) or "").strip()
+            except Exception:
+                continue
             if re.match(r"^R\b", label):
-                target = row
-                break
-    except Exception:
-        target = rows.first
+                return row
+        return None
+
+    target = None
+    grace = min(remaining, _POSITRON_R_GRACE_POLLS)
+    while grace > 0:
+        target = _find_r_row()
+        if target is not None:
+            break
+        page.wait_for_timeout(_POSITRON_POLL_MS)
+        grace -= 1
+        remaining -= 1
+    if target is None:
+        target = page.locator(_POSITRON_QUICKPICK_ROW).first
 
     # Select the interpreter; fall back to Enter. Both are best-effort so the
     # "never raises" contract holds even if the row/keyboard is detached.
@@ -401,10 +439,14 @@ def _positron_console_language(page: Page, timeout: int) -> str:
     rather than a language the caller assumed. Starts a console if needed, waits
     for an interactive prompt, and maps it to a language (``">>>"`` → Python,
     ``">"`` → R). Falls back to ``"r"`` if no prompt is readable in time.
+
+    ``timeout`` is the total budget for both phases (console start + prompt
+    detection), so callers that pass a remaining-time budget are not billed
+    twice.
     """
+    deadline = time.monotonic() + timeout / 1000.0
     ensure_positron_console(page, timeout=timeout)
     active_line = page.locator(_POSITRON_CONSOLE_READY).first
-    deadline = time.monotonic() + timeout / 1000.0
     while time.monotonic() < deadline:
         _activate_positron_console(page)
         try:
@@ -473,20 +515,21 @@ def positron_eval_r(page: Page, expr: str, timeout: int = 30_000) -> str:
 def positron_eval_python(page: Page, expr: str, timeout: int = 30_000) -> str:
     """Evaluate *expr* as Python in the Positron console and return the captured output.
 
-    Uses the same active-console selectors as ``positron_eval_r``.  Submits the
-    wrapped multi-line expression line-by-line (Enter between lines) as the
-    console requires each line to be individually submitted.
+    Uses the same active-console selectors as ``positron_eval_r``. Submits a
+    single semicolon-chained line (Positron's Python console is IPython, whose
+    line-by-line multi-line input is glued together unreliably), so *expr* must
+    be simple statements, not a compound block.
 
     Args:
         page: Playwright page for an active Positron session.
-        expr: Python expression or statement.
+        expr: Python expression or simple statement(s).
         timeout: Max milliseconds to wait for output.
 
     Returns:
         Raw text between the VIP markers, stripped of whitespace.
     """
     start, end = _make_sentinels()
-    wrapped = _wrap_python_expr(expr, start, end)
+    wrapped = _wrap_python_expr_inline(expr, start, end)
 
     if not ensure_positron_console(page, timeout=timeout):
         raise ExecError(
@@ -502,10 +545,8 @@ def positron_eval_python(page: Page, expr: str, timeout: int = 30_000) -> str:
 
     ci = active.locator(_POSITRON_CONSOLE_INPUT).first
     ci.click()
-    # Submit each line separately; Enter submits a complete statement in the Python REPL.
-    for line in wrapped.splitlines():
-        page.keyboard.insert_text(line)
-        page.keyboard.press("Enter")
+    page.keyboard.insert_text(wrapped)
+    page.keyboard.press("Enter")
 
     # Poll the joined span text until the end marker appears.
     deadline = time.monotonic() + timeout / 1000.0
@@ -846,13 +887,20 @@ def terminal_run(
         # A cold Positron session discovers interpreters and starts its console
         # asynchronously, so read_file can raise (no console yet / output not
         # captured) on early polls; treat those as "not ready" and keep polling
-        # until the deadline rather than failing the whole command. Each attempt
-        # gets the remaining budget so the first cold-start console has time to
-        # come up, instead of a fixed few seconds that guarantees failure.
+        # until the deadline. Each attempt gets the remaining budget so the first
+        # cold-start console has time to come up, instead of a fixed few seconds
+        # that guarantees failure. RStudio's console is ready immediately, so its
+        # ExecError is a real failure and stays fatal (as in the VS Code branch);
+        # only the Positron cold-start ExecError is retried.
         while time.monotonic() < deadline:
             remaining_ms = max(1, int((deadline - time.monotonic()) * 1000))
             try:
                 content = read_file(page, tmpfile, timeout=remaining_ms, lang=readback_lang)
+            except ExecError:
+                if ide == "positron":
+                    time.sleep(poll_interval)
+                    continue
+                raise
             except Exception:
                 time.sleep(poll_interval)
                 continue
@@ -957,9 +1005,8 @@ def read_file(page: Page, path: str, timeout: int = 30_000, *, lang: str = "r") 
         # caller's assumed language (Positron auto-starts R or Python).
         if _positron_console_language(page, timeout) == "r":
             return positron_eval_r(page, _read_file_r_expr(path), timeout=timeout)
-        return positron_eval_python(
-            page, f'with open("{path}") as _f: print(_f.read())', timeout=timeout
-        )
+        # Simple expression (no compound block) so it runs on one line in IPython.
+        return positron_eval_python(page, f'print(open("{path}").read())', timeout=timeout)
     if ide == "vscode":
         return read_file_via_vscode_editor(page, path, timeout=timeout)
     # RStudio (and unknown — fall back to RStudio R path)


### PR DESCRIPTION
## Summary

`test_clone_positron` (and any Positron console read-back) fails against fresh Workbench deployments with:

```
No Positron console could be started (no R/Python interpreter resolved); cannot evaluate the expression.
```

This was surfaced by the rstudio-pro daily VIP verification once 0.54.7 (#497) began actually running the Positron git-ops scenarios. It is **not** a Workbench/Positron product bug and **not** a missing-interpreter/environment problem — interpreters resolve fine (`test_launch_positron` passes). The failures are cold-start races in VIP's own Positron console read-back path. This PR fixes them.

## Root cause (verified by live reproduction)

Reproduced end-to-end against a native Workbench image, driving the real Positron console:

1. **Console-start budget too short, and fatal on the first poll.** `terminal_run`'s RStudio/Positron read-back called `read_file(..., timeout=5_000)` and re-raised the first `ExecError` as fatal. A cold Positron session discovers interpreters and starts its console asynchronously — well over 5s while extensions activate — so the first poll always failed and aborted the command. (This is the exact error in the title.)
2. **Typing before the interpreter is input-ready.** `positron_eval_r`/`_python` waited only for the active line to be *visible* plus a fixed 3s settle, then typed. The REPL is often still "starting" then, so keystrokes were dropped or left it at a `+` continuation prompt and the end marker never printed.
3. **`keyboard.type()` dropped characters** in the long wrapped expression, producing unbalanced input.
4. **Interpreter/language mismatch.** `ensure_positron_console` selected the first offered interpreter (often the Python **IPython** console, whose multi-line input handling breaks marker-bracketed read-back), while the read-back assumed R.

## Changes

- `terminal_run`: give each Positron/RStudio read-back poll the remaining deadline budget instead of a fixed 5s, and retry read-back errors until the deadline; only a genuine non-zero command exit stays fatal.
- `positron_eval_r`/`_python`: wait for the interactive prompt (`>` / `>>>`) on the active line before typing (mirrors Positron's own e2e `Console.waitForReady`), and use `keyboard.insert_text` (atomic) instead of `keyboard.type`.
- `ensure_positron_console`: prefer an R interpreter (single-line, semicolon-chained read-back that runs on one Enter), falling back to the first when no R is offered.
- `file_exists`/`read_file`: for Positron, route to the language of the console that actually started (detected from its prompt) rather than the caller's assumed `lang`.
- Updated the Positron routing self-tests to reflect detection-based routing.

## Testing

- `selftests/test_workbench_exec.py`: 73 passed.
- Live Workbench (native image), `-n 0`: `test_clone_positron` passes (3× stable, ~31s), and `test_clone_rstudio`, `test_clone_vscode`, `test_launch_positron` all pass.
- `ruff check` and `ruff format --check` clean.
