### PR TITLE
fix(workbench): match current RStudio Pro Workbench Jobs selectors

### DIFF
--- a/selftests/test_pages.py
+++ b/selftests/test_pages.py
@@ -2,7 +2,8 @@
 
 Covers ``get_homepage`` (versioned page-object factory) and
 ``get_new_session_dialog_close_strategy`` (version-keyed behavior strategy
-dict), both in ``vip_tests.workbench.pages.homepage``.
+dict), both in ``vip_tests.workbench.pages.homepage``, plus the cross-build
+coverage of the ``RStudioSession`` Workbench Jobs selectors.
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from vip_tests.workbench.pages.homepage import (
     get_homepage,
     get_new_session_dialog_close_strategy,
 )
+from vip_tests.workbench.pages.rstudio_session import RStudioSession
 
 
 class TestGetHomepage:
@@ -84,3 +86,36 @@ def test_resolution_is_consistent_between_factory_and_strategy(version):
     # confirm they resolve in lockstep for versions at/after it.
     assert get_homepage(version) is Homepage_2026_05
     assert get_new_session_dialog_close_strategy(version) is _close_dialog_via_escape
+
+
+class TestRStudioSessionWorkbenchJobsSelectors:
+    """Lock the Workbench Jobs selectors' cross-build coverage.
+
+    These constants OR-join current and legacy RStudio Pro IDs so the
+    ``test_workbench_job`` scenario survives the "workbench_jobs" (underscore)
+    vs "workbenchjobs" (no underscore) ID drift documented in the class. The
+    selectors are only exercised against a live IDE, so these string-level
+    assertions are the only automated guard against a "cleanup" silently
+    dropping a variant and reintroducing the false-negative skip.
+    """
+
+    def test_tab_matches_both_id_forms(self):
+        assert "#rstudio_workbench_tab_workbench_jobs" in RStudioSession.WORKBENCH_JOBS_TAB
+        assert "#rstudio_workbench_tab_workbenchjobs" in RStudioSession.WORKBENCH_JOBS_TAB
+
+    def test_panel_matches_both_id_forms(self):
+        assert "#rstudio_workbench_panel_workbench_jobs" in RStudioSession.WORKBENCH_JOBS_PANEL
+        assert "#rstudio_workbench_panel_workbenchjobs" in RStudioSession.WORKBENCH_JOBS_PANEL
+
+    def test_tab_avoids_substring_match_that_collides_with_panel(self):
+        # A substring match such as [id*='workbench_jobs'] would also match the
+        # panel id, resolving the tab locator to two elements and tripping
+        # Playwright strict mode. Keep the tab locator to exact IDs (plus the
+        # text fallback) so it targets exactly one element.
+        assert "[id*='workbench_jobs']" not in RStudioSession.WORKBENCH_JOBS_TAB
+        assert "[id*='workbenchjobs']" not in RStudioSession.WORKBENCH_JOBS_TAB
+
+    def test_new_button_and_submit_button_target_current_ids(self):
+        assert "#rstudio_tb_startworkbenchjob" in RStudioSession.WORKBENCH_JOB_NEW_BUTTON
+        assert "Start Workbench Job" in RStudioSession.WORKBENCH_JOB_NEW_BUTTON
+        assert "#rstudio_dlg_ok" in RStudioSession.WORKBENCH_JOB_SUBMIT_BUTTON

--- a/src/vip_tests/workbench/pages/rstudio_session.py
+++ b/src/vip_tests/workbench/pages/rstudio_session.py
@@ -37,13 +37,24 @@ class RStudioSession:
     BACKGROUND_JOB_SCRIPT_INPUT = "input[placeholder*='script'], input[id*='script']"
     BACKGROUND_JOB_RUN_BUTTON = "button:text-is('Start'), button[id*='start']"
 
