### PR TITLE
fix(workbench): skip chronicle test with correct reason when disabled

### DIFF
--- a/selftests/test_workbench_chronicle.py
+++ b/selftests/test_workbench_chronicle.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+from _pytest.outcomes import Skipped
+
 from vip.gherkin import parse_feature_file
 from vip_tests.workbench.chronicle_probe import (
     TOKEN_NO_DATA,
     TOKEN_OK,
     raw_chunk_probe_expr,
 )
+from vip_tests.workbench.test_chronicle import chronicle_enabled_guard
 
 BASE = "/var/lib/rstudio-server/shared-storage/chronicle"
 _R_FILE = Path("src/vip_tests/workbench/chronicle_probe.R")
@@ -82,15 +86,25 @@ class TestRawChunkProbeExpr:
 class TestGuardPrecedesLogin:
     def test_chronicle_enabled_guard_runs_before_login(self):
         # The Chronicle-enabled guard is a cheap config check; login is an
-        # expensive browser step that emits its own auth skip message on
-        # failure. If login ran first, a deployment with Chronicle disabled
-        # would skip with the misleading auth message instead of "Chronicle
-        # verification is disabled" (issue #462). Ordering the guard first
-        # guarantees the correct skip reason.
+        # expensive browser step that emits its own auth skip message when it
+        # can't establish a session. With login ordered first, a deployment
+        # that both disables Chronicle and fails login (e.g. --interactive-auth
+        # with no valid IdP session, as in issue #462) skips with that auth
+        # message and never reaches the guard — hiding the real reason.
+        # Ordering the guard first makes Chronicle-disabled skip with the
+        # correct reason regardless of login, and avoids a pointless login.
         steps = parse_feature_file(_FEATURE_FILE)["scenarios"][0]["steps"]
         guard = next(i for i, s in enumerate(steps) if "Chronicle verification is enabled" in s)
         login = next(i for i, s in enumerate(steps) if "logged in to Workbench" in s)
         assert guard < login
+
+    def test_disabled_chronicle_skips_with_config_reason(self):
+        # The point of running the guard first (issue #462) is the skip reason
+        # it emits; assert the message text so a future edit can't preserve the
+        # ordering while regressing what the user actually sees.
+        with pytest.raises(Skipped) as exc:
+            chronicle_enabled_guard(False)
+        assert "Chronicle verification is disabled" in str(exc.value)
 
 
 class TestTokensInSyncWithRFile:

--- a/selftests/test_workbench_chronicle.py
+++ b/selftests/test_workbench_chronicle.py
@@ -23,7 +23,11 @@ from vip_tests.workbench.test_chronicle import chronicle_enabled_guard
 
 BASE = "/var/lib/rstudio-server/shared-storage/chronicle"
 _R_FILE = Path("src/vip_tests/workbench/chronicle_probe.R")
-_FEATURE_FILE = Path("src/vip_tests/workbench/test_chronicle.feature")
+# Resolve relative to this file, not the cwd, so the test passes wherever
+# pytest is invoked from.
+_FEATURE_FILE = (
+    Path(__file__).parent.parent / "src" / "vip_tests" / "workbench" / "test_chronicle.feature"
+)
 
 
 class TestRawChunkProbeExpr:
@@ -93,10 +97,16 @@ class TestGuardPrecedesLogin:
         # message and never reaches the guard — hiding the real reason.
         # Ordering the guard first makes Chronicle-disabled skip with the
         # correct reason regardless of login, and avoids a pointless login.
-        steps = parse_feature_file(_FEATURE_FILE)["scenarios"][0]["steps"]
-        guard = next(i for i, s in enumerate(steps) if "Chronicle verification is enabled" in s)
-        login = next(i for i, s in enumerate(steps) if "logged in to Workbench" in s)
-        assert guard < login
+        parsed = parse_feature_file(_FEATURE_FILE)
+        assert parsed["scenarios"], "expected scenarios in test_chronicle.feature"
+        for scenario in parsed["scenarios"]:
+            steps = scenario["steps"]
+            guard = next(i for i, s in enumerate(steps) if "Chronicle verification is enabled" in s)
+            login = next(i for i, s in enumerate(steps) if "logged in to Workbench" in s)
+            assert guard < login, (
+                f"scenario {scenario['title']!r}: 'Chronicle verification is enabled' "
+                "must precede login so a disabled deployment skips with the correct reason"
+            )
 
     def test_disabled_chronicle_skips_with_config_reason(self):
         # The point of running the guard first (issue #462) is the skip reason

