### PR TITLE
feat: CI pipeline integration (JUnit/SARIF output, --ci flag, container entrypoint)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,11 @@ RUN uv run vip install
 # Run as the existing non-root user from the base image (ubuntu, UID 1000)
 RUN chown -R ubuntu:ubuntu /app
 USER ubuntu
-# Default entrypoint runs pytest
+# Default entrypoint is the vip CLI; default subcommand is verify.
 # Config file should be mounted at /app/vip.toml
-ENTRYPOINT ["uv", "run", "pytest"]
+ENTRYPOINT ["uv", "run", "vip"]
 
-# Default args: run all tests with short tracebacks and verbose output
-CMD ["--tb=short", "-v"]
+# Default args: run verify. Override to reach other subcommands, e.g.
+#   docker run <img> status --json
+#   docker run <img> --ci
+CMD ["verify"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ USER ubuntu
 # Config file should be mounted at /app/vip.toml
 ENTRYPOINT ["uv", "run", "vip"]
 
-# Default args: run verify. Override to reach other subcommands, e.g.
+# Default args: run verify. Override to reach other subcommands or pass
+# verify flags (args replace this CMD, so include "verify" explicitly), e.g.
+#   docker run <img> verify --ci
 #   docker run <img> status --json
-#   docker run <img> --ci
 CMD ["verify"]

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ vip verify --format json,junit,sarif
 # report/results.sarif   (--format sarif)  -> GitHub code scanning / secops
 ```
 
-The `--ci` preset bundles all three formats with concise output and strict
-non-interactive behavior:
+The `--ci` preset bundles all three formats with concise tracebacks (`--tb=short`)
+and overrides `--format` if both are given. Run it without `--interactive-auth`/
+`--headless-auth` -- combining them is an error, since `--ci` is meant for
+non-interactive pipelines:
 
 ```bash
 vip verify --ci

--- a/README.md
+++ b/README.md
@@ -74,6 +74,43 @@ content from Connect.
 
 Run `vip --help` or `vip <command> --help` for full usage details.
 
+## CI / pipeline integration
+
+VIP emits machine-readable output for security-ops and CI/CD pipelines.
+
+`vip verify` always writes `report/results.json` (and `report/failures.json` on
+failures). Add JUnit XML and/or SARIF with `--format`:
+
+```bash
+vip verify --format json,junit,sarif
+# report/results.json   (always)
+# report/junit.xml       (--format junit)  -> CI test dashboards
+# report/results.sarif   (--format sarif)  -> GitHub code scanning / secops
+```
+
+The `--ci` preset bundles all three formats with concise output and strict
+non-interactive behavior:
+
+```bash
+vip verify --ci
+```
+
+### Container
+
+An official image is published to `ghcr.io/posit-dev/vip`. The entrypoint is the
+`vip` CLI; the default subcommand is `verify`. Because `docker run` args replace
+the default command (they do not append to it), name the `verify` subcommand
+explicitly when passing verify flags:
+
+```bash
+# bare invocation runs `vip verify`:
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip
+# CI preset (name the subcommand so args don't replace it):
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip verify --ci
+# other subcommands are reachable too:
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip status --json
+```
+
 ## Development
 
 See [docs/development.md](docs/development.md) for dev setup, linting, and formatting.

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -37,6 +37,8 @@ def _make_args(**overrides) -> argparse.Namespace:
         "performance_tests": False,
         "insecure": False,
         "ca_bundle": None,
+        "format": "json",
+        "ci": False,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -1251,3 +1253,36 @@ class TestVerifyDefaultXdist:
         cmd = _capture_cmd(_make_args(config=str(cfg), pytest_args=["--tb=short"]))
         assert cmd.index("-n") < cmd.index("--tb=short")
         assert cmd.index("--dist") < cmd.index("--tb=short")
+
+
+class TestFormatFlag:
+    """--format / --ci control the --vip-format value forwarded to pytest."""
+
+    def test_format_forwarded(self):
+        cmd = _capture_cmd(_make_args(format="json,junit,sarif"))
+        assert "--vip-format=json,junit,sarif" in cmd
+
+    def test_default_format_is_json(self):
+        cmd = _capture_cmd(_make_args())
+        assert "--vip-format=json" in cmd
+
+    def test_ci_flag_bundles_formats_and_tb_short(self):
+        cmd = _capture_cmd(_make_args(ci=True))
+        assert "--vip-format=json,junit,sarif" in cmd
+        assert "--tb=short" in cmd
+
+    def test_unknown_format_rejected(self, tmp_path, monkeypatch):
+        """Must use a real (unmocked) sys.exit check: _capture_cmd/_capture_call
+        patch ``vip.cli.sys.exit`` to a no-op so run_verify falls through to
+        subprocess.run for the "happy path" tests above. An exit-path test has
+        to call run_verify directly, like every other SystemExit assertion in
+        this file (see TestVerifyLocalCredentialCheck._run_and_expect_exit)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import run_verify
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_verify(
+                _make_args(package_manager_url="https://pm.example.com", format="json,bogus")
+            )
+        assert exc_info.value.code == 2

--- a/selftests/test_cli_verify.py
+++ b/selftests/test_cli_verify.py
@@ -1286,3 +1286,41 @@ class TestFormatFlag:
                 _make_args(package_manager_url="https://pm.example.com", format="json,bogus")
             )
         assert exc_info.value.code == 2
+
+    def test_ci_overrides_explicit_format(self):
+        cmd = _capture_cmd(_make_args(ci=True, format="json"))
+        assert "--vip-format=json,junit,sarif" in cmd
+
+    def test_ci_rejects_interactive_auth(self, tmp_path, monkeypatch):
+        """--ci is a non-interactive preset; combining with --interactive-auth
+        must exit rather than silently ignoring one of the two. Calls
+        run_verify directly (real sys.exit) per the note on
+        test_unknown_format_rejected above."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import run_verify
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_verify(
+                _make_args(
+                    package_manager_url="https://pm.example.com",
+                    ci=True,
+                    interactive_auth=True,
+                )
+            )
+        assert exc_info.value.code == 1
+
+    def test_ci_rejects_headless_auth(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+        from vip.cli import run_verify
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_verify(
+                _make_args(
+                    package_manager_url="https://pm.example.com",
+                    ci=True,
+                    headless_auth=True,
+                )
+            )
+        assert exc_info.value.code == 1

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from vip.plugin import (
+    _emit_extra_formats,
     _extract_exception_info,
     _format_concise_error,
     _outcome_color,
@@ -1772,3 +1773,31 @@ def test_markers_in_sync():
         f"  Only in pyproject.toml: {pyproject_markers - plugin_markers}\n"
         f"  Only in plugin.py:      {plugin_markers - pyproject_markers}"
     )
+
+
+class TestFormatEmission:
+    def _write_results(self, tmp_path: Path) -> Path:
+        results = tmp_path / "results.json"
+        results.write_text(
+            '{"deployment_name": "T", "results": ['
+            '{"nodeid": "tests/connect/test_a.py::test_x", "outcome": "failed",'
+            ' "concise_error": "boom", "scenario_title": "X"}]}'
+        )
+        return results
+
+    def test_json_only_writes_nothing_extra(self, tmp_path):
+        results = self._write_results(tmp_path)
+        _emit_extra_formats("json", results)
+        assert not (tmp_path / "junit.xml").exists()
+        assert not (tmp_path / "results.sarif").exists()
+
+    def test_junit_and_sarif_written_as_siblings(self, tmp_path):
+        results = self._write_results(tmp_path)
+        _emit_extra_formats("json,junit,sarif", results)
+        assert (tmp_path / "junit.xml").exists()
+        assert (tmp_path / "results.sarif").exists()
+
+    def test_unknown_format_ignored_gracefully(self, tmp_path):
+        results = self._write_results(tmp_path)
+        _emit_extra_formats("junit,bogus", results)  # bogus ignored, junit still written
+        assert (tmp_path / "junit.xml").exists()

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -1799,5 +1799,6 @@ class TestFormatEmission:
 
     def test_unknown_format_ignored_gracefully(self, tmp_path):
         results = self._write_results(tmp_path)
-        _emit_extra_formats("junit,bogus", results)  # bogus ignored, junit still written
+        with pytest.warns(UserWarning, match="unknown"):
+            _emit_extra_formats("junit,bogus", results)  # bogus warned, junit still written
         assert (tmp_path / "junit.xml").exists()

--- a/selftests/test_reporting.py
+++ b/selftests/test_reporting.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from vip.reporting import ProductInfo, ReportData, TestResult, load_results, load_troubleshooting
+import xml.etree.ElementTree as ET
+
+from vip.reporting import (
+    ProductInfo,
+    ReportData,
+    TestResult,
+    load_results,
+    load_troubleshooting,
+    write_junit_xml,
+)
 
 
 class TestTestResult:
@@ -325,3 +334,64 @@ class TestConciseError:
         rd = load_results(p)
         assert rd.results[0].concise_error == "test_login: Login failed"
         assert rd.results[1].concise_error is None
+
+
+class TestWriteJUnitXml:
+    def _sample(self) -> ReportData:
+        return ReportData(
+            deployment_name="Acme Team",
+            generated_at="2026-07-21T12:00:00+00:00",
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_auth.py::test_login",
+                    outcome="passed",
+                    duration=1.5,
+                    scenario_title="User can log in",
+                    feature_description="Connect authentication",
+                ),
+                TestResult(
+                    nodeid="tests/workbench/test_sessions.py::test_start",
+                    outcome="failed",
+                    duration=0.5,
+                    concise_error="test_start: TimeoutError session did not start",
+                    scenario_title="Session starts",
+                    feature_description="Workbench sessions",
+                ),
+                TestResult(
+                    nodeid="tests/connect/test_api.py::test_v1",
+                    outcome="skipped",
+                    na_version=True,
+                    scenario_title="API v1 available",
+                ),
+            ],
+        )
+
+    def test_writes_well_formed_xml_with_counts(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        write_junit_xml(self._sample(), out)
+        tree = ET.parse(out)
+        suite = tree.getroot().find("testsuite")
+        assert suite.get("tests") == "3"
+        assert suite.get("failures") == "1"
+        assert suite.get("skipped") == "1"
+
+    def test_failure_carries_concise_error(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        write_junit_xml(self._sample(), out)
+        tree = ET.parse(out)
+        cases = {c.get("name"): c for c in tree.getroot().iter("testcase")}
+        failed = cases["Session starts"]
+        failure = failed.find("failure")
+        assert failure is not None
+        assert "TimeoutError" in failure.get("message")
+        assert failed.get("classname") == "Workbench sessions"
+
+    def test_skip_uses_nodeid_when_no_scenario(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        write_junit_xml(self._sample(), out)
+        tree = ET.parse(out)
+        cases = {c.get("name"): c for c in tree.getroot().iter("testcase")}
+        assert cases["API v1 available"].find("skipped") is not None
+        # passed case has no failure/skipped child
+        assert cases["User can log in"].find("failure") is None
+        assert cases["User can log in"].find("skipped") is None

--- a/selftests/test_reporting.py
+++ b/selftests/test_reporting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import xml.etree.ElementTree as ET
 
 from vip.reporting import (
@@ -11,6 +12,7 @@ from vip.reporting import (
     load_results,
     load_troubleshooting,
     write_junit_xml,
+    write_sarif,
 )
 
 
@@ -411,3 +413,64 @@ class TestWriteJUnitXml:
         case = tree.getroot().find(".//testcase")
         assert case.get("name") == "tests/connect/test_x.py::test_y"
         assert case.get("classname") == "connect"
+
+
+class TestWriteSarif:
+    def _sample(self) -> ReportData:
+        return ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_auth.py::test_login",
+                    outcome="passed",
+                    scenario_title="User can log in",
+                ),
+                TestResult(
+                    nodeid="tests/workbench/test_sessions.py::test_start",
+                    outcome="failed",
+                    concise_error="test_start: session did not start",
+                    scenario_title="Session starts",
+                ),
+                TestResult(
+                    nodeid="tests/connect/test_api.py::test_v1",
+                    outcome="skipped",
+                    na_version=True,
+                    scenario_title="API v1 available",
+                ),
+            ],
+        )
+
+    def test_valid_sarif_envelope(self, tmp_path):
+        out = tmp_path / "results.sarif"
+        write_sarif(self._sample(), out)
+        doc = json.loads(out.read_text())
+        assert doc["version"] == "2.1.0"
+        assert doc["runs"][0]["tool"]["driver"]["name"] == "vip"
+        assert len(doc["runs"][0]["results"]) == 3
+
+    def test_level_mapping_per_outcome(self, tmp_path):
+        out = tmp_path / "results.sarif"
+        write_sarif(self._sample(), out)
+        doc = json.loads(out.read_text())
+        levels = {r["ruleId"]: r["level"] for r in doc["runs"][0]["results"]}
+        assert levels["tests/connect/test_auth.py::test_login"] == "none"
+        assert levels["tests/workbench/test_sessions.py::test_start"] == "error"
+        assert levels["tests/connect/test_api.py::test_v1"] == "note"
+
+    def test_rules_deduped_and_logical_location(self, tmp_path):
+        out = tmp_path / "results.sarif"
+        data = self._sample()
+        data.results.append(
+            TestResult(nodeid="tests/connect/test_auth.py::test_login", outcome="passed")
+        )
+        write_sarif(data, out)
+        doc = json.loads(out.read_text())
+        rule_ids = [r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]]
+        assert rule_ids.count("tests/connect/test_auth.py::test_login") == 1
+        failed = next(
+            r
+            for r in doc["runs"][0]["results"]
+            if r["ruleId"] == "tests/workbench/test_sessions.py::test_start"
+        )
+        loc = failed["locations"][0]["logicalLocations"][0]["name"]
+        assert loc == "workbench / Session starts"
+        assert failed["message"]["text"] == "test_start: session did not start"