-    # Workbench Jobs pane (Launcher jobs, separate from Background Jobs)
-    WORKBENCH_JOBS_PANEL = "#rstudio_workbench_panel_workbenchjobs"
-    WORKBENCH_JOBS_TAB = "[id*='workbenchjobs'], button:text-is('Workbench Jobs')"
-    WORKBENCH_JOB_NEW_BUTTON = (
-        "button[title='Run Script as Workbench Job'], button:text-is('Run Script as Workbench Job')"
+    # Workbench Jobs pane (Launcher jobs, separate from Background Jobs).
+    # Newer RStudio Pro builds use "workbench_jobs" (with underscore) IDs;
+    # older builds used "workbenchjobs" (no underscore). Accept both.
+    WORKBENCH_JOBS_PANEL = (
+        "#rstudio_workbench_panel_workbench_jobs, #rstudio_workbench_panel_workbenchjobs"
     )
-    WORKBENCH_JOB_SUBMIT_BUTTON = "button:text-is('Submit')"
+    WORKBENCH_JOBS_TAB = (
+        "#rstudio_workbench_tab_workbench_jobs, #rstudio_workbench_tab_workbenchjobs, "
+        "[id*='workbench_jobs'], [id*='workbenchjobs'], button:text-is('Workbench Jobs')"
+    )
+    WORKBENCH_JOB_NEW_BUTTON = (
+        "#rstudio_tb_startworkbenchjob, button:text-is('Start Workbench Job'), "
+        "button[title='Run Script as Workbench Job'], "
+        "button:text-is('Run Script as Workbench Job')"
+    )
+    WORKBENCH_JOB_SUBMIT_BUTTON = (
+        "#rstudio_dlg_ok, button:text-is('Start'), button:text-is('Submit')"
+    )
 
     # Job status (shared between Background and Workbench Jobs)
     JOB_STATUS_SUCCEEDED = (

--- a/src/vip_tests/workbench/pages/rstudio_session.py
+++ b/src/vip_tests/workbench/pages/rstudio_session.py
@@ -1,6 +1,9 @@
 """RStudio session selectors.
 
-Mirrors: rstudio-pro/e2e/pages/rstudio_session.page.ts
+These mirror the RStudio Pro e2e page objects under rstudio-pro/e2e (the
+Workbench Jobs selectors correspond to its Launcher pane and IDE modal page
+objects). Treat them as structural references, not a 1:1 copy, and verify
+against the live IDE DOM when RStudio Pro builds shift element IDs.
 """
 
 
@@ -38,20 +41,30 @@ class RStudioSession:
     BACKGROUND_JOB_RUN_BUTTON = "button:text-is('Start'), button[id*='start']"
 
     # Workbench Jobs pane (Launcher jobs, separate from Background Jobs).
-    # Newer RStudio Pro builds use "workbench_jobs" (with underscore) IDs;
-    # older builds used "workbenchjobs" (no underscore). Accept both.
+    # Verified against Workbench 2026.07.0 (RStudio Pro) over CDP.
+    #
+    # The tab and panel IDs use "workbench_jobs" (underscore) on current builds;
+    # the prior no-underscore "workbenchjobs" form is kept as a fallback for
+    # older builds in the support window. Only the two exact IDs are used --
+    # a substring match like [id*='workbench_jobs'] would also match the panel
+    # ("rstudio_workbench_panel_workbench_jobs"), so the tab locator would
+    # resolve to two elements and trip Playwright strict mode.
     WORKBENCH_JOBS_PANEL = (
         "#rstudio_workbench_panel_workbench_jobs, #rstudio_workbench_panel_workbenchjobs"
     )
     WORKBENCH_JOBS_TAB = (
         "#rstudio_workbench_tab_workbench_jobs, #rstudio_workbench_tab_workbenchjobs, "
-        "[id*='workbench_jobs'], [id*='workbenchjobs'], button:text-is('Workbench Jobs')"
+        "button:text-is('Workbench Jobs')"
     )
+    # The "new job" toolbar button is #rstudio_tb_startworkbenchjob, labeled
+    # "Start Workbench Job" on current builds (was "Run Script as Workbench Job"
+    # on older builds -- kept as a text fallback).
     WORKBENCH_JOB_NEW_BUTTON = (
         "#rstudio_tb_startworkbenchjob, button:text-is('Start Workbench Job'), "
-        "button[title='Run Script as Workbench Job'], "
         "button:text-is('Run Script as Workbench Job')"
     )
+    # The submission dialog's OK button (#rstudio_dlg_ok) is captioned "Start"
+    # ("Submit" kept as a text fallback for older builds).
     WORKBENCH_JOB_SUBMIT_BUTTON = (
         "#rstudio_dlg_ok, button:text-is('Start'), button:text-is('Submit')"
     )


### PR DESCRIPTION
## Problem

`workbench/test_jobs.py::test_workbench_job[chromium]` was skipping with:

> Workbench Jobs tab not found — Workbench Jobs (Launcher) may not be available in this Workbench configuration

on deployments that **do** have Launcher jobs enabled (reproduced against `pwb.demo.soleng.posit.it`, **Posit Workbench 2026.07.0**). This was a false negative: the feature is available, but the selectors in `RStudioSession` (`src/vip_tests/workbench/pages/rstudio_session.py`) no longer matched the RStudio Pro IDE DOM, so `WORKBENCH_JOBS_TAB.wait_for(state="visible")` timed out and hit the `pytest.skip` at `test_jobs.py:266`.

## Root cause

Inspecting a live RStudio Pro session (Workbench 2026.07.0, R 4.6.1) over the Chrome DevTools Protocol revealed four stale selectors:

| Selector | Old (broken) | Actual DOM |
|---|---|---|
| `WORKBENCH_JOBS_TAB` | `[id*='workbenchjobs']` (no underscore), or a `button` | `<div id="rstudio_workbench_tab_workbench_jobs">` — underscore in `workbench_jobs`, and a `DIV` not a `button` |
| `WORKBENCH_JOB_NEW_BUTTON` | text/title `Run Script as Workbench Job` | `<button id="rstudio_tb_startworkbenchjob" title="Run a job on a cluster">Start Workbench Job</button>` |
| `WORKBENCH_JOB_SUBMIT_BUTTON` | text `Submit` | dialog OK button `#rstudio_dlg_ok` with text `Start` |
| `WORKBENCH_JOBS_PANEL` | `#rstudio_workbench_panel_workbenchjobs` | `#rstudio_workbench_panel_workbench_jobs` |

The tab mismatch is what produced the exact skip observed.

## Fix

Each selector now accepts **both** the current underscore IDs (`workbench_jobs`) and the legacy no-underscore variants (`workbenchjobs`), so the test works across RStudio Pro builds without another break when IDs shift.

Verified over CDP against a live session: tab, panel, new-job button, and the submission dialog (script input `rstudio_tbb_text_pro_job_script` matches the existing `input[id*='script']` branch) all resolve. `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)