--- a/selftests/test_workbench_chronicle.py
+++ b/selftests/test_workbench_chronicle.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from vip.gherkin import parse_feature_file
 from vip_tests.workbench.chronicle_probe import (
     TOKEN_NO_DATA,
     TOKEN_OK,
@@ -18,6 +19,7 @@ from vip_tests.workbench.chronicle_probe import (
 
 BASE = "/var/lib/rstudio-server/shared-storage/chronicle"
 _R_FILE = Path("src/vip_tests/workbench/chronicle_probe.R")
+_FEATURE_FILE = Path("src/vip_tests/workbench/test_chronicle.feature")
 
 
 class TestRawChunkProbeExpr:
@@ -75,6 +77,20 @@ class TestRawChunkProbeExpr:
     def test_custom_base_path(self):
         expr = raw_chunk_probe_expr("/mnt/chronicle", "pwb_users")
         assert 'cat(vip_chronicle_probe("/mnt/chronicle", "pwb_users"))' in expr
+
+
+class TestGuardPrecedesLogin:
+    def test_chronicle_enabled_guard_runs_before_login(self):
+        # The Chronicle-enabled guard is a cheap config check; login is an
+        # expensive browser step that emits its own auth skip message on
+        # failure. If login ran first, a deployment with Chronicle disabled
+        # would skip with the misleading auth message instead of "Chronicle
+        # verification is disabled" (issue #462). Ordering the guard first
+        # guarantees the correct skip reason.
+        steps = parse_feature_file(_FEATURE_FILE)["scenarios"][0]["steps"]
+        guard = next(i for i, s in enumerate(steps) if "Chronicle verification is enabled" in s)
+        login = next(i for i, s in enumerate(steps) if "logged in to Workbench" in s)
+        assert guard < login
 
 
 class TestTokensInSyncWithRFile:

--- a/src/vip_tests/workbench/test_chronicle.feature
+++ b/src/vip_tests/workbench/test_chronicle.feature
@@ -16,8 +16,8 @@ Feature: Workbench Chronicle observability
   and workbench-api-admin-enabled=1 in rserver.conf (see vip.toml.example).
 
   Scenario: Chronicle has collected telemetry readable in-session
-    Given the user is logged in to Workbench
-    And Chronicle verification is enabled in vip.toml
+    Given Chronicle verification is enabled in vip.toml
+    And the user is logged in to Workbench
     When the user starts a new RStudio session
     And the session transitions to Active state
     And the RStudio IDE is displayed and functional


### PR DESCRIPTION
## Summary

Fixes #462. When Chronicle isn't enabled, `test_chronicle.py::test_chronicle_collects_data` skipped with the login step's auth "next steps" message instead of telling the user Chronicle verification is disabled.

## Root cause

`test_chronicle.feature` ran `Given the user is logged in to Workbench` before `And Chronicle verification is enabled in vip.toml`. pytest-bdd executes steps in file order, so the browser login ran first. Since `chronicle_enabled` defaults to `False` and `vip verify --workbench-url ...` never sets `[chronicle] enabled`, a quick run always hit login first — and on any login skip/failure the auth message fired, masking the real reason.

## Fix

Swap the two `Given` steps so the cheap config guard runs first:

```gherkin
Given Chronicle verification is enabled in vip.toml
And the user is logged in to Workbench
```

This gives clean separation of skip reasons:

- Chronicle disabled → "set enabled = true under `[chronicle]`" (the message the reporter expected)
- Chronicle enabled but login fails → the auth message, which is correct in that case

The two steps are independent (the guard reads only the `chronicle_enabled` config fixture; login needs the page), and this matches the guard-first pattern already used in `test_git_ops.feature` and `test_session_idle.feature`. The Connect Chronicle test doesn't have this bug — its first step is a lightweight accessibility check, not a browser login — so it's untouched.

## Testing

- Added `TestGuardPrecedesLogin` in `selftests/test_workbench_chronicle.py` asserting the guard precedes login, so the ordering can't silently regress (confirmed Red before the fix, Green after).
- `uv run pytest selftests/test_workbench_chronicle.py selftests/test_gherkin.py` — 18 passed.
- `uv run ruff check` / `ruff format --check` across all CI dirs — clean.
- Collect-only on the product test confirms the reordered steps still bind.