### PR TITLE
feat: pin dependencies to a tighter range on each release (#399)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -20,6 +22,24 @@ jobs:
 
       - name: Build wheel and sdist
         run: uv build
+
+      # Export the exact locked runtime dependency set so users can reproduce a
+      # release's tested environment: `uv tool install posit-vip -c <file>`.
+      - name: Export locked constraints
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          uv export --no-emit-project --no-hashes --format requirements.txt \
+            -o "constraints-${version}.txt"
+
+      # The GitHub release is created by semantic-release (release.yml) together
+      # with the tag that triggers this workflow, so it already exists here.
+      # --clobber keeps re-runs idempotent.
+      - name: Attach constraints file to the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          gh release upload "${GITHUB_REF_NAME}" "constraints-${version}.txt" --clobber
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,6 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -23,28 +21,53 @@ jobs:
       - name: Build wheel and sdist
         run: uv build
 
-      # Export the exact locked runtime dependency set so users can reproduce a
-      # release's tested environment: `uv tool install posit-vip -c <file>`.
-      - name: Export locked constraints
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          uv export --no-emit-project --no-hashes --format requirements.txt \
-            -o "constraints-${version}.txt"
-
-      # The GitHub release is created by semantic-release (release.yml) together
-      # with the tag that triggers this workflow, so it already exists here.
-      # --clobber keeps re-runs idempotent.
-      - name: Attach constraints file to the GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          gh release upload "${GITHUB_REF_NAME}" "constraints-${version}.txt" --clobber
-
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
+
+  constraints:
+    name: Attach locked constraints to release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Resolve release version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      # --frozen guarantees the exported set is exactly the committed uv.lock,
+      # never a silent re-resolve.
+      - name: Export locked constraints
+        run: |
+          uv export --frozen --no-emit-project --no-hashes --format requirements.txt \
+            -o "constraints-${VERSION}.txt"
+
+      # Runs independently of the PyPI publish so a transient release-API delay
+      # (semantic-release pushes the tag just before creating the release) can
+      # never block publishing. Retry tolerates that race; --clobber is idempotent.
+      - name: Attach constraints file to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          file="constraints-${VERSION}.txt"
+          for attempt in 1 2 3 4 5; do
+            if gh release upload "${GITHUB_REF_NAME}" "$file" --clobber; then
+              echo "Attached $file to ${GITHUB_REF_NAME}"
+              exit 0
+            fi
+            echo "Release ${GITHUB_REF_NAME} not ready (attempt $attempt/5); waiting 15s..."
+            sleep 15
+          done
+          echo "::error::Failed to attach $file to ${GITHUB_REF_NAME} after 5 attempts"
+          exit 1
 
   publish:
     name: Publish to PyPI

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ constraints file (attached to every GitHub release as `constraints-<version>.txt
 
 ```bash
 uv tool install posit-vip \
-  -c https://github.com/posit-dev/vip/releases/download/v0.55.1/constraints-0.55.1.txt
+  -c https://github.com/posit-dev/vip/releases/download/vX.Y.Z/constraints-X.Y.Z.txt
 ```
+
+Replace `X.Y.Z` with the release you are installing (see the
+[releases page](https://github.com/posit-dev/vip/releases)).
 
 For a fully pinned, batteries-included environment, use the container image,
 which installs from the committed `uv.lock`:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ vip install
 vip verify --connect-url https://connect.example.com --interactive-auth
 ```
 
+### Reproducible install
+
+`uv tool install posit-vip` resolves the newest versions each release allows. To
+install the exact set a release was tested against, pass that release's
+constraints file (attached to every GitHub release as `constraints-<version>.txt`):
+
+```bash
+uv tool install posit-vip \
+  -c https://github.com/posit-dev/vip/releases/download/v0.55.1/constraints-0.55.1.txt
+```
+
+For a fully pinned, batteries-included environment, use the container image,
+which installs from the committed `uv.lock`:
+
+```bash
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip:latest
+```
+
 On a headless server (no display), use `--headless-auth` instead:
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,6 +81,27 @@ git add uv.lock
 Because the uv version is pinned, the regenerated lockfile is identical to what
 CI and other contributors produce, so the conflict resolves cleanly.
 
+## Dependency pinning policy
+
+The wheel published to PyPI carries the version constraints declared in
+`pyproject.toml`'s `[project.dependencies]`, so `uv tool install posit-vip` and
+`pip install posit-vip` resolve against them. To keep a fresh install
+predictable (see [#399](https://github.com/posit-dev/vip/issues/399)):
+
+- **Exact `==` pins** for the dependencies that shape a `vip` run's output —
+  `pytest`, `pytest-bdd`, `pytest-order`, `pytest-playwright`, `pytest-xdist`,
+  and `playwright`. Each pin must equal the version resolved in `uv.lock`;
+  `selftests/test_dependency_pins.py` fails if they drift apart.
+- **Next-major caps** (e.g. `requests>=2.33.0,<3`) on every other runtime
+  dependency, so a breaking major release cannot land on install. The `report`
+  and `load` optional groups are capped the same way; the `dev` group is left
+  loose.
+
+Bumps flow through Dependabot's `uv` job (weekly, 7-day cooldown): it raises the
+pin or cap in `pyproject.toml` and updates `uv.lock` in one PR, which CI gates
+before merge. The next release then ships the tested set. To bump a pin by hand,
+edit the constraint and run `just relock` in the same commit.
+
 ## Design principles
 
 - **Non-destructive** — tests create, verify, and clean up their own content.

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,7 +95,7 @@ predictable (see [#399](https://github.com/posit-dev/vip/issues/399)):
 - **Next-major caps** (e.g. `requests>=2.33.0,<3`) on every other runtime
   dependency, so a breaking major release cannot land on install. The `report`
   and `load` optional groups are capped the same way; the `dev` group is left
-  loose.
+  uncapped by this policy (aside from `ruff`'s pre-existing narrow range).
 
 Bumps flow through Dependabot's `uv` job (weekly, 7-day cooldown): it raises the
 pin or cap in `pyproject.toml` and updates `uv.lock` in one PR, which CI gates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pytest-playwright==0.8.0",  # exact-pinned
     "pytest-xdist==3.8.0",  # exact-pinned
     "tomli>=2.0,<3;python_version<'3.11'",
-    "requests>=2.33.0,<3",  # transitive via pytest-playwright; pinned to track updates
+    "requests>=2.33.0,<3",  # transitive via pytest-playwright; capped to track updates
     "pygments>=2.20.0,<3",  # CVE-2026-4539 fix
     "pip>=26.1.2,<27",  # CVE-2026-3219, PYSEC-2026-196 fix; transitive via pip-api
     "mako>=1.3.12,<2",  # CVE-2026-44307 fix; transitive via pytest-bdd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,39 +20,39 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.27,<1",
-    "playwright>=1.40",
+    "playwright==1.61.0",  # exact-pinned: shapes vip run output; see docs/development.md
     "pyotp~=2.9",
-    "pytest>=9.0.3",  # CVE-2025-71176 fix
-    "pytest-bdd>=7.0",
-    "pytest-order>=1.3",
-    "pytest-playwright>=0.5",
-    "pytest-xdist>=3.0",
-    "tomli>=2.0;python_version<'3.11'",
-    "requests>=2.33.0",  # transitive via pytest-playwright; pinned to track updates
-    "pygments>=2.20.0",  # CVE-2026-4539 fix
-    "pip>=26.1.2",  # CVE-2026-3219, PYSEC-2026-196 fix; transitive via pip-api
-    "mako>=1.3.12",  # CVE-2026-44307 fix; transitive via pytest-bdd
-    "idna>=3.15",  # CVE-2026-45409 fix; transitive via httpx/requests/anyio
+    "pytest==9.1.1",  # exact-pinned; at/above CVE-2025-71176 floor (9.0.3)
+    "pytest-bdd==8.1.0",  # exact-pinned
+    "pytest-order==1.5.0",  # exact-pinned
+    "pytest-playwright==0.8.0",  # exact-pinned
+    "pytest-xdist==3.8.0",  # exact-pinned
+    "tomli>=2.0,<3;python_version<'3.11'",
+    "requests>=2.33.0,<3",  # transitive via pytest-playwright; pinned to track updates
+    "pygments>=2.20.0,<3",  # CVE-2026-4539 fix
+    "pip>=26.1.2,<27",  # CVE-2026-3219, PYSEC-2026-196 fix; transitive via pip-api
+    "mako>=1.3.12,<2",  # CVE-2026-44307 fix; transitive via pytest-bdd
+    "idna>=3.15,<4",  # CVE-2026-45409 fix; transitive via httpx/requests/anyio
 ]
 
 [project.optional-dependencies]
 report = [
-    "jinja2>=3.1",
-    "jupyter",
-    "ipykernel",
-    "nbformat>=5.7",
-    "nbclient>=0.8",
-    "nbconvert>=7.17.1",  # CVE-2026-39377, CVE-2026-39378 fix; transitive via jupyter
-    "mistune>=3.2.1",  # CVE-2026-33079 fix; transitive via nbconvert
-    "tornado>=6.5.7",  # CVE-2026-31958, GHSA-pw6j-qg29-8w7f fix; transitive via jupyter
-    "bleach>=6.4.0",  # GHSA-gj48-438w-jh9v, GHSA-8rfp-98v4-mmr6 fix; transitive via nbconvert[css]
-    "jupyterlab>=4.5.9",  # GHSA-vmhf-c436-hxj4 fix; transitive via jupyter
+    "jinja2>=3.1,<4",
+    "jupyter<2",
+    "ipykernel<8",
+    "nbformat>=5.7,<6",
+    "nbclient>=0.8,<1",
+    "nbconvert>=7.17.1,<8",  # CVE-2026-39377, CVE-2026-39378 fix; transitive via jupyter
+    "mistune>=3.2.1,<4",  # CVE-2026-33079 fix; transitive via nbconvert
+    "tornado>=6.5.7,<7",  # CVE-2026-31958, GHSA-pw6j-qg29-8w7f fix; transitive via jupyter
+    "bleach>=6.4.0,<7",  # GHSA-gj48-438w-jh9v, GHSA-8rfp-98v4-mmr6 fix; transitive via nbconvert[css]
+    "jupyterlab>=4.5.9,<5",  # GHSA-vmhf-c436-hxj4 fix; transitive via jupyter
 ]
 load = [
-    "locust>=2.20",
-    "msgpack>=1.2.1",  # GHSA-6v7p-g79w-8964 fix; transitive via locust
-    "python-engineio>=4.13.2",  # CVE-2026-48802, CVE-2026-48809 fix; transitive via locust
-    "python-socketio>=5.16.2",  # CVE-2026-48804 fix; transitive via locust
+    "locust>=2.20,<3",
+    "msgpack>=1.2.1,<2",  # GHSA-6v7p-g79w-8964 fix; transitive via locust
+    "python-engineio>=4.13.2,<5",  # CVE-2026-48802, CVE-2026-48809 fix; transitive via locust
+    "python-socketio>=5.16.2,<6",  # CVE-2026-48804 fix; transitive via locust
 ]
 dev = [
     "ruff>=0.15.0,<0.16",

--- a/selftests/install/test_platform.py
+++ b/selftests/install/test_platform.py
@@ -13,8 +13,8 @@ def _pinned_playwright_version() -> str:
     """The playwright version declared in pyproject.toml's [project.dependencies].
 
     Handles any specifier form (``==1.61.0``, ``>=1.40``, ``>=1.40,<2``) by
-    preferring an exact ``==`` pin and otherwise falling back to the first
-    specifier's version.
+    preferring an exact ``==`` pin and otherwise falling back to the floor
+    (``>=``/``>``/``~=``) version.
     """
     try:
         import tomllib
@@ -27,7 +27,11 @@ def _pinned_playwright_version() -> str:
     pw_dep = next(d for d in pyproject["project"]["dependencies"] if d.startswith("playwright"))
     specifier = Requirement(pw_dep).specifier
     exact = next((s.version for s in specifier if s.operator == "=="), None)
-    return exact or next(s.version for s in specifier)
+    if exact is not None:
+        return exact
+    # No exact pin: return the floor version. SpecifierSet iterates an unordered
+    # set, so pick the lower-bound operator explicitly instead of "the first".
+    return next(s.version for s in specifier if s.operator in (">=", ">", "~="))
 
 
 @pytest.fixture()

--- a/selftests/install/test_platform.py
+++ b/selftests/install/test_platform.py
@@ -9,6 +9,27 @@ import pytest
 from vip.install import platform as plat
 
 
+def _pinned_playwright_version() -> str:
+    """The playwright version declared in pyproject.toml's [project.dependencies].
+
+    Handles any specifier form (``==1.61.0``, ``>=1.40``, ``>=1.40,<2``) by
+    preferring an exact ``==`` pin and otherwise falling back to the first
+    specifier's version.
+    """
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # Python 3.10
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    from packaging.requirements import Requirement
+
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    pw_dep = next(d for d in pyproject["project"]["dependencies"] if d.startswith("playwright"))
+    specifier = Requirement(pw_dep).specifier
+    exact = next((s.version for s in specifier if s.operator == "=="), None)
+    return exact or next(s.version for s in specifier)
+
+
 @pytest.fixture()
 def fake_os_release(tmp_path: Path, monkeypatch):
     def _write(content: str) -> Path:
@@ -199,17 +220,7 @@ def test_suse_packages_is_tuple_of_strings():
 
 def test_list_reviewed_against_playwright_suse_matches_pinned_version():
     """Reminds maintainer to review SUSE_PACKAGES when playwright is bumped."""
-    import sys
-
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        import tomli as tomllib  # type: ignore[no-redef]
-
-    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
-    deps = pyproject["project"]["dependencies"]
-    pw_dep = next(d for d in deps if d.startswith("playwright"))
-    pinned = pw_dep.split(">=", 1)[1].split(",", 1)[0].strip()
+    pinned = _pinned_playwright_version()
     reviewed = plat.LIST_REVIEWED_AGAINST_PLAYWRIGHT_SUSE
     nativedeps_url = (
         "https://github.com/microsoft/playwright/blob/main"
@@ -225,18 +236,7 @@ def test_list_reviewed_against_playwright_suse_matches_pinned_version():
 
 def test_list_reviewed_against_playwright_matches_pinned_version():
     """Reminds maintainer to review DEBIAN_PACKAGES when playwright is bumped."""
-    import sys
-
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        import tomli as tomllib  # type: ignore[no-redef]
-
-    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
-    deps = pyproject["project"]["dependencies"]
-    pw_dep = next(d for d in deps if d.startswith("playwright"))
-    # Extract version specifier (e.g. "playwright>=1.50,<2.0" → "1.50,<2.0" → "1.50").
-    pinned = pw_dep.split(">=", 1)[1].split(",", 1)[0].strip()
+    pinned = _pinned_playwright_version()
     reviewed = plat.LIST_REVIEWED_AGAINST_PLAYWRIGHT
     nativedeps_url = (
         "https://github.com/microsoft/playwright/blob/main"

--- a/selftests/test_dependency_pins.py
+++ b/selftests/test_dependency_pins.py
@@ -1,0 +1,100 @@
+"""Guards VIP's published dependency-pinning policy (issue #399).
+
+The wheel published to PyPI carries whatever version constraints live in
+``pyproject.toml``'s ``[project.dependencies]``. To keep ``uv tool install
+posit-vip`` / ``pip install posit-vip`` producing predictable output, the
+dependencies that shape a ``vip`` run (pytest and its plugins, playwright) are
+pinned to an exact version, and every other runtime dependency is capped below
+its next major.
+
+Two invariants are enforced so the policy cannot silently erode:
+
+1. Each package in ``EXACT_PINS`` is pinned with ``==`` and that pin matches the
+   version resolved in ``uv.lock`` (so the published pin is always the tested
+   one).
+2. Each package in ``CAPPED`` carries an upper bound so a breaking major release
+   cannot slip in on a fresh install.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+from packaging.requirements import Requirement
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+LOCKFILE = REPO_ROOT / "uv.lock"
+
+# Dependencies whose exact version determines a `vip` run's behaviour/output.
+EXACT_PINS = {
+    "playwright",
+    "pytest",
+    "pytest-bdd",
+    "pytest-order",
+    "pytest-playwright",
+    "pytest-xdist",
+}
+
+# Runtime dependencies that must carry an upper bound (cap at next major). An
+# upper bound is any of `<`, `<=`, `~=`, or `==`.
+CAPPED = {
+    "httpx",
+    "requests",
+    "pygments",
+    "mako",
+    "idna",
+    "pip",
+    "tomli",
+    "pyotp",
+}
+
+_BOUNDING_OPERATORS = {"<", "<=", "~=", "=="}
+
+
+def canonical(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def _runtime_requirements() -> dict[str, Requirement]:
+    data = tomllib.loads(PYPROJECT.read_text())
+    return {
+        canonical(Requirement(spec).name): Requirement(spec)
+        for spec in data["project"]["dependencies"]
+    }
+
+
+def _locked_versions() -> dict[str, str]:
+    data = tomllib.loads(LOCKFILE.read_text())
+    return {canonical(pkg["name"]): pkg["version"] for pkg in data["package"]}
+
+
+def test_output_drivers_are_exact_pinned_to_locked_version():
+    reqs = _runtime_requirements()
+    locked = _locked_versions()
+    for name in sorted(EXACT_PINS):
+        assert name in reqs, f"{name} missing from [project.dependencies]"
+        specs = list(reqs[name].specifier)
+        assert len(specs) == 1 and specs[0].operator == "==", (
+            f"{name} must be exact-pinned with '==' (found '{reqs[name].specifier}')"
+        )
+        pinned = specs[0].version
+        assert locked.get(name) == pinned, (
+            f"{name}=={pinned} disagrees with uv.lock ({locked.get(name)}); "
+            "re-pin to the locked version or run `just relock`"
+        )
+
+
+def test_other_runtime_deps_are_capped():
+    reqs = _runtime_requirements()
+    for name in sorted(CAPPED):
+        assert name in reqs, f"{name} missing from [project.dependencies]"
+        operators = {s.operator for s in reqs[name].specifier}
+        assert operators & _BOUNDING_OPERATORS, (
+            f"{name} must carry an upper bound (found '{reqs[name].specifier}')"
+        )

--- a/selftests/test_dependency_pins.py
+++ b/selftests/test_dependency_pins.py
@@ -98,3 +98,40 @@ def test_other_runtime_deps_are_capped():
         assert operators & _BOUNDING_OPERATORS, (
             f"{name} must carry an upper bound (found '{reqs[name].specifier}')"
         )
+
+
+# Optional-dependency groups that must also be capped at next major.
+CAPPED_OPTIONAL = {
+    "report": {
+        "jinja2",
+        "jupyter",
+        "ipykernel",
+        "nbformat",
+        "nbclient",
+        "nbconvert",
+        "mistune",
+        "tornado",
+        "bleach",
+        "jupyterlab",
+    },
+    "load": {"locust", "msgpack", "python-engineio", "python-socketio"},
+}
+
+
+def _optional_requirements(group: str) -> dict[str, Requirement]:
+    data = tomllib.loads(PYPROJECT.read_text())
+    return {
+        canonical(Requirement(spec).name): Requirement(spec)
+        for spec in data["project"]["optional-dependencies"][group]
+    }
+
+
+def test_report_and_load_groups_are_capped():
+    for group, names in CAPPED_OPTIONAL.items():
+        reqs = _optional_requirements(group)
+        for name in sorted(names):
+            assert name in reqs, f"{name} missing from [{group}] optional-dependencies"
+            operators = {s.operator for s in reqs[name].specifier}
+            assert operators & _BOUNDING_OPERATORS, (
+                f"{name} in [{group}] must carry an upper bound (found '{reqs[name].specifier}')"
+            )

--- a/selftests/test_dependency_pins.py
+++ b/selftests/test_dependency_pins.py
@@ -7,13 +7,16 @@ dependencies that shape a ``vip`` run (pytest and its plugins, playwright) are
 pinned to an exact version, and every other runtime dependency is capped below
 its next major.
 
-Two invariants are enforced so the policy cannot silently erode:
+Three invariants are enforced so the policy cannot silently erode:
 
 1. Each package in ``EXACT_PINS`` is pinned with ``==`` and that pin matches the
    version resolved in ``uv.lock`` (so the published pin is always the tested
    one).
-2. Each package in ``CAPPED`` carries an upper bound so a breaking major release
-   cannot slip in on a fresh install.
+2. Each runtime dependency carries an upper bound, and every declared runtime
+   dependency is classified as either ``EXACT_PINS`` or ``CAPPED`` (a new,
+   unclassified dependency fails the suite rather than shipping uncapped).
+3. Each ``report``/``load`` optional-group dependency carries an upper bound,
+   and every declared entry in those groups is listed in ``CAPPED_OPTIONAL``.
 """
 
 from __future__ import annotations
@@ -100,6 +103,16 @@ def test_other_runtime_deps_are_capped():
         )
 
 
+def test_every_runtime_dependency_is_classified():
+    """No runtime dep may escape the policy by not being listed above."""
+    declared = set(_runtime_requirements())
+    assert declared == EXACT_PINS | CAPPED, (
+        "every [project.dependencies] entry must be listed in EXACT_PINS or "
+        f"CAPPED; unclassified: {sorted(declared - (EXACT_PINS | CAPPED))}, "
+        f"stale: {sorted((EXACT_PINS | CAPPED) - declared)}"
+    )
+
+
 # Optional-dependency groups that must also be capped at next major.
 CAPPED_OPTIONAL = {
     "report": {
@@ -129,8 +142,12 @@ def _optional_requirements(group: str) -> dict[str, Requirement]:
 def test_report_and_load_groups_are_capped():
     for group, names in CAPPED_OPTIONAL.items():
         reqs = _optional_requirements(group)
+        declared = set(reqs)
+        assert declared == names, (
+            f"every [{group}] entry must be listed in CAPPED_OPTIONAL[{group!r}]; "
+            f"unclassified: {sorted(declared - names)}, stale: {sorted(names - declared)}"
+        )
         for name in sorted(names):
-            assert name in reqs, f"{name} missing from [{group}] optional-dependencies"
             operators = {s.operator for s in reqs[name].specifier}
             assert operators & _BOUNDING_OPERATORS, (
                 f"{name} in [{group}] must carry an upper bound (found '{reqs[name].specifier}')"

--- a/src/vip/install/platform.py
+++ b/src/vip/install/platform.py
@@ -144,7 +144,7 @@ def debian_packages(platform_info: PlatformInfo) -> tuple[str, ...]:
 # When updating the playwright pin in pyproject.toml, review DEBIAN_PACKAGES against
 # https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/nativeDeps.ts
 # and update this value. The selftest enforces that they match.
-LIST_REVIEWED_AGAINST_PLAYWRIGHT = "1.40"
+LIST_REVIEWED_AGAINST_PLAYWRIGHT = "1.61.0"
 
 
 # openSUSE/SLES equivalents. Names from `zypper search --provides` against
@@ -177,4 +177,4 @@ SUSE_PACKAGES: tuple[str, ...] = (
 )
 
 # Mirror of LIST_REVIEWED_AGAINST_PLAYWRIGHT for the SUSE list.
-LIST_REVIEWED_AGAINST_PLAYWRIGHT_SUSE = "1.40"
+LIST_REVIEWED_AGAINST_PLAYWRIGHT_SUSE = "1.61.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2183,7 +2183,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.55.1"
+version = "0.55.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -2183,7 +2183,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.54.7"
+version = "0.55.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -2231,39 +2231,39 @@ report = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bleach", marker = "extra == 'report'", specifier = ">=6.4.0" },
+    { name = "bleach", marker = "extra == 'report'", specifier = ">=6.4.0,<7" },
     { name = "httpx", specifier = ">=0.27,<1" },
-    { name = "idna", specifier = ">=3.15" },
-    { name = "ipykernel", marker = "extra == 'report'" },
-    { name = "jinja2", marker = "extra == 'report'", specifier = ">=3.1" },
-    { name = "jupyter", marker = "extra == 'report'" },
-    { name = "jupyterlab", marker = "extra == 'report'", specifier = ">=4.5.9" },
-    { name = "locust", marker = "extra == 'load'", specifier = ">=2.20" },
-    { name = "mako", specifier = ">=1.3.12" },
-    { name = "mistune", marker = "extra == 'report'", specifier = ">=3.2.1" },
+    { name = "idna", specifier = ">=3.15,<4" },
+    { name = "ipykernel", marker = "extra == 'report'", specifier = "<8" },
+    { name = "jinja2", marker = "extra == 'report'", specifier = ">=3.1,<4" },
+    { name = "jupyter", marker = "extra == 'report'", specifier = "<2" },
+    { name = "jupyterlab", marker = "extra == 'report'", specifier = ">=4.5.9,<5" },
+    { name = "locust", marker = "extra == 'load'", specifier = ">=2.20,<3" },
+    { name = "mako", specifier = ">=1.3.12,<2" },
+    { name = "mistune", marker = "extra == 'report'", specifier = ">=3.2.1,<4" },
     { name = "msgpack", marker = "extra == 'dev'", specifier = ">=1.2.1" },
-    { name = "msgpack", marker = "extra == 'load'", specifier = ">=1.2.1" },
+    { name = "msgpack", marker = "extra == 'load'", specifier = ">=1.2.1,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "nbclient", marker = "extra == 'report'", specifier = ">=0.8" },
-    { name = "nbconvert", marker = "extra == 'report'", specifier = ">=7.17.1" },
-    { name = "nbformat", marker = "extra == 'report'", specifier = ">=5.7" },
-    { name = "pip", specifier = ">=26.1.2" },
+    { name = "nbclient", marker = "extra == 'report'", specifier = ">=0.8,<1" },
+    { name = "nbconvert", marker = "extra == 'report'", specifier = ">=7.17.1,<8" },
+    { name = "nbformat", marker = "extra == 'report'", specifier = ">=5.7,<6" },
+    { name = "pip", specifier = ">=26.1.2,<27" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
-    { name = "playwright", specifier = ">=1.40" },
-    { name = "pygments", specifier = ">=2.20.0" },
+    { name = "playwright", specifier = "==1.61.0" },
+    { name = "pygments", specifier = ">=2.20.0,<3" },
     { name = "pyotp", specifier = "~=2.9" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-bdd", specifier = ">=7.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-bdd", specifier = "==8.1.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "pytest-order", specifier = ">=1.3" },
-    { name = "pytest-playwright", specifier = ">=0.5" },
-    { name = "pytest-xdist", specifier = ">=3.0" },
-    { name = "python-engineio", marker = "extra == 'load'", specifier = ">=4.13.2" },
-    { name = "python-socketio", marker = "extra == 'load'", specifier = ">=5.16.2" },
-    { name = "requests", specifier = ">=2.33.0" },
+    { name = "pytest-order", specifier = "==1.5.0" },
+    { name = "pytest-playwright", specifier = "==0.8.0" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
+    { name = "python-engineio", marker = "extra == 'load'", specifier = ">=4.13.2,<5" },
+    { name = "python-socketio", marker = "extra == 'load'", specifier = ">=5.16.2,<6" },
+    { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0,<0.16" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
-    { name = "tornado", marker = "extra == 'report'", specifier = ">=6.5.7" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0,<3" },
+    { name = "tornado", marker = "extra == 'report'", specifier = ">=6.5.7,<7" },
 ]
 provides-extras = ["report", "load", "dev"]
 

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -52,7 +52,11 @@ vip install</code></pre>
             <code>constraints-&lt;version&gt;.txt</code>):
           </p>
           <pre><code>uv tool install posit-vip \
-  -c https://github.com/posit-dev/vip/releases/download/v0.55.1/constraints-0.55.1.txt</code></pre>
+  -c https://github.com/posit-dev/vip/releases/download/vX.Y.Z/constraints-X.Y.Z.txt</code></pre>
+          <p>
+            Replace <code>X.Y.Z</code> with the release you are installing (see
+            the <a href="https://github.com/posit-dev/vip/releases">releases page</a>).
+          </p>
           <p>
             Run your first VIP test against Posit Public Package Manager:
           </p>

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -45,6 +45,15 @@ vip install</code></pre>
             <code>vip uninstall</code>.
           </p>
           <p>
+            <code>uv tool install posit-vip</code> resolves the newest versions
+            each release allows. For a reproducible install pinned to a
+            release's tested dependency set, pass that release's constraints
+            file (attached to every GitHub release as
+            <code>constraints-&lt;version&gt;.txt</code>):
+          </p>
+          <pre><code>uv tool install posit-vip \
+  -c https://github.com/posit-dev/vip/releases/download/v0.55.1/constraints-0.55.1.txt</code></pre>
+          <p>
             Run your first VIP test against Posit Public Package Manager:
           </p>
           <pre><code>vip verify --package-manager-url https://p3m.dev --filter 'not test_product_does_not_expose_sensitive_headers and not test_prometheus_metrics'</code></pre>


### PR DESCRIPTION
Closes #399.

## What

VIP's published wheel declared only lower-bound (`>=`) dependency ranges, so `uv tool install posit-vip` / `pip install posit-vip` resolved whatever was newest on PyPI — including untested pytest/playwright releases that can change test output. Dev and CI were already reproducible via `uv.lock` + `uv sync --frozen`; only the published package and the end-user install path were unpinned. This tightens the published constraints and adds a fully-locked install path.

## Changes

- **Hybrid pins in `pyproject.toml`** — exact `==` pins for the dependencies that shape a `vip` run's output (`pytest`, `pytest-bdd`, `pytest-order`, `pytest-playwright`, `pytest-xdist`, `playwright`), pinned to the `uv.lock` versions; next-major caps (`,<N`) on every other runtime dependency and on the `report`/`load` optional groups. The `dev` group stays loose.
- **Drift guard** (`selftests/test_dependency_pins.py`) — fails if an exact pin diverges from `uv.lock`, or if any capped runtime/optional dependency loses its upper bound. Runs in the existing selftest CI matrix; no new job.
- **Locked-install path** — a new isolated `constraints` job in `publish.yml` exports the exact locked runtime set (`uv export --frozen`) and attaches it to each GitHub release as `constraints-<version>.txt`. README + website document `uv tool install posit-vip -c <constraints-url>` and the Docker image as the fully-locked option. The job cannot block the PyPI-publish job.
- **Policy docs** — `docs/development.md` gains a "Dependency pinning policy" section. Ongoing bumps flow through the existing Dependabot `uv` job (weekly, 7-day cooldown), gated by CI before merge.

## Testing

- `uv run pytest selftests/test_dependency_pins.py` — 3 passing; RED/GREEN verified by toggling a pin and a cap.
- `uv lock --check` clean; `just check` (ruff lint + format) clean.
