### PR TITLE
ci: attach constraints via draft-then-publish under immutable releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,15 +52,23 @@ jobs:
           uv export --frozen --no-emit-project --no-hashes --format requirements.txt \
             -o "constraints-${VERSION}.txt"
 
-      # Reproduces the body semantic-release used to attach via --vcs-release:
-      # the CHANGELOG.md section for this version, plus a compare-link footer.
+      # Reproduces the body semantic-release attached via --vcs-release: the
+      # CHANGELOG.md section for this version (including its "## vX.Y.Z (date)"
+      # heading), plus a compare-link footer. The heading is matched literally
+      # (index/==) so version numbers are never treated as regex patterns.
       - name: Build release notes from changelog
         run: |
           awk -v tag="v${VERSION}" '
-            $0 ~ "^## " tag "( |$)" {found=1; next}
+            index($0, "## " tag " ") == 1 || $0 == "## " tag {found=1; print; next}
             found && /^## v/ {exit}
             found {print}
           ' CHANGELOG.md > release-notes.md
+          # An empty file means the heading was not found (e.g. changelog format
+          # drift); fail loudly rather than publish a blank-body release.
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No CHANGELOG.md section found for ${GITHUB_REF_NAME}; check heading format"
+            exit 1
+          fi
           prev=$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)
           if [ -n "$prev" ]; then
             printf '\n---\n\n**Detailed Changes**: [%s...%s](https://github.com/%s/compare/%s...%s)\n' \
@@ -68,19 +76,29 @@ jobs:
               >> release-notes.md
           fi
 
-      # Immutable releases lock their assets at publish time, so the only way to
-      # ship the constraints file is to create the release as a draft, attach the
-      # asset, then publish. semantic-release no longer creates the release
-      # (--no-vcs-release in release.yml); this job owns it end to end.
+      # Immutable releases lock their assets at publish time, so the constraints
+      # file must be attached while the release is still a draft, then published.
+      # semantic-release no longer creates the release (--no-vcs-release in
+      # release.yml); this job owns it end to end. The create step is idempotent
+      # so a re-run after a partial failure refreshes the draft's asset instead
+      # of erroring on an already-existing release, and the asset is verified
+      # present before the release is published and locked.
       - name: Publish release with constraints attached
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" "constraints-${VERSION}.txt" \
-            --draft \
-            --title "${GITHUB_REF_NAME}" \
-            --notes-file release-notes.md
-          gh release edit "${GITHUB_REF_NAME}" --draft=false
+          tag="${GITHUB_REF_NAME}"
+          file="constraints-${VERSION}.txt"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" "$file" --clobber
+          else
+            gh release create "$tag" "$file" \
+              --draft \
+              --title "$tag" \
+              --notes-file release-notes.md
+          fi
+          gh release view "$tag" --json assets --jq '.assets[].name' | grep -qxF "$file"
+          gh release edit "$tag" --draft=false
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ jobs:
             index($0, "## " tag " ") == 1 || $0 == "## " tag {found=1; print; next}
             found && /^## v/ {exit}
             found {print}
+            END {if (!found) exit 1}
           ' CHANGELOG.md > release-notes.md
           # An empty file means the heading was not found (e.g. changelog format
           # drift); fail loudly rather than publish a blank-body release.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           name: dist
           path: dist/
 
-  constraints:
+  release:
     name: Attach locked constraints to release
     runs-on: ubuntu-latest
     permissions:
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Need history back to the previous tag to build the compare link.
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
@@ -50,24 +52,35 @@ jobs:
           uv export --frozen --no-emit-project --no-hashes --format requirements.txt \
             -o "constraints-${VERSION}.txt"
 
-      # Runs independently of the PyPI publish so a transient release-API delay
-      # (semantic-release pushes the tag just before creating the release) can
-      # never block publishing. Retry tolerates that race; --clobber is idempotent.
-      - name: Attach constraints file to the release
+      # Reproduces the body semantic-release used to attach via --vcs-release:
+      # the CHANGELOG.md section for this version, plus a compare-link footer.
+      - name: Build release notes from changelog
+        run: |
+          awk -v tag="v${VERSION}" '
+            $0 ~ "^## " tag "( |$)" {found=1; next}
+            found && /^## v/ {exit}
+            found {print}
+          ' CHANGELOG.md > release-notes.md
+          prev=$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)
+          if [ -n "$prev" ]; then
+            printf '\n---\n\n**Detailed Changes**: [%s...%s](https://github.com/%s/compare/%s...%s)\n' \
+              "$prev" "${GITHUB_REF_NAME}" "${GITHUB_REPOSITORY}" "$prev" "${GITHUB_REF_NAME}" \
+              >> release-notes.md
+          fi
+
+      # Immutable releases lock their assets at publish time, so the only way to
+      # ship the constraints file is to create the release as a draft, attach the
+      # asset, then publish. semantic-release no longer creates the release
+      # (--no-vcs-release in release.yml); this job owns it end to end.
+      - name: Publish release with constraints attached
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          file="constraints-${VERSION}.txt"
-          for attempt in 1 2 3 4 5; do
-            if gh release upload "${GITHUB_REF_NAME}" "$file" --clobber; then
-              echo "Attached $file to ${GITHUB_REF_NAME}"
-              exit 0
-            fi
-            echo "Release ${GITHUB_REF_NAME} not ready (attempt $attempt/5); waiting 15s..."
-            sleep 15
-          done
-          echo "::error::Failed to attach $file to ${GITHUB_REF_NAME} after 5 attempts"
-          exit 1
+          gh release create "${GITHUB_REF_NAME}" "constraints-${VERSION}.txt" \
+            --draft \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file release-notes.md
+          gh release edit "${GITHUB_REF_NAME}" --draft=false
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,10 @@ jobs:
       - name: Install python-semantic-release
         run: pip install python-semantic-release==9.21.0
 
+      # --no-vcs-release: the GitHub release is created by publish.yml (on the
+      # tag push) so the locked constraints file can be attached before the
+      # release is published and locked by immutable releases.
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version --push --tag --changelog --vcs-release
+        run: semantic-release version --push --tag --changelog --no-vcs-release


### PR DESCRIPTION
## Problem

The `Publish to PyPI` workflow's constraints job fails on every release with:

    HTTP 422: Cannot upload assets to an immutable release.

GitHub's Immutable Releases feature is enabled on this repo, so a release's assets are locked the instant it is published. semantic-release created the release (published, not draft) in `release.yml`, then `publish.yml` tried to `gh release upload` the `constraints-<version>.txt` afterward — which is impossible for an immutable release. The retry loop's "release not ready" assumption no longer holds; 422 is permanent, so all 5 attempts fail.

PyPI publishing itself was unaffected.

## Fix

Move GitHub release creation into the tag-triggered `publish.yml` and use the only flow immutable releases support: create as draft → attach the constraints file → publish.

- `release.yml`: `--vcs-release` → `--no-vcs-release`. semantic-release still bumps the version, writes the changelog, and pushes the tag; it no longer creates the GitHub release.
- `publish.yml`: the renamed `release` job creates the release as a draft with the constraints file attached, then un-drafts it (which locks it immutably, now with the asset baked in). Release notes are reproduced from the `CHANGELOG.md` section plus the compare-link footer, matching the previous `--vcs-release` body.

The old tag/release race the retry loop guarded against is gone: nothing creates the release until this job does, after the tag exists.

## Notes

- Fix applies to future releases only. v0.56.0 is already published and immutable with no constraints asset; it cannot be amended retroactively.
- No change to the README-documented download URL or to the PyPI publish job.
