### PR TITLE
fix(install): invoke playwright via python -m for uv tool installs

### DIFF
--- a/.github/workflows/install-flow-smoke.yml
+++ b/.github/workflows/install-flow-smoke.yml
@@ -18,12 +18,14 @@ on:
     branches: [main]
     paths:
       - 'src/vip/install/**'
+      - 'src/vip/cli.py'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/install-flow-smoke.yml'
   pull_request:
     paths:
       - 'src/vip/install/**'
+      - 'src/vip/cli.py'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/install-flow-smoke.yml'
@@ -31,6 +33,14 @@ on:
 
 permissions:
   contents: read
+
+# In a container GitHub defaults `run:` steps to sh (dash), not bash, so any
+# bashism silently changes behavior (and `set -o pipefail` errors outright).
+# Force bash everywhere for consistent behavior across both jobs; GitHub's bash
+# default also runs with `-eo pipefail`.
+defaults:
+  run:
+    shell: bash
 
 jobs:
   ubuntu:
@@ -43,29 +53,31 @@ jobs:
     container:
       image: ubuntu:24.04
     steps:
+      # git for actions/checkout; ca-certificates for setup-uv's HTTPS download.
       - name: Install base tools
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends git curl ca-certificates
+          apt-get install -y --no-install-recommends git ca-certificates
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
+          enable-cache: true
 
       - name: Install vip as a uv tool (isolated venv, only vip on PATH)
-        run: uv tool install .
+        run: |
+          uv tool install .
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: vip install (default flow, as root)
         run: vip install
 
       - name: Assert Chromium was cached
         run: |
-          set -euo pipefail
           ls -d "$HOME/.cache/ms-playwright/chromium-"*
           echo "Chromium cache present."
 
@@ -79,6 +91,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
+          version: "0.11.28"
           enable-cache: true
 
       - name: Install vip as a uv tool (isolated venv, only vip on PATH)
@@ -91,6 +104,5 @@ jobs:
 
       - name: Assert Chromium was cached
         run: |
-          set -euo pipefail
           ls -d "$HOME/Library/Caches/ms-playwright/chromium-"*
           echo "Chromium cache present."

--- a/.github/workflows/install-flow-smoke.yml
+++ b/.github/workflows/install-flow-smoke.yml
@@ -1,0 +1,96 @@
+name: Install Flow Smoke
+
+# Reproduces the documented default install flow from README.md:
+#
+#   uv tool install posit-vip
+#   vip install
+#
+# `uv tool install` puts vip in an isolated venv and only exposes vip's own
+# entry point on PATH -- playwright's console script is NOT on PATH. Every other
+# install test runs `uv run vip install` from inside the project venv, where the
+# whole venv bin/ is on PATH, so this topology went untested and a bare
+# `playwright` lookup in `vip install` broke real users. This smoke installs vip
+# the way users do (from the local checkout, so it tests this branch) and runs
+# the bare `vip install`.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/vip/install/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/install-flow-smoke.yml'
+  pull_request:
+    paths:
+      - 'src/vip/install/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/install-flow-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu:
+    name: ubuntu-24.04 (uv tool, root)
+    runs-on: ubuntu-latest
+    # Bare ubuntu:24.04 as root faithfully replays the reported scenario: a full
+    # `vip install` that apt-installs the Chromium system libs itself and then
+    # runs the Playwright step. It is also the only CI job that exercises vip's
+    # own `apt install` path (src/vip/install/runner.py) as root.
+    container:
+      image: ubuntu:24.04
+    steps:
+      - name: Install base tools
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git curl ca-certificates
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install vip as a uv tool (isolated venv, only vip on PATH)
+        run: uv tool install .
+
+      - name: vip install (default flow, as root)
+        run: vip install
+
+      - name: Assert Chromium was cached
+        run: |
+          set -euo pipefail
+          ls -d "$HOME/.cache/ms-playwright/chromium-"*
+          echo "Chromium cache present."
+
+  macos:
+    name: macos-latest (uv tool)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install vip as a uv tool (isolated venv, only vip on PATH)
+        run: |
+          uv tool install .
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: vip install (default flow)
+        run: vip install
+
+      - name: Assert Chromium was cached
+        run: |
+          set -euo pipefail
+          ls -d "$HOME/Library/Caches/ms-playwright/chromium-"*
+          echo "Chromium cache present."

--- a/selftests/install/test_playwright.py
+++ b/selftests/install/test_playwright.py
@@ -143,7 +143,15 @@ def test_install_chromium_invokes_subprocess(monkeypatch):
 
     monkeypatch.setattr(pw.subprocess, "Popen", fake_popen)
     pw.install_chromium()
