### PR TITLE
fix(workbench): reactivate Positron console tab before concluding no console

### DIFF
--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -277,6 +277,10 @@ _POSITRON_POLL_MS = 1_000
 # selecting immediately can miss R and fall back to the (less reliable) Python
 # console. Bounded so a genuinely R-less deployment settles quickly.
 _POSITRON_R_GRACE_POLLS = 10
+# Polls to let .positron-console re-render after activating the Console tab. A
+# console hidden behind the Terminal is removed from the DOM on some Positron
+# builds, so we activate + briefly poll before concluding no console exists.
+_POSITRON_REACTIVATE_POLLS = 3
 
 
 def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
@@ -302,8 +306,24 @@ def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
     Returns:
         ``True`` if a console is running, ``False`` otherwise.
     """
-    if page.locator(PositronSession.CONSOLE_PANEL).count() > 0:
-        return True
+    # One poll budget is shared across every phase below so the total wait is
+    # bounded by *timeout* rather than a multiple of it.
+    remaining = max(1, timeout // _POSITRON_POLL_MS)
+
+    # A console started earlier may be hidden behind the Terminal tab (a prior
+    # terminal_run selects it), which removes .positron-console from the DOM on
+    # some Positron builds. Activate the Console tab first and give the panel a
+    # moment to re-render, so an existing console is detected instead of being
+    # missed -- once a session exists its "Start New Console Session" button is
+    # gone, so a missed console would otherwise look like "no console" and fail.
+    _activate_positron_console(page)
+    reactivate = min(remaining, _POSITRON_REACTIVATE_POLLS)
+    while reactivate > 0:
+        if page.locator(PositronSession.CONSOLE_PANEL).count() > 0:
+            return True
+        page.wait_for_timeout(_POSITRON_POLL_MS)
+        reactivate -= 1
+        remaining -= 1
 
     start = page.locator(_POSITRON_START_BUTTON)
     if start.count() == 0:
@@ -312,10 +332,6 @@ def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
         start.first.click()
     except Exception:
         return False
-
-    # A single poll budget is shared across both phases below so the total wait
-    # is bounded by *timeout* rather than ~2x it.
-    remaining = max(1, timeout // _POSITRON_POLL_MS)
 
     # Phase 1: poll the interpreter quickpick — discovery lags the click on a
     # cold session (~10s live).


### PR DESCRIPTION
## Summary

Follow-up to #509. After that merged (VIP 0.56.0), the Workbench daily VIP verification's **preview** leg passes, but the **GA release** leg still fails `test_clone_positron`, now with:

```
terminal_run timed out after 120000ms waiting for done marker in '/tmp/vip_term_....txt'
```

Reproduced against the exact failing image (`ghcr.io/posit-dev/workbench:2026.07.1-147.pro6`, GA) and root-caused it as a distinct, build-specific race.

## Root cause

`terminal_run` runs the clone in the Positron **Terminal**, then reads the result back via the Positron **Console**. On the GA build (2026.07.1), selecting the Terminal tab **removes `.positron-console` from the DOM**. When the console readback then calls `ensure_positron_console`, it sees no console panel — and because a console session already exists, the "Start New Console Session" button is also gone — so it returns `False`, surfacing as `No Positron console could be started (no R/Python interpreter resolved)`. Every readback retry hits the same state, so `terminal_run` exhausts its budget and times out.

It's intermittent (depends on whether the Terminal held focus at readback time) and hit the GA image far more often (~1-in-3) than the daily/preview build, which is why #509 looked green on preview but the release leg kept failing. The console and interpreter are fine — the captured console showed `R 4.6.1 started.` — VIP just failed to *find* the backgrounded console.

## Fix

`ensure_positron_console` now activates the Console tab and briefly polls for `.positron-console` to re-render **before** falling through to the start-a-new-console path, so an existing (backgrounded) console is detected instead of being missed. The reactivation poll draws from the same shared `timeout` budget, so the total wait stays bounded (the existing self-test for that invariant still holds).

## Testing

- Reproduced the failure on the GA arm64 image, then verified the fix: `test_clone_positron` passed **12/12** (previously ~1-in-3 failed), alongside `test_clone_rstudio`, `test_clone_vscode`, and `test_launch_positron`.
- `selftests/test_workbench_exec.py`: 76 passed. `ruff check` / `format --check` clean.