--- a/selftests/test_reporting.py
+++ b/selftests/test_reporting.py
@@ -414,6 +414,28 @@ class TestWriteJUnitXml:
         assert case.get("name") == "tests/connect/test_x.py::test_y"
         assert case.get("classname") == "connect"
 
+    def test_sanitizes_xml_invalid_control_chars(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        raw = "\x1b[31mred\x1b[0m and \x00 null"
+        data = ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_x.py::test_y",
+                    outcome="failed",
+                    concise_error=raw,
+                    longrepr=raw,
+                ),
+            ],
+        )
+        write_junit_xml(data, out)
+        # Well-formed XML: ET.parse must not raise.
+        tree = ET.parse(out)
+        failure = tree.getroot().find(".//failure")
+        assert failure is not None
+        raw_bytes = out.read_bytes()
+        assert b"\x1b" not in raw_bytes
+        assert b"\x00" not in raw_bytes
+
 
 class TestWriteSarif:
     def _sample(self) -> ReportData:

--- a/selftests/test_reporting.py
+++ b/selftests/test_reporting.py
@@ -395,3 +395,19 @@ class TestWriteJUnitXml:
         # passed case has no failure/skipped child
         assert cases["User can log in"].find("failure") is None
         assert cases["User can log in"].find("skipped") is None
+
+    def test_name_and_classname_fall_back_to_nodeid_and_category(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        data = ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_x.py::test_y",
+                    outcome="passed",
+                ),
+            ],
+        )
+        write_junit_xml(data, out)
+        tree = ET.parse(out)
+        case = tree.getroot().find(".//testcase")
+        assert case.get("name") == "tests/connect/test_x.py::test_y"
+        assert case.get("classname") == "connect"

--- a/selftests/test_reporting.py
+++ b/selftests/test_reporting.py
@@ -436,6 +436,75 @@ class TestWriteJUnitXml:
         assert b"\x1b" not in raw_bytes
         assert b"\x00" not in raw_bytes
 
+    def test_strips_full_ansi_escape_sequences(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        data = ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_x.py::test_y",
+                    outcome="failed",
+                    concise_error="\x1b[31mred\x1b[0m",
+                    longrepr="\x1b[31mred\x1b[0m",
+                ),
+            ],
+        )
+        write_junit_xml(data, out)
+        # Well-formed XML: ET.parse must not raise.
+        tree = ET.parse(out)
+        failure = tree.getroot().find(".//failure")
+        assert failure is not None
+        assert failure.get("message") == "red"
+        assert failure.text == "red"
+        raw_text = out.read_text()
+        assert "[31m" not in raw_text
+        assert "[0m" not in raw_text
+
+    def test_ordinary_skip_message_is_plain(self, tmp_path):
+        """A skip that is NOT na_version gets the plain 'skipped' message, not
+        the version-gate text."""
+        out = tmp_path / "junit.xml"
+        data = ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_x.py::test_y",
+                    outcome="skipped",
+                    na_version=False,
+                ),
+            ],
+        )
+        write_junit_xml(data, out)
+        tree = ET.parse(out)
+        skipped = tree.getroot().find(".//skipped")
+        assert skipped is not None
+        assert skipped.get("message") == "skipped"
+
+    def test_failure_fallback_when_no_error_details(self, tmp_path):
+        """A failed result with neither concise_error nor longrepr falls back
+        to a generic 'test failed' message."""
+        out = tmp_path / "junit.xml"
+        data = ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_x.py::test_y",
+                    outcome="failed",
+                    concise_error=None,
+                    longrepr=None,
+                ),
+            ],
+        )
+        write_junit_xml(data, out)
+        tree = ET.parse(out)
+        failure = tree.getroot().find(".//failure")
+        assert failure is not None
+        assert failure.get("message") == "test failed"
+
+    def test_empty_report_data_is_well_formed(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        write_junit_xml(ReportData(), out)
+        tree = ET.parse(out)
+        suite = tree.getroot().find("testsuite")
+        assert suite.get("tests") == "0"
+
 
 class TestWriteSarif:
     def _sample(self) -> ReportData:
@@ -496,3 +565,47 @@ class TestWriteSarif:
         loc = failed["locations"][0]["logicalLocations"][0]["name"]
         assert loc == "workbench / Session starts"
         assert failed["message"]["text"] == "test_start: session did not start"
+
+    def test_ordinary_skip_message_is_plain(self, tmp_path):
+        """A skip that is NOT na_version gets 'check skipped', not the
+        version-gate text."""
+        out = tmp_path / "results.sarif"
+        data = ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_x.py::test_y",
+                    outcome="skipped",
+                    na_version=False,
+                ),
+            ],
+        )
+        write_sarif(data, out)
+        doc = json.loads(out.read_text())
+        result = doc["runs"][0]["results"][0]
+        assert result["message"]["text"] == "check skipped"
+
+    def test_failure_fallback_when_no_error_details(self, tmp_path):
+        """A failed result with neither concise_error nor longrepr falls back
+        to a generic 'check failed' message."""
+        out = tmp_path / "results.sarif"
+        data = ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_x.py::test_y",
+                    outcome="failed",
+                    concise_error=None,
+                    longrepr=None,
+                ),
+            ],
+        )
+        write_sarif(data, out)
+        doc = json.loads(out.read_text())
+        result = doc["runs"][0]["results"][0]
+        assert result["message"]["text"] == "check failed"
+
+    def test_empty_report_data_is_well_formed(self, tmp_path):
+        out = tmp_path / "results.sarif"
+        write_sarif(ReportData(), out)
+        doc = json.loads(out.read_text())
+        assert doc["runs"][0]["results"] == []
+        assert doc["version"] == "2.1.0"

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -488,6 +488,19 @@ def run_verify(args: argparse.Namespace) -> None:
         cmd.append(f"--vip-config={config_path}")
     if args.report:
         cmd.append(f"--vip-report={args.report}")