-    assert calls == [(pw.sys.executable, "-m", "playwright", "install", "chromium")]
+    assert len(calls) == 1
+    command = calls[0]
+    # Shape guard: the install path must never shell out to a bare tool name on
+    # PATH (which breaks under `uv tool install`); it must invoke the module with
+    # the current interpreter. Asserted as a shape, not just the exact tuple, so
+    # a newly-added bare-executable subprocess call is also caught.
+    assert command[0] == pw.sys.executable
+    assert command[1] == "-m"
+    assert command == (pw.sys.executable, "-m", "playwright", "install", "chromium")
 
 
 def test_install_chromium_raises_on_failure(monkeypatch):

--- a/selftests/install/test_playwright.py
+++ b/selftests/install/test_playwright.py
@@ -125,6 +125,16 @@ def _popen_factory(**kwargs):
 
 
 def test_install_chromium_invokes_subprocess(monkeypatch):
+    """Playwright must be invoked via ``python -m playwright`` using the current
+    interpreter, not a bare ``playwright`` executable on PATH.
+
+    When vip is installed with ``uv tool install posit-vip`` it lives in an
+    isolated venv and only vip's own entry point (``vip``) is exposed on PATH;
+    playwright's console script never lands in ``~/.local/bin``. A bare
+    ``playwright`` lookup then fails with ``[Errno 2] No such file or
+    directory``. Going through ``sys.executable -m playwright`` uses the same
+    interpreter vip is running under, where playwright is importable.
+    """
     calls = []
 
     def fake_popen(args, **kwargs):
@@ -133,7 +143,7 @@ def test_install_chromium_invokes_subprocess(monkeypatch):
 
     monkeypatch.setattr(pw.subprocess, "Popen", fake_popen)
     pw.install_chromium()
-    assert calls == [("playwright", "install", "chromium")]
+    assert calls == [(pw.sys.executable, "-m", "playwright", "install", "chromium")]
 
 
 def test_install_chromium_raises_on_failure(monkeypatch):

--- a/src/vip/install/playwright.py
+++ b/src/vip/install/playwright.py
@@ -113,8 +113,14 @@ def install_chromium() -> None:
     vip-attributed summary line.
     """
     try:
+        # Invoke via `python -m playwright` using the interpreter vip is running
+        # under, not a bare `playwright` executable on PATH. When vip is installed
+        # with `uv tool install posit-vip` it lives in an isolated venv and only
+        # vip's own entry point is exposed on PATH -- playwright's console script
+        # is not -- so a bare `playwright` lookup fails with ENOENT. Playwright is
+        # a dependency in that same venv, so `sys.executable -m playwright` finds it.
         proc = subprocess.Popen(
-            ["playwright", "install", "chromium"],
+            [sys.executable, "-m", "playwright", "install", "chromium"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,


### PR DESCRIPTION
## Problem

A fresh VIP install on Ubuntu 24.04 using the documented `uv tool install posit-vip` method fails at the Playwright step of `vip install`. The apt system-dependency step completes successfully, then:

```
Error: could not invoke playwright (is it installed?): [Errno 2] No such file or directory: 'playwright'
```

Reported in Slack by Monanshi Shah; Sam Cofer correctly suspected the new `uv tool` install method.

## Root cause

`install_chromium()` shelled out to a bare `playwright` executable:

```python
subprocess.Popen(["playwright", "install", "chromium"], ...)
```

When VIP is installed with `uv tool install posit-vip`, it lives in an isolated venv and `uv` only exposes the entry points declared by posit-vip (just `vip`) on the PATH. Playwright is a dependency inside that same venv, but its `playwright` console script never lands in `~/.local/bin`, so a bare PATH lookup fails with ENOENT.

This did not reproduce under the dev workflow (`uv sync` / `uv run`) because there the whole venv `bin/` is on PATH.

## Fix

Invoke Playwright through the interpreter VIP is already running under:

```python
subprocess.Popen([sys.executable, "-m", "playwright", "install", "chromium"], ...)
```

`sys.executable` points at the Python inside the uv tool's isolated venv, and playwright ships a `__main__.py`, so `python -m playwright install chromium` works whether VIP was installed via `uv tool`, `uv run`, or a plain pip venv.

## Test

Updated `test_install_chromium_invokes_subprocess` to assert the command is built as `sys.executable -m playwright ...` rather than a bare `playwright`, with a docstring explaining the uv-tool PATH failure mode. The existing "binary missing" and streaming/filter tests still pass unchanged.

All 115 install selftests pass; ruff lint + format clean.