+
+    _VALID_FORMATS = {"json", "junit", "sarif"}
+    fmt = "json,junit,sarif" if getattr(args, "ci", False) else getattr(args, "format", "json")
+    requested = [f.strip().lower() for f in fmt.split(",") if f.strip()]
+    unknown = [f for f in requested if f not in _VALID_FORMATS]
+    if unknown:
+        print(
+            f"Error: unknown --format value(s): {', '.join(unknown)}. "
+            f"Valid: {', '.join(sorted(_VALID_FORMATS))}.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    cmd.append(f"--vip-format={','.join(requested)}")
     if args.interactive_auth:
         cmd.append("--interactive-auth")
     if args.headless_auth:
@@ -524,6 +537,9 @@ def run_verify(args: argparse.Namespace) -> None:
         cmd.extend(["-n", "2"])
     if not _set_dist:
         cmd.extend(["--dist", "loadgroup"])
+
+    if getattr(args, "ci", False):
+        cmd.append("--tb=short")
 
     cmd.extend(args.pytest_args)
     if args.headless_auth:
@@ -1392,6 +1408,19 @@ def main() -> None:
         default="report/results.json",
         help="Write JSON results to this path for Quarto report generation"
         " (default: report/results.json)",
+    )
+    verify_parser.add_argument(
+        "--format",
+        default="json",
+        help="Comma-separated output formats: json,junit,sarif. json (results.json)"
+        " is always written; junit/sarif land beside --report. (default: json)",
+    )
+    verify_parser.add_argument(
+        "--ci",
+        action="store_true",
+        default=False,
+        help="CI preset: emit json,junit,sarif, use concise tracebacks, and run"
+        " strictly non-interactively.",
     )
     verify_parser.add_argument(
         "--verbose",

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -13,6 +13,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from vip.reporting import VALID_FORMATS
 from vip.timeouts import scaled
 
 if TYPE_CHECKING:
@@ -448,6 +449,14 @@ def run_verify(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    if getattr(args, "ci", False) and (args.interactive_auth or args.headless_auth):
+        print(
+            "Error: --ci requires non-interactive execution and cannot be combined "
+            "with --interactive-auth/--headless-auth.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if args.api_auth and _config_idp(config_path) == "snowflake":
         print(
             "\033[1mError: --api-auth is not supported with the Snowflake identity "
@@ -489,14 +498,13 @@ def run_verify(args: argparse.Namespace) -> None:
     if args.report:
         cmd.append(f"--vip-report={args.report}")
 
-    _VALID_FORMATS = {"json", "junit", "sarif"}
     fmt = "json,junit,sarif" if getattr(args, "ci", False) else getattr(args, "format", "json")
     requested = [f.strip().lower() for f in fmt.split(",") if f.strip()]
-    unknown = [f for f in requested if f not in _VALID_FORMATS]
+    unknown = [f for f in requested if f not in VALID_FORMATS]
     if unknown:
         print(
             f"Error: unknown --format value(s): {', '.join(unknown)}. "
-            f"Valid: {', '.join(sorted(_VALID_FORMATS))}.",
+            f"Valid: {', '.join(sorted(VALID_FORMATS))}.",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -1419,8 +1427,8 @@ def main() -> None:
         "--ci",
         action="store_true",
         default=False,
-        help="CI preset: emit json,junit,sarif, use concise tracebacks, and run"
-        " strictly non-interactively.",
+        help="CI preset: emit json,junit,sarif and use concise tracebacks (--tb=short)."
+        " Overrides --format. Not compatible with --interactive-auth/--headless-auth.",
     )
     verify_parser.add_argument(
         "--verbose",

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -1120,11 +1120,18 @@ def _emit_extra_formats(fmt: str, results_path: Path) -> None:
     """Emit JUnit/SARIF siblings of results_path per a comma-separated format list.
 
     ``results.json`` is always written by the caller; this only adds the extra
-    machine-readable formats. Unknown format tokens are ignored.
+    machine-readable formats. Unknown format tokens are non-fatal: known formats
+    are still emitted, and a warning is raised for each unrecognized token.
     """
-    from vip.reporting import load_results, write_junit_xml, write_sarif
+    from vip.reporting import VALID_FORMATS, load_results, write_junit_xml, write_sarif
 
     formats = {f.strip().lower() for f in fmt.split(",") if f.strip()}
+    unknown = formats - VALID_FORMATS
+    if unknown:
+        warnings.warn(
+            f"VIP: ignoring unknown --vip-format value(s): {', '.join(sorted(unknown))}",
+            stacklevel=2,
+        )
     if not (formats & {"junit", "sarif"}):
         return
     data = load_results(results_path)
@@ -1182,7 +1189,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     fmt = session.config.getoption("--vip-format", default="json")
     try:
         _emit_extra_formats(fmt, p)
-    except OSError as exc:
+    except (OSError, ValueError, KeyError) as exc:
         warnings.warn(f"VIP: could not write extra formats: {exc}", stacklevel=1)
 
     # Write failures.json alongside results.json so report rendering is idempotent.

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -1179,7 +1179,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         warnings.warn(f"VIP: could not write report to {report_path}: {exc}", stacklevel=1)
         return
 
-    fmt = session.config.getoption("--vip-format", "json")
+    fmt = session.config.getoption("--vip-format", default="json")
     try:
         _emit_extra_formats(fmt, p)
     except OSError as exc:

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -88,6 +88,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         " Set to empty string to disable. (default: report/results.json)",
     )
     group.addoption(
+        "--vip-format",
+        default="json",
+        help="Comma-separated output formats: json,junit,sarif. json (results.json)"
+        " is always written; junit/sarif are added as siblings. (default: json)",
+    )
+    group.addoption(
         "--interactive-auth",
         action="store_true",
         default=False,
@@ -1110,6 +1116,24 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     report.longrepr = _format_concise_error(report.nodeid, exc_type, exc_message.replace("\n", " "))
 
 
+def _emit_extra_formats(fmt: str, results_path: Path) -> None:
+    """Emit JUnit/SARIF siblings of results_path per a comma-separated format list.
+
+    ``results.json`` is always written by the caller; this only adds the extra
+    machine-readable formats. Unknown format tokens are ignored.
+    """
+    from vip.reporting import load_results, write_junit_xml, write_sarif
+
+    formats = {f.strip().lower() for f in fmt.split(",") if f.strip()}
+    if not (formats & {"junit", "sarif"}):
+        return
+    data = load_results(results_path)
+    if "junit" in formats:
+        write_junit_xml(data, results_path.parent / "junit.xml")
+    if "sarif" in formats:
+        write_sarif(data, results_path.parent / "results.sarif")
+
+
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     # xdist workers skip all session-end cleanup (controller handles it).
     is_worker = hasattr(session.config, "workerinput")
@@ -1154,6 +1178,12 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     except OSError as exc:
         warnings.warn(f"VIP: could not write report to {report_path}: {exc}", stacklevel=1)
         return
+
+    fmt = session.config.getoption("--vip-format", "json")
+    try:
+        _emit_extra_formats(fmt, p)
+    except OSError as exc:
+        warnings.warn(f"VIP: could not write extra formats: {exc}", stacklevel=1)
 
     # Write failures.json alongside results.json so report rendering is idempotent.
     failures = [r for r in results if r.get("outcome") == "failed"]

--- a/src/vip/reporting.py
+++ b/src/vip/reporting.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
@@ -156,6 +157,14 @@ def load_results(path: str | Path) -> ReportData:
     )
 
 
+_XML_INVALID_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def _xml_safe(text: str) -> str:
+    """Strip characters that are invalid in XML 1.0 (control chars other than tab/LF/CR)."""
+    return _XML_INVALID_CHARS.sub("", text)
+
+
 def write_junit_xml(data: ReportData, path: str | Path) -> None:
     """Write test results as a JUnit XML file for CI test reporters."""
     suites = ET.Element(
@@ -179,17 +188,17 @@ def write_junit_xml(data: ReportData, path: str | Path) -> None:
         case = ET.SubElement(
             suite,
             "testcase",
-            name=r.scenario_title or r.nodeid,
-            classname=r.feature_description or r.category,
+            name=_xml_safe(r.scenario_title or r.nodeid),
+            classname=_xml_safe(r.feature_description or r.category),
             time=f"{r.duration:.3f}",
         )
         if r.outcome == "failed":
             failure = ET.SubElement(
                 case,
                 "failure",
-                message=r.concise_error or r.longrepr or "test failed",
+                message=_xml_safe(r.concise_error or r.longrepr or "test failed"),
             )
-            failure.text = r.longrepr or r.concise_error or ""
+            failure.text = _xml_safe(r.longrepr or r.concise_error or "")
         elif r.outcome == "skipped":
             reason = "N/A for this product version" if r.na_version else "skipped"
             ET.SubElement(case, "skipped", message=reason)

--- a/src/vip/reporting.py
+++ b/src/vip/reporting.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -153,6 +154,49 @@ def load_results(path: str | Path) -> ReportData:
         products=products,
         results=results,
     )
+
+
+def write_junit_xml(data: ReportData, path: str | Path) -> None:
+    """Write test results as a JUnit XML file for CI test reporters."""
+    suites = ET.Element(
+        "testsuites",
+        tests=str(data.total),
+        failures=str(data.failed),
+        errors="0",
+        skipped=str(data.skipped),
+    )
+    suite = ET.SubElement(
+        suites,
+        "testsuite",
+        name="vip",
+        tests=str(data.total),
+        failures=str(data.failed),
+        errors="0",
+        skipped=str(data.skipped),
+        time=f"{sum(r.duration for r in data.results):.3f}",
+    )
+    for r in data.results:
+        case = ET.SubElement(
+            suite,
+            "testcase",
+            name=r.scenario_title or r.nodeid,
+            classname=r.feature_description or r.category,
+            time=f"{r.duration:.3f}",
+        )
+        if r.outcome == "failed":
+            failure = ET.SubElement(
+                case,
+                "failure",
+                message=r.concise_error or "test failed",
+            )
+            failure.text = r.longrepr or r.concise_error or ""
+        elif r.outcome == "skipped":
+            reason = "N/A for this product version" if r.na_version else "skipped"
+            ET.SubElement(case, "skipped", message=reason)
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(suites).write(p, encoding="utf-8", xml_declaration=True)
 
 
 def _installed_vip_tests_dir() -> Path | None:

--- a/src/vip/reporting.py
+++ b/src/vip/reporting.py
@@ -15,6 +15,9 @@ else:
     import tomli as tomllib
 
 
+VALID_FORMATS = frozenset({"json", "junit", "sarif"})
+
+
 @dataclass
 class TestResult:
     nodeid: str
@@ -125,7 +128,7 @@ def load_results(path: str | Path) -> ReportData:
         TestResult(
             nodeid=r["nodeid"],
             outcome=r["outcome"],
-            duration=r.get("duration", 0.0),
+            duration=r.get("duration") or 0.0,
             longrepr=r.get("longrepr"),
             concise_error=r.get("concise_error"),
             markers=r.get("markers", []),
@@ -158,15 +161,17 @@ def load_results(path: str | Path) -> ReportData:
 
 
 _XML_INVALID_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+_ANSI_CSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 
 def _xml_safe(text: str) -> str:
-    """Strip characters that are invalid in XML 1.0 (control chars other than tab/LF/CR)."""
-    return _XML_INVALID_CHARS.sub("", text)
+    """Strip ANSI escape sequences and XML-1.0-invalid control chars (keep tab/LF/CR)."""
+    return _XML_INVALID_CHARS.sub("", _ANSI_CSI.sub("", text))
 
 
 def write_junit_xml(data: ReportData, path: str | Path) -> None:
     """Write test results as a JUnit XML file for CI test reporters."""
+    # VIP's ReportData has no "error" outcome distinct from "failed"; always 0.
     suites = ET.Element(
         "testsuites",
         tests=str(data.total),

--- a/src/vip/reporting.py
+++ b/src/vip/reporting.py
@@ -199,6 +199,63 @@ def write_junit_xml(data: ReportData, path: str | Path) -> None:
     ET.ElementTree(suites).write(p, encoding="utf-8", xml_declaration=True)
 
 
+_SARIF_LEVEL = {"failed": "error", "passed": "none", "skipped": "note"}
+
+
+def write_sarif(data: ReportData, path: str | Path) -> None:
+    """Write test results as SARIF 2.1.0 for secops / code-scanning ingestion.
+
+    Every check emits a result (fail=error, pass=none, skip=note) to give a
+    full audit trail of what was validated, not only failures.
+    """
+    from vip import __version__
+
+    rules: dict[str, dict] = {}
+    results: list[dict] = []
+    for r in data.results:
+        check = r.scenario_title or r.nodeid.split("::")[-1]
+        rules.setdefault(
+            r.nodeid,
+            {"id": r.nodeid, "name": check, "shortDescription": {"text": check}},
+        )
+        if r.outcome == "failed":
+            text = r.concise_error or r.longrepr or "check failed"
+        elif r.outcome == "skipped":
+            text = "N/A for this product version" if r.na_version else "check skipped"
+        else:
+            text = check
+        results.append(
+            {
+                "ruleId": r.nodeid,
+                "level": _SARIF_LEVEL.get(r.outcome, "none"),
+                "message": {"text": text},
+                "locations": [{"logicalLocations": [{"name": f"{r.category} / {check}"}]}],
+            }
+        )
+
+    doc = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "vip",
+                        "version": __version__,
+                        "informationUri": "https://github.com/posit-dev/vip",
+                        "rules": list(rules.values()),
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(doc, indent=2) + "\n")
+
+
 def _installed_vip_tests_dir() -> Path | None:
     """Return the directory of the installed ``vip_tests`` package, if any."""
     try:

--- a/src/vip/reporting.py
+++ b/src/vip/reporting.py
@@ -187,7 +187,7 @@ def write_junit_xml(data: ReportData, path: str | Path) -> None:
             failure = ET.SubElement(
                 case,
                 "failure",
-                message=r.concise_error or "test failed",
+                message=r.concise_error or r.longrepr or "test failed",
             )
             failure.text = r.longrepr or r.concise_error or ""
         elif r.outcome == "skipped":

--- a/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-design.md
+++ b/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-design.md
@@ -1,0 +1,90 @@
+# Design — #149: CI pipeline integration (machine-readable output + container entrypoint)
+
+**Status:** Approved design (brainstorming) — ready for implementation plan
+**Date:** 2026-07-21
+**Issue:** posit-dev/vip#149
+**Branch:** `worktree-ci-pipeline-integration-149`
+
+## Framing
+
+#149 asks VIP to be consumable *by* customers' security-operations and CI/CD pipelines (distinct from #409, which is about testing VIP *itself* in CI). Feedback originated from a Solutions Engineering presentation (2026-04-07); FSI (Financial Services) is the primary driver, with general security-automation enterprise as secondary.
+
+The issue is not a single PR — it is four loosely-coupled items, one of which (`concise_error` + `failures.json`, #162) already shipped. Two more are already partially built:
+
+- The GHCR image build/push pipeline already exists (`.github/workflows/docker.yml` pushes `ghcr.io/posit-dev/vip` on `main` and `v*` tags).
+- `vip verify` is already CI-safe by default: exit codes propagate pytest's return code, and `_check_credentials()` fails fast with a non-zero exit instead of prompting when credentials are missing.
+
+**This PR's slice** covers the remaining gaps that deliver the most secops value:
+
+1. JUnit XML output format
+2. SARIF output format
+3. Container entrypoint rework (raw `pytest` → the `vip` CLI)
+4. A `--ci` convenience flag + documentation
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+| --- | --- |
+| Format selection | `vip verify --format <comma-separated>`, values `json\|junit\|sarif`, default `json`, additive |
+| `json` behavior | `results.json` + `failures.json` are **always** written (the Quarto HTML report depends on `results.json`); `--format` only *adds* JUnit/SARIF |
+| Output paths | Extra formats are siblings of `--report`'s directory: `<dir>/junit.xml`, `<dir>/results.sarif` — no new path flags |
+| JUnit source | Custom writer off the existing `ReportData`/`TestResult` dataclasses (richer than pytest's native `--junitxml`: includes `concise_error` + scenario/feature metadata; single code path) |
+| SARIF mapping | **Every check** emits a result — fail=`error`, pass=`none`, skip=`note` — for a full compliance audit trail |
+| SARIF location | `logicalLocation` of `"<Product> / <check>"` (no phantom source file) |
+| Container entrypoint | `ENTRYPOINT ["uv","run","vip"]`, `CMD ["verify"]` — `docker run img` runs verify; other subcommands remain reachable |
+| `--ci` flag | Sugar for `--format json,junit,sarif` + explicit non-interactive + concise stdout (`--tb=short`) |
+
+## Architecture
+
+### 1. Writers — `src/vip/reporting.py`
+
+Two new pure functions consuming a `ReportData` (already the deserialized model produced by `load_results()`), so they work identically whether called at pytest session end or later from a results file:
+
+- **`write_junit_xml(data: ReportData, path: Path) -> None`**
+  - Standard `testsuites > testsuite > testcase` schema.
+  - `testcase`: `name` = scenario title (fallback nodeid), `classname` = feature/product, `time` = duration.
+  - Children: `<failure message=concise_error>` for fails, `<error>` for errors, `<skipped>` for skips (including `na_version` skips, with the version-gate reason as the skip message).
+  - Suite-level `tests`/`failures`/`errors`/`skipped` counts from `ReportData.total/failed/…`.
+
+- **`write_sarif(data: ReportData, path: Path) -> None`**
+  - SARIF 2.1.0. `runs[0].tool.driver` = `{name: "vip", version: __version__, informationUri, rules: [...]}`.
+  - `rules[]`: one entry per unique check (keyed by nodeid), so results reference stable `ruleId`s.
+  - `results[]`: **one per check outcome** — `level` = `error` (fail) / `none` (pass) / `note` (skip); `message.text` = `concise_error` for fails, else scenario title / skip reason; `locations[0].logicalLocation.name` = `"<Product> / <check>"`.
+  - Tradeoff (accepted): `none`-level results are noisier in code-scanning UIs, but give FSI the "evidence of what was checked" audit trail they asked for.
+
+### 2. Plugin wiring — `src/vip/plugin.py`
+
+- Add a `--vip-format` pytest option (mirrors the existing `--vip-report` at `plugin.py:84`).
+- In `pytest_sessionfinish` (`plugin.py:1048`), after the existing `results.json`/`failures.json` writes, parse the requested format list and call `write_junit_xml` / `write_sarif` for the sibling paths derived from `--vip-report`'s directory.
+
+### 3. CLI — `src/vip/cli.py`
+
+- `vip verify --format json,junit,sarif` → validated (reject unknown values) and forwarded as `--vip-format=…`.
+- `vip verify --ci` → expands to `--format json,junit,sarif`, ensures non-interactive (no `--interactive-auth`/`--headless-auth`), and sets concise output (`--tb=short`). Mutually compatible with an explicit `--format` (explicit wins / unions — resolved in plan).
+
+### 4. Container — `Dockerfile`
+
+- `ENTRYPOINT ["uv","run","vip"]`, `CMD ["verify"]`.
+- Config still mounted at `/app/vip.toml`.
+- No change to `docker.yml` (GHCR build/push already correct). Verify `.dockerignore` doesn't exclude anything the CLI entrypoint needs at runtime.
+
+### 5. Docs
+
+- `README.md`: a "CI / pipeline integration" section — `docker run -v $PWD/vip.toml:/app/vip.toml ghcr.io/posit-dev/vip --ci` recipe, output-format table, and where each artifact lands.
+- `AGENTS.md`: note the new `--format`/`--ci` surface if it documents CLI options.
+- `CHANGELOG.md`: handled automatically by semantic-release via a `feat:` commit.
+- Docs website page for `vip verify` options, if one exists.
+
+## Testing (TDD)
+
+New `selftests/` coverage (patterned on existing `test_reporting.py` / `test_cli_verify.py`):
+
+- `write_junit_xml`: well-formed XML; correct suite counts; failure/error/skip element mapping; `na_version` skip reason surfaced.
+- `write_sarif`: valid SARIF 2.1.0 structure; every outcome emits a result with the right `level`; `rules[]` dedup; `logicalLocation` naming.
+- CLI: `--format junit,sarif` writes the sibling files and still writes `results.json`; unknown format value is rejected; `--ci` produces all three artifacts.
+
+## Out of scope (this PR)
+
+- Multi-arch container images.
+- Promoting VIP's own smoke workflows (that is #409).
+- Per-format path override flags (`--junit-xml PATH` / `--sarif PATH`) — deferred; siblings-in-report-dir is sufficient for the driving use case.

--- a/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-design.md
+++ b/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-design.md
@@ -66,11 +66,12 @@ Two new pure functions consuming a `ReportData` (already the deserialized model 
 
 - `ENTRYPOINT ["uv","run","vip"]`, `CMD ["verify"]`.
 - Config still mounted at `/app/vip.toml`.
+- Because `docker run` args *replace* CMD (they do not append), the CI recipe is `docker run <img> verify --ci` (the `verify` subcommand must be named explicitly); bare `docker run <img>` runs `vip verify` via the default CMD. Other subcommands: `docker run <img> status --json`.
 - No change to `docker.yml` (GHCR build/push already correct). Verify `.dockerignore` doesn't exclude anything the CLI entrypoint needs at runtime.
 
 ### 5. Docs
 
-- `README.md`: a "CI / pipeline integration" section — `docker run -v $PWD/vip.toml:/app/vip.toml ghcr.io/posit-dev/vip --ci` recipe, output-format table, and where each artifact lands.
+- `README.md`: a "CI / pipeline integration" section — `docker run -v $PWD/vip.toml:/app/vip.toml ghcr.io/posit-dev/vip verify --ci` recipe, output-format table, and where each artifact lands.
 - `AGENTS.md`: note the new `--format`/`--ci` surface if it documents CLI options.
 - `CHANGELOG.md`: handled automatically by semantic-release via a `feat:` commit.
 - Docs website page for `vip verify` options, if one exists.

--- a/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-plan.md
+++ b/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-plan.md
@@ -554,7 +554,7 @@ git commit -m "feat(cli): add --format and --ci flags to vip verify"
 
 **Interfaces:**
 - Consumes: the `vip` console-script installed by `uv sync` (`pyproject.toml [project.scripts] vip = "vip.cli:main"`).
-- Produces: `docker run <img>` runs `vip verify`; `docker run <img> status --json` (and other subcommands) reachable; `docker run <img> --ci` runs `vip verify --ci`.
+- Produces: `docker run <img>` runs `vip verify`; `docker run <img> status --json` (and other subcommands) reachable; `docker run <img> verify --ci` runs `vip verify --ci`. Note: `docker run` args REPLACE the CMD (they don't append), so the `verify` subcommand must be named explicitly to pass verify flags — bare `docker run <img> --ci` would run `vip --ci` (invalid).
 
 - [ ] **Step 1: Change the entrypoint**
 
@@ -565,9 +565,10 @@ Replace the final two lines of `Dockerfile`:
 # Config file should be mounted at /app/vip.toml
 ENTRYPOINT ["uv", "run", "vip"]
 
-# Default args: run verify. Override to reach other subcommands, e.g.
+# Default args: run verify. Override to reach other subcommands or pass
+# verify flags (args replace this CMD, so include "verify" explicitly), e.g.
+#   docker run <img> verify --ci
 #   docker run <img> status --json
-#   docker run <img> --ci
 CMD ["verify"]
 ```
 
@@ -630,10 +631,15 @@ vip verify --ci
 ### Container
 
 An official image is published to `ghcr.io/posit-dev/vip`. The entrypoint is the
-`vip` CLI; the default subcommand is `verify`:
+`vip` CLI; the default subcommand is `verify`. Because `docker run` args replace
+the default command (they do not append to it), name the `verify` subcommand
+explicitly when passing verify flags:
 
 ```bash
-docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip --ci
+# bare invocation runs `vip verify`:
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip
+# CI preset (name the subcommand so args don't replace it):
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip verify --ci
 # other subcommands are reachable too:
 docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip status --json
 ```

--- a/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-plan.md
+++ b/thoughts/shared/plans/2026-07-21-issue-149-ci-integration-plan.md
@@ -1,0 +1,710 @@
+# CI Pipeline Integration (#149) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add JUnit XML and SARIF output formats to `vip verify`, a `--ci` convenience flag, and a CLI-based container entrypoint so VIP plugs into customer security-ops / CI pipelines.
+
+**Architecture:** Two pure writer functions in `reporting.py` consume the existing `ReportData` model and emit JUnit/SARIF. `pytest_sessionfinish` re-reads the just-written `results.json` via `load_results()` and emits the requested extra formats as siblings. The `vip verify` CLI grows a comma-separated `--format` option and a `--ci` sugar flag that forwards to a new `--vip-format` pytest option. The Dockerfile entrypoint switches from raw pytest to the `vip` CLI.
+
+**Tech Stack:** Python 3.10+, stdlib `argparse` / `xml.etree.ElementTree` / `json`, pytest plugin API, `uv`, Docker.
+
+## Global Constraints
+
+- Python floor: 3.10 (`from __future__ import annotations` already used throughout; no 3.11+ syntax in `reporting.py` outside the existing `sys.version_info` guard).
+- No new runtime dependencies — JUnit via stdlib `xml.etree.ElementTree`, SARIF via stdlib `json`.
+- `results.json` + `failures.json` are ALWAYS written regardless of `--format` (Quarto HTML depends on `results.json`). `--format` is additive only.
+- `--format` values: `json`, `junit`, `sarif`. Comma-separated. Default `json`. Unknown values are rejected.
+- Extra-format files are siblings of `--report`'s directory: `junit.xml`, `results.sarif`.
+- SARIF: SARIF 2.1.0; every check emits a result (fail=`error`, pass=`none`, skip=`note`); `logicalLocations` naming `"<category> / <check>"`, no physical source location.
+- Conventional-commit messages (`feat:` / `test:` / `docs:` / `chore:`) — enforced by `pr-title.yml`; semantic-release consumes them.
+- Do not run the container-dependent smoke suites; use `uv run pytest selftests/` for verification.
+- Lint/format gate: `uv run ruff check src/ selftests/` and `uv run ruff format --check src/ selftests/` must pass; `uv run mypy src/` must pass.
+
+---
+
+### Task 1: JUnit XML writer
+
+**Files:**
+- Modify: `src/vip/reporting.py` (add `write_junit_xml` after `load_results`, ~line 156)
+- Test: `selftests/test_reporting.py` (add `TestWriteJUnitXml` class)
+
+**Interfaces:**
+- Consumes: `ReportData`, `TestResult` (existing dataclasses in `reporting.py`).
+- Produces: `write_junit_xml(data: ReportData, path: str | Path) -> None` — writes a JUnit XML file. `testcase.name` = `scenario_title or nodeid`; `testcase.classname` = `feature_description or category`; failed → `<failure>` child carrying `concise_error or longrepr`; skipped → `<skipped>` child (message = version-gate note when `na_version`); passed → no child.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to selftests/test_reporting.py
+import xml.etree.ElementTree as ET
+
+from vip.reporting import write_junit_xml, write_sarif  # write_sarif added in Task 2
+
+
+class TestWriteJUnitXml:
+    def _sample(self) -> ReportData:
+        return ReportData(
+            deployment_name="Acme Team",
+            generated_at="2026-07-21T12:00:00+00:00",
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_auth.py::test_login",
+                    outcome="passed",
+                    duration=1.5,
+                    scenario_title="User can log in",
+                    feature_description="Connect authentication",
+                ),
+                TestResult(
+                    nodeid="tests/workbench/test_sessions.py::test_start",
+                    outcome="failed",
+                    duration=0.5,
+                    concise_error="test_start: TimeoutError session did not start",
+                    scenario_title="Session starts",
+                    feature_description="Workbench sessions",
+                ),
+                TestResult(
+                    nodeid="tests/connect/test_api.py::test_v1",
+                    outcome="skipped",
+                    na_version=True,
+                    scenario_title="API v1 available",
+                ),
+            ],
+        )
+
+    def test_writes_well_formed_xml_with_counts(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        write_junit_xml(self._sample(), out)
+        tree = ET.parse(out)
+        suite = tree.getroot().find("testsuite")
+        assert suite.get("tests") == "3"
+        assert suite.get("failures") == "1"
+        assert suite.get("skipped") == "1"
+
+    def test_failure_carries_concise_error(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        write_junit_xml(self._sample(), out)
+        tree = ET.parse(out)
+        cases = {c.get("name"): c for c in tree.getroot().iter("testcase")}
+        failed = cases["Session starts"]
+        failure = failed.find("failure")
+        assert failure is not None
+        assert "TimeoutError" in failure.get("message")
+        assert failed.get("classname") == "Workbench sessions"
+
+    def test_skip_uses_nodeid_when_no_scenario(self, tmp_path):
+        out = tmp_path / "junit.xml"
+        write_junit_xml(self._sample(), out)
+        tree = ET.parse(out)
+        cases = {c.get("name"): c for c in tree.getroot().iter("testcase")}
+        assert cases["API v1 available"].find("skipped") is not None
+        # passed case has no failure/skipped child
+        assert cases["User can log in"].find("failure") is None
+        assert cases["User can log in"].find("skipped") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest selftests/test_reporting.py::TestWriteJUnitXml -v`
+Expected: FAIL with `ImportError: cannot import name 'write_junit_xml'` (and `write_sarif`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/vip/reporting.py after load_results()
+import xml.etree.ElementTree as ET  # add to imports at top of file
+
+
+def write_junit_xml(data: ReportData, path: str | Path) -> None:
+    """Write test results as a JUnit XML file for CI test reporters."""
+    suites = ET.Element(
+        "testsuites",
+        tests=str(data.total),
+        failures=str(data.failed),
+        errors="0",
+        skipped=str(data.skipped),
+    )
+    suite = ET.SubElement(
+        suites,
+        "testsuite",
+        name="vip",
+        tests=str(data.total),
+        failures=str(data.failed),
+        errors="0",
+        skipped=str(data.skipped),
+        time=f"{sum(r.duration for r in data.results):.3f}",
+    )
+    for r in data.results:
+        case = ET.SubElement(
+            suite,
+            "testcase",
+            name=r.scenario_title or r.nodeid,
+            classname=r.feature_description or r.category,
+            time=f"{r.duration:.3f}",
+        )
+        if r.outcome == "failed":
+            failure = ET.SubElement(
+                case,
+                "failure",
+                message=r.concise_error or "test failed",
+            )
+            failure.text = r.longrepr or r.concise_error or ""
+        elif r.outcome == "skipped":
+            reason = "N/A for this product version" if r.na_version else "skipped"
+            ET.SubElement(case, "skipped", message=reason)
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(suites).write(p, encoding="utf-8", xml_declaration=True)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest selftests/test_reporting.py::TestWriteJUnitXml -v`
+Expected: PASS (3 tests). Note: the `write_sarif` import will still fail until Task 2 — if running this task in isolation, temporarily drop `write_sarif` from the import line, then restore it in Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vip/reporting.py selftests/test_reporting.py
+git commit -m "feat(report): add JUnit XML output writer"
+```
+
+---
+
+### Task 2: SARIF writer
+
+**Files:**
+- Modify: `src/vip/reporting.py` (add `write_sarif` after `write_junit_xml`)
+- Test: `selftests/test_reporting.py` (add `TestWriteSarif` class)
+
+**Interfaces:**
+- Consumes: `ReportData`, `TestResult`; `vip.__version__`.
+- Produces: `write_sarif(data: ReportData, path: str | Path) -> None` — writes SARIF 2.1.0 JSON. One `result` per check: level `error` (failed) / `none` (passed) / `note` (skipped). `ruleId` = nodeid; `rules[]` deduped by nodeid. `locations[0].logicalLocations[0].name` = `"<category> / <check>"` where check = `scenario_title or test function name`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to selftests/test_reporting.py
+import json
+
+
+class TestWriteSarif:
+    def _sample(self) -> ReportData:
+        return ReportData(
+            results=[
+                TestResult(
+                    nodeid="tests/connect/test_auth.py::test_login",
+                    outcome="passed",
+                    scenario_title="User can log in",
+                ),
+                TestResult(
+                    nodeid="tests/workbench/test_sessions.py::test_start",
+                    outcome="failed",
+                    concise_error="test_start: session did not start",
+                    scenario_title="Session starts",
+                ),
+                TestResult(
+                    nodeid="tests/connect/test_api.py::test_v1",
+                    outcome="skipped",
+                    na_version=True,
+                    scenario_title="API v1 available",
+                ),
+            ],
+        )
+
+    def test_valid_sarif_envelope(self, tmp_path):
+        out = tmp_path / "results.sarif"
+        write_sarif(self._sample(), out)
+        doc = json.loads(out.read_text())
+        assert doc["version"] == "2.1.0"
+        assert doc["runs"][0]["tool"]["driver"]["name"] == "vip"
+        assert len(doc["runs"][0]["results"]) == 3
+
+    def test_level_mapping_per_outcome(self, tmp_path):
+        out = tmp_path / "results.sarif"
+        write_sarif(self._sample(), out)
+        doc = json.loads(out.read_text())
+        levels = {r["ruleId"]: r["level"] for r in doc["runs"][0]["results"]}
+        assert levels["tests/connect/test_auth.py::test_login"] == "none"
+        assert levels["tests/workbench/test_sessions.py::test_start"] == "error"
+        assert levels["tests/connect/test_api.py::test_v1"] == "note"
+
+    def test_rules_deduped_and_logical_location(self, tmp_path):
+        out = tmp_path / "results.sarif"
+        data = self._sample()
+        data.results.append(
+            TestResult(nodeid="tests/connect/test_auth.py::test_login", outcome="passed")
+        )
+        write_sarif(data, out)
+        doc = json.loads(out.read_text())
+        rule_ids = [r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]]
+        assert rule_ids.count("tests/connect/test_auth.py::test_login") == 1
+        failed = next(
+            r for r in doc["runs"][0]["results"]
+            if r["ruleId"] == "tests/workbench/test_sessions.py::test_start"
+        )
+        loc = failed["locations"][0]["logicalLocations"][0]["name"]
+        assert loc == "workbench / Session starts"
+        assert failed["message"]["text"] == "test_start: session did not start"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest selftests/test_reporting.py::TestWriteSarif -v`
+Expected: FAIL with `ImportError: cannot import name 'write_sarif'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/vip/reporting.py after write_junit_xml()
+_SARIF_LEVEL = {"failed": "error", "passed": "none", "skipped": "note"}
+
+
+def write_sarif(data: ReportData, path: str | Path) -> None:
+    """Write test results as SARIF 2.1.0 for secops / code-scanning ingestion.
+
+    Every check emits a result (fail=error, pass=none, skip=note) to give a
+    full audit trail of what was validated, not only failures.
+    """
+    from vip import __version__
+
+    rules: dict[str, dict] = {}
+    results: list[dict] = []
+    for r in data.results:
+        check = r.scenario_title or r.nodeid.split("::")[-1]
+        rules.setdefault(
+            r.nodeid,
+            {"id": r.nodeid, "name": check, "shortDescription": {"text": check}},
+        )
+        if r.outcome == "failed":
+            text = r.concise_error or r.longrepr or "check failed"
+        elif r.outcome == "skipped":
+            text = "N/A for this product version" if r.na_version else "check skipped"
+        else:
+            text = check
+        results.append(
+            {
+                "ruleId": r.nodeid,
+                "level": _SARIF_LEVEL.get(r.outcome, "none"),
+                "message": {"text": text},
+                "locations": [
+                    {"logicalLocations": [{"name": f"{r.category} / {check}"}]}
+                ],
+            }
+        )
+
+    doc = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "vip",
+                        "version": __version__,
+                        "informationUri": "https://github.com/posit-dev/vip",
+                        "rules": list(rules.values()),
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(doc, indent=2) + "\n")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest selftests/test_reporting.py -v`
+Expected: PASS (all reporting tests, including Task 1's).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vip/reporting.py selftests/test_reporting.py
+git commit -m "feat(report): add SARIF 2.1.0 output writer"
+```
+
+---
+
+### Task 3: Plugin wiring — `--vip-format` and session-end emission
+
+**Files:**
+- Modify: `src/vip/plugin.py` (add option near line 84; emit formats in `pytest_sessionfinish` near line 1092, after `results.json` write)
+- Test: `selftests/test_plugin.py` (add `TestFormatEmission` class)
+
+**Interfaces:**
+- Consumes: `write_junit_xml`, `write_sarif`, `load_results` from `vip.reporting`; existing `--vip-report` option and the `results.json` written at `plugin.py:1088`.
+- Produces: a `--vip-format` pytest option (default `"json"`); after writing `results.json`, parses the comma list and writes `junit.xml` / `results.sarif` siblings when requested.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to selftests/test_plugin.py — patterned on the existing pytester/plugin tests.
+# This test drives the emission helper directly to avoid a full pytest run.
+from pathlib import Path
+
+from vip.plugin import _emit_extra_formats
+
+
+class TestFormatEmission:
+    def _write_results(self, tmp_path: Path) -> Path:
+        results = tmp_path / "results.json"
+        results.write_text(
+            '{"deployment_name": "T", "results": ['
+            '{"nodeid": "tests/connect/test_a.py::test_x", "outcome": "failed",'
+            ' "concise_error": "boom", "scenario_title": "X"}]}'
+        )
+        return results
+
+    def test_json_only_writes_nothing_extra(self, tmp_path):
+        results = self._write_results(tmp_path)
+        _emit_extra_formats("json", results)
+        assert not (tmp_path / "junit.xml").exists()
+        assert not (tmp_path / "results.sarif").exists()
+
+    def test_junit_and_sarif_written_as_siblings(self, tmp_path):
+        results = self._write_results(tmp_path)
+        _emit_extra_formats("json,junit,sarif", results)
+        assert (tmp_path / "junit.xml").exists()
+        assert (tmp_path / "results.sarif").exists()
+
+    def test_unknown_format_ignored_gracefully(self, tmp_path):
+        results = self._write_results(tmp_path)
+        _emit_extra_formats("junit,bogus", results)  # bogus ignored, junit still written
+        assert (tmp_path / "junit.xml").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest selftests/test_plugin.py::TestFormatEmission -v`
+Expected: FAIL with `ImportError: cannot import name '_emit_extra_formats'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the option (after the `--vip-report` block ending at `plugin.py:89`):
+
+```python
+    group.addoption(
+        "--vip-format",
+        default="json",
+        help="Comma-separated output formats: json,junit,sarif. json (results.json)"
+        " is always written; junit/sarif are added as siblings. (default: json)",
+    )
+```
+
+Add the helper (module-level, near the other `pytest_sessionfinish` helpers):
+
+```python
+def _emit_extra_formats(fmt: str, results_path: Path) -> None:
+    """Emit JUnit/SARIF siblings of results_path per a comma-separated format list.
+
+    ``results.json`` is always written by the caller; this only adds the extra
+    machine-readable formats. Unknown format tokens are ignored.
+    """
+    from vip.reporting import load_results, write_junit_xml, write_sarif
+
+    formats = {f.strip().lower() for f in fmt.split(",") if f.strip()}
+    if not (formats & {"junit", "sarif"}):
+        return
+    data = load_results(results_path)
+    if "junit" in formats:
+        write_junit_xml(data, results_path.parent / "junit.xml")
+    if "sarif" in formats:
+        write_sarif(data, results_path.parent / "results.sarif")
+```
+
+Wire it into `pytest_sessionfinish`, immediately after the `results.json` write succeeds (right after `p.write_text(...)` at `plugin.py:1088`, before the `failures.json` block):
+
+```python
+    fmt = session.config.getoption("--vip-format", "json")
+    try:
+        _emit_extra_formats(fmt, p)
+    except OSError as exc:
+        warnings.warn(f"VIP: could not write extra formats: {exc}", stacklevel=1)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest selftests/test_plugin.py::TestFormatEmission -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vip/plugin.py selftests/test_plugin.py
+git commit -m "feat(plugin): emit JUnit/SARIF via --vip-format at session end"
+```
+
+---
+
+### Task 4: CLI `--format` and `--ci` flags
+
+**Files:**
+- Modify: `src/vip/cli.py` (add args to `verify_parser` near line 1359; forward in `run_verify` near line 471)
+- Test: `selftests/test_cli_verify.py` (add tests + extend `_make_args` defaults)
+
+**Interfaces:**
+- Consumes: existing `run_verify` command-assembly (`cli.py:456-492`); `args.report`, `args.format`, `args.ci`.
+- Produces: `vip verify --format json,junit,sarif` forwards `--vip-format=<validated>`; `vip verify --ci` forces `--vip-format=json,junit,sarif`, `--tb=short`, and non-interactive (no `--interactive-auth`/`--headless-auth`). Unknown `--format` value exits non-zero before launching pytest.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to selftests/test_cli_verify.py; also add to _make_args defaults:
+#     "format": "json",
+#     "ci": False,
+
+class TestFormatFlag:
+    def test_format_forwarded(self):
+        cmd = _capture_cmd(_make_args(format="json,junit,sarif"))
+        assert "--vip-format=json,junit,sarif" in cmd
+
+    def test_default_format_is_json(self):
+        cmd = _capture_cmd(_make_args())
+        assert "--vip-format=json" in cmd
+
+    def test_ci_flag_bundles_formats_and_tb_short(self):
+        cmd = _capture_cmd(_make_args(ci=True))
+        assert "--vip-format=json,junit,sarif" in cmd
+        assert "--tb=short" in cmd
+
+    def test_unknown_format_rejected(self):
+        with pytest.raises(SystemExit):
+            _capture_cmd(_make_args(format="json,bogus"))
+```
+
+(Add `import pytest` to the test file if not already present.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest selftests/test_cli_verify.py::TestFormatFlag -v`
+Expected: FAIL (`--vip-format` not in cmd / no SystemExit).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add args to `verify_parser` (after the `--report` block at `cli.py:1359`):
+
+```python
+    verify_parser.add_argument(
+        "--format",
+        default="json",
+        help="Comma-separated output formats: json,junit,sarif. json (results.json)"
+        " is always written; junit/sarif land beside --report. (default: json)",
+    )
+    verify_parser.add_argument(
+        "--ci",
+        action="store_true",
+        default=False,
+        help="CI preset: emit json,junit,sarif, use concise tracebacks, and run"
+        " strictly non-interactively.",
+    )
+```
+
+Forward in `run_verify` (replace the `if args.report:` block at `cli.py:470-471` region; insert format handling right after it):
+
+```python
+    if args.report:
+        cmd.append(f"--vip-report={args.report}")
+
+    _VALID_FORMATS = {"json", "junit", "sarif"}
+    fmt = "json,junit,sarif" if getattr(args, "ci", False) else getattr(args, "format", "json")
+    requested = [f.strip().lower() for f in fmt.split(",") if f.strip()]
+    unknown = [f for f in requested if f not in _VALID_FORMATS]
+    if unknown:
+        print(
+            f"Error: unknown --format value(s): {', '.join(unknown)}. "
+            f"Valid: {', '.join(sorted(_VALID_FORMATS))}.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    cmd.append(f"--vip-format={','.join(requested)}")
+```
+
+Then apply the `--ci` non-interactive + concise behavior. Add, just before `cmd.extend(args.pytest_args)` at `cli.py:492`:
+
+```python
+    if getattr(args, "ci", False):
+        cmd.append("--tb=short")
+```
+
+`--ci` non-interactivity is inherent: it does not set `interactive_auth`/`headless_auth`, and those default to `False`, so no browser is launched. (No extra code needed; covered by `_check_credentials` fail-fast.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest selftests/test_cli_verify.py -v`
+Expected: PASS (existing + new `TestFormatFlag`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vip/cli.py selftests/test_cli_verify.py
+git commit -m "feat(cli): add --format and --ci flags to vip verify"
+```
+
+---
+
+### Task 5: Container entrypoint rework
+
+**Files:**
+- Modify: `Dockerfile` (ENTRYPOINT/CMD near the end)
+
+**Interfaces:**
+- Consumes: the `vip` console-script installed by `uv sync` (`pyproject.toml [project.scripts] vip = "vip.cli:main"`).
+- Produces: `docker run <img>` runs `vip verify`; `docker run <img> status --json` (and other subcommands) reachable; `docker run <img> --ci` runs `vip verify --ci`.
+
+- [ ] **Step 1: Change the entrypoint**
+
+Replace the final two lines of `Dockerfile`:
+
+```dockerfile
+# Default entrypoint is the vip CLI; default subcommand is verify.
+# Config file should be mounted at /app/vip.toml
+ENTRYPOINT ["uv", "run", "vip"]
+
+# Default args: run verify. Override to reach other subcommands, e.g.
+#   docker run <img> status --json
+#   docker run <img> --ci
+CMD ["verify"]
+```
+
+- [ ] **Step 2: Verify the image builds and the entrypoint resolves**
+
+Run:
+```bash
+docker build -t vip-ci-test . && \
+docker run --rm --entrypoint uv vip-ci-test run vip --help | head -5
+```
+Expected: build succeeds; help output lists `verify`, `status`, `report` subcommands.
+
+(If Docker is unavailable in the environment, note this step as deferred-to-CI and verify the `Dockerfile` diff by inspection instead — `docker.yml` builds it on the PR.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat(docker): run the vip CLI as the container entrypoint"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `README.md` (add a "CI / pipeline integration" section)
+- Modify: `AGENTS.md` (if it enumerates `vip verify` options, add `--format`/`--ci`)
+
+**Interfaces:**
+- Consumes: the flags/behaviors from Tasks 1–5. No code.
+- Produces: user-facing docs. `CHANGELOG.md` is NOT hand-edited (semantic-release generates it from the `feat:` commits).
+
+- [ ] **Step 1: Add the README section**
+
+Add a section such as:
+
+````markdown
+## CI / pipeline integration
+
+VIP emits machine-readable output for security-ops and CI/CD pipelines.
+
+`vip verify` always writes `report/results.json` (and `report/failures.json` on
+failures). Add JUnit XML and/or SARIF with `--format`:
+
+```bash
+vip verify --format json,junit,sarif
+# report/results.json   (always)
+# report/junit.xml       (--format junit)  -> CI test dashboards
+# report/results.sarif   (--format sarif)  -> GitHub code scanning / secops
+```
+
+The `--ci` preset bundles all three formats with concise output and strict
+non-interactive behavior:
+
+```bash
+vip verify --ci
+```
+
+### Container
+
+An official image is published to `ghcr.io/posit-dev/vip`. The entrypoint is the
+`vip` CLI; the default subcommand is `verify`:
+
+```bash
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip --ci
+# other subcommands are reachable too:
+docker run --rm -v "$PWD/vip.toml:/app/vip.toml" ghcr.io/posit-dev/vip status --json
+```
+````
+
+- [ ] **Step 2: Update AGENTS.md if it lists verify options**
+
+Run: `grep -n "vip verify\|--report\|--verbose" AGENTS.md`
+If a `vip verify` options list exists, add one line each for `--format` and `--ci` mirroring the README wording. If no such list exists, skip (no change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md AGENTS.md
+git commit -m "docs: document --format, --ci, and the container entrypoint"
+```
+
+---
+
+### Task 7: Full verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint, format, types**
+
+Run:
+```bash
+uv run ruff check src/ selftests/ && \
+uv run ruff format --check src/ selftests/ && \
+uv run mypy src/
+```
+Expected: all pass.
+
+- [ ] **Step 2: Full selftest suite**
+
+Run: `uv run pytest selftests/ -q`
+Expected: all pass (baseline was 228 passed for the touched files; total suite green).
+
+- [ ] **Step 3: End-to-end smoke of the writers via the CLI path**
+
+Run:
+```bash
+uv run python -c "
+from pathlib import Path
+from vip.reporting import ReportData, TestResult, write_junit_xml, write_sarif
+d = ReportData(results=[TestResult(nodeid='tests/connect/t.py::a', outcome='failed', concise_error='x', scenario_title='A')])
+write_junit_xml(d, '/tmp/j.xml'); write_sarif(d, '/tmp/r.sarif')
+import xml.etree.ElementTree as ET, json
+ET.parse('/tmp/j.xml'); json.loads(Path('/tmp/r.sarif').read_text())
+print('OK: junit + sarif well-formed')
+"
+```
+Expected: `OK: junit + sarif well-formed`.
+
+- [ ] **Step 4: No commit** (verification task; fixes, if any, fold into the relevant task's commit)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- JUnit XML → Task 1. ✅
+- SARIF (all-outcomes, logical locations) → Task 2. ✅
+- Plugin wiring / `--vip-format` / siblings-in-report-dir / json-always-on → Task 3. ✅
+- CLI `--format` (comma-separated, validated) + `--ci` → Task 4. ✅
+- Container entrypoint rework → Task 5. ✅
+- Docs (README + AGENTS) → Task 6; CHANGELOG via semantic-release. ✅
+- Testing (TDD each writer + CLI) → Tasks 1–4 + sweep in Task 7. ✅
+
+**Type consistency:** `write_junit_xml(data, path)` / `write_sarif(data, path)` signatures match across reporting.py, plugin `_emit_extra_formats`, and tests. `--vip-format` (plugin) ↔ `--format`/`args.format`/`args.ci` (CLI) forwarding is consistent. `load_results(path)` reused for the dict→dataclass mapping (DRY).
+
+**Placeholder scan:** none — every code step is complete.
+
+**Out of scope (deferred):** per-format path override flags; multi-arch images; promoting VIP's own smoke workflows (#409).


### PR DESCRIPTION
## Summary

Makes VIP consumable by customer security-ops and CI/CD pipelines (issue #149, driven by FSI feedback). Adds machine-readable output formats, a one-flag CI preset, and a CLI-based container entrypoint.

Design + plan: `thoughts/shared/plans/2026-07-21-issue-149-ci-integration-design.md`.

## What's included

- **JUnit XML output** — `write_junit_xml()` in `reporting.py`, standard `testsuites/testsuite/testcase` schema with VIP's `concise_error` + scenario metadata; consumed by CI test dashboards.
- **SARIF 2.1.0 output** — `write_sarif()`, every check emitted as a result (fail=`error`, pass=`none`, skip=`note`) for a full compliance audit trail; ingested by GitHub code scanning / secops tooling.
- **`vip verify --format json,junit,sarif`** — comma-separated, additive. `results.json`/`failures.json` are always written (the HTML report depends on them); JUnit/SARIF land as siblings in the report dir.
- **`vip verify --ci`** — preset bundling `--format json,junit,sarif` + `--tb=short` + non-interactive.
- **Container entrypoint** — Dockerfile `ENTRYPOINT ["uv","run","vip"]` / `CMD ["verify"]`. Note: `docker run` args replace CMD, so the CI recipe is `docker run <img> verify --ci`.
- **Docs** — README "CI / pipeline integration" section.

## Issue #149 checklist advanced

- [x] JUnit XML output format
- [x] SARIF output format
- [x] CI-friendly entrypoint (`--ci`, exit codes, non-interactive)
- [x] Container entrypoint reworked to the `vip` CLI (GHCR build/push already existed via `docker.yml`)

## Testing

- 259 tests pass across `test_reporting`, `test_plugin`, `test_cli_verify`, `test_cli_report` (TDD throughout).
- End-to-end verified: a live pytest session with `--vip-format=json,junit,sarif` emits all sibling files; `--format json` emits no extras.
- `ruff` + `mypy` clean on changed files.

## Follow-ups (deferred, non-blocking)

- SARIF unknown-outcome default (currently dead code — pytest constrains outcomes).
- `--ci` regression test pinning non-interactive flags absent.
- `--format` value de-duplication (cosmetic; plugin folds to a set anyway).
- Multi-arch image; per-format path override flags.
