### PR TITLE
feat(workbench): run IDE-launch tests under --api-auth via the Workbench API

### DIFF
--- a/selftests/test_clients_workbench_api.py
+++ b/selftests/test_clients_workbench_api.py
@@ -1,0 +1,260 @@
+"""Selftests for the Workbench Admin API client methods (#504).
+
+Exercise the Bearer auth header, the launch/get/stop request shapes (including
+the singular ``session_id`` vs plural ``session_ids`` gotcha), the
+``wait_for_active`` poll helper, and the IDE-value map. No real network
+connections are made: the client's internal httpx client is replaced with one
+backed by ``httpx.MockTransport``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from vip.clients.workbench import (
+    SESSION_ACTIVE_STATE,
+    SESSION_TERMINAL_FAILURE_STATES,
+    WORKBENCH_IDE_VALUES,
+    WorkbenchClient,
+    WorkbenchSessionError,
+)
+
+
+def _mock_client(handler, *, api_key: str = "", auth_scheme: str = "Key") -> WorkbenchClient:
+    """Build a WorkbenchClient whose httpx client uses a MockTransport.
+
+    The Authorization header computed by the constructor is preserved so tests
+    can assert on the auth scheme, unlike a bare replacement client.
+    """
+    wc = WorkbenchClient("https://wb.example.com", api_key=api_key, auth_scheme=auth_scheme)
+    headers = dict(wc._client.headers)
+    wc._client.close()
+    wc._client = httpx.Client(
+        base_url="https://wb.example.com",
+        headers=headers,
+        transport=httpx.MockTransport(handler),
+    )
+    return wc
+
+
+# ---------------------------------------------------------------------------
+# Auth scheme
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_scheme_sets_authorization_header():
+    captured: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers.get("Authorization")
+        return httpx.Response(200, json={"result": {"version": {"major": 2026}}})
+
+    wc = _mock_client(handler, api_key="tok", auth_scheme="Bearer")
+    wc.get_version()
+    assert captured["auth"] == "Bearer tok"
+
+
+def test_key_scheme_is_still_available_for_ui_cleanup_path():
+    captured: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers.get("Authorization")
+        return httpx.Response(200, json=[])
+
+    wc = _mock_client(handler, api_key="tok", auth_scheme="Key")
+    wc.list_sessions()
+    assert captured["auth"] == "Key tok"
+
+
+# ---------------------------------------------------------------------------
+# launch_session
+# ---------------------------------------------------------------------------
+
+
+def test_launch_session_posts_method_and_kwparams_and_returns_result():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"result": {"id": "s-1", "url": "/s/abc", "project_id": "p-1"}},
+        )
+
+    wc = _mock_client(handler)
+    result = wc.launch_session("RStudio", username="alice", name="VIP test_ide_launch_api.py - x")
+
+    assert seen["path"] == "/api/launch_session"
+    assert seen["body"]["method"] == "launch_session"
+    assert seen["body"]["kwparams"] == {
+        "workbench": "RStudio",
+        "username": "alice",
+        "name": "VIP test_ide_launch_api.py - x",
+    }
+    assert result == {"id": "s-1", "url": "/s/abc", "project_id": "p-1"}
+
+
+def test_launch_session_omits_optional_kwparams_when_not_given():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"result": {"id": "s-2"}})
+
+    wc = _mock_client(handler)
+    wc.launch_session("VS Code")
+    assert seen["body"]["kwparams"] == {"workbench": "VS Code"}
+
+
+def test_launch_session_raises_on_http_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": "forbidden"})
+
+    wc = _mock_client(handler)
+    with pytest.raises(httpx.HTTPStatusError):
+        wc.launch_session("RStudio", username="alice")
+
+
+# ---------------------------------------------------------------------------
+# get_session / stop_session — singular vs plural key gotcha
+# ---------------------------------------------------------------------------
+
+
+def test_get_session_uses_singular_session_id_key():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"result": {"activity_state": "running"}})
+
+    wc = _mock_client(handler)
+    wc.get_session("s-1", username="alice", fields=["id", "activity_state"])
+
+    assert seen["path"] == "/api/get_session"
+    kwparams = seen["body"]["kwparams"]
+    assert kwparams["session_id"] == "s-1"  # singular
+    assert "session_ids" not in kwparams
+    assert kwparams["user"] == "alice"  # from username
+    assert kwparams["fields"] == ["id", "activity_state"]
+
+
+def test_stop_session_uses_plural_session_ids_key():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"result": True})
+
+    wc = _mock_client(handler)
+    ok = wc.stop_session("s-1", force_quit=True)
+
+    assert ok is True
+    assert seen["path"] == "/api/stop_session"
+    kwparams = seen["body"]["kwparams"]
+    assert kwparams["session_ids"] == "s-1"  # plural
+    assert "session_id" not in kwparams
+    assert kwparams["force_quit"] is True
+
+
+def test_stop_session_joins_multiple_ids():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200)
+
+    wc = _mock_client(handler)
+    wc.stop_session(["s-1", "s-2", "s-3"])
+    assert seen["body"]["kwparams"]["session_ids"] == "s-1,s-2,s-3"
+
+
+def test_stop_session_never_raises_returns_false_on_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    wc = _mock_client(handler)
+    assert wc.stop_session("s-1") is False
+
+
+def test_stop_session_returns_false_on_4xx():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    wc = _mock_client(handler)
+    assert wc.stop_session("s-1") is False
+
+
+# ---------------------------------------------------------------------------
+# wait_for_active poll helper
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_active_returns_running_after_transition():
+    states = iter(["starting", "starting", "running"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"result": {"activity_state": next(states)}})
+
+    wc = _mock_client(handler)
+    state = wc.wait_for_active("s-1", timeout=5, poll_interval=0)
+    assert state == SESSION_ACTIVE_STATE
+
+
+def test_wait_for_active_raises_on_terminal_failure():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"result": {"activity_state": "failed"}})
+
+    wc = _mock_client(handler)
+    with pytest.raises(WorkbenchSessionError, match="terminal state"):
+        wc.wait_for_active("s-1", timeout=5, poll_interval=0)
+
+
+def test_wait_for_active_raises_on_timeout_when_stuck():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"result": {"activity_state": "starting"}})
+
+    wc = _mock_client(handler)
+    with pytest.raises(WorkbenchSessionError, match="did not reach"):
+        # timeout=0 forces the deadline check to fire after the first poll.
+        wc.wait_for_active("s-1", timeout=0, poll_interval=0)
+
+
+def test_wait_for_active_reads_state_from_list_result():
+    states = iter([[{"id": "s-1", "activity_state": "pending"}], [{"activity_state": "running"}]])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"result": next(states)})
+
+    wc = _mock_client(handler)
+    assert wc.wait_for_active("s-1", timeout=5, poll_interval=0) == "running"
+
+
+# ---------------------------------------------------------------------------
+# IDE value map — regression guard against a rename
+# ---------------------------------------------------------------------------
+
+
+def test_workbench_ide_values_are_exactly_the_five_docs_verified_values():
+    assert WORKBENCH_IDE_VALUES == {
+        "RStudio": "RStudio",
+        "VS Code": "VS Code",
+        "JupyterLab": "JupyterLab",
+        "Jupyter Notebook": "Jupyter Notebook",
+        "Positron": "Positron",
+    }
+
+
+@pytest.mark.parametrize("ide", ["RStudio", "VS Code", "JupyterLab", "Positron"])
+def test_launch_covered_ides_are_present(ide):
+    assert ide in WORKBENCH_IDE_VALUES
+
+
+def test_terminal_failure_states_are_stable():
+    assert SESSION_TERMINAL_FAILURE_STATES == ("failed", "killed")
+    assert SESSION_ACTIVE_STATE == "running"

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -473,6 +473,42 @@ class TestPluginIntegration:
         # which may contain "deselected" in the tmpdir path).
         assert "deselected" not in result.stdout.lines[-1]
 
+    def test_workbench_api_auth_retained_under_api_auth(self, selftest_pytester):
+        """Under --api-auth, a @workbench @api_auth test is retained while a
+        plain @workbench (browser) test is deselected.
+
+        This is the plumbing that lets the Workbench Admin-API IDE-launch
+        scenarios (#504) run under --api-auth without any plugin.py change:
+        _is_api_auth_only keeps auth-requiring tests that carry @api_auth.
+        Workbench must be *configured* (a URL) so the tests are not deselected
+        for product, which would mask the auth logic under test.
+        """
+        selftest_pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                '[workbench]\nurl = "https://wb.example.com"\n'
+            ),
+        )
+        selftest_pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.workbench
+            @pytest.mark.api_auth
+            def test_api_ok():
+                assert True
+
+            @pytest.mark.workbench
+            def test_needs_browser():
+                assert True
+            """
+        )
+        result = selftest_pytester.runpytest("--vip-config=vip.toml", "--api-auth", "-v")
+        # The api_auth test runs; the browser-only Workbench test is deselected.
+        result.assert_outcomes(passed=1)
+        result.stdout.fnmatch_lines(["*1 deselected*"])
+
     def test_bdd_parameterized_unconfigured_deselected(self, selftest_pytester):
         """A parameterized '<product> is configured' step should deselect
         when the product is not configured."""

--- a/selftests/test_workbench_ide_launch_api.py
+++ b/selftests/test_workbench_ide_launch_api.py
@@ -1,0 +1,80 @@
+"""Selftests for the Playwright-free step helpers in test_ide_launch_api.py (#504).
+
+Covers the pure skip/fail decision helpers that gate the Workbench API
+IDE-launch scenarios under ``--api-auth``:
+
+- ``_api_privilege_skip`` — the actionable 401/403 skip message
+- ``_ide_unavailable`` — classifying a 400 body as "IDE not installed" (skip)
+  vs an unclassifiable error (fail)
+
+No live Workbench deployment or Playwright browser is required. The step
+functions themselves need a running server, but these helpers are pure and
+decide skip-vs-fail, so they are worth guarding directly.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vip_tests.workbench.test_ide_launch_api import _api_privilege_skip, _ide_unavailable
+
+
+class TestApiPrivilegeSkip:
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_names_the_code_and_the_actionable_causes(self, code):
+        msg = _api_privilege_skip(code)
+        assert f"HTTP {code}" in msg
+        # The message must point at the three load-bearing requirements so the
+        # reader knows exactly why the API rejected the launch.
+        assert "super-admin" in msg
+        assert "workbench-api-super-admin-enabled=1" in msg
+        assert "VIP_WORKBENCH_API_KEY" in msg
+
+
+def _status_error(status_code: int, body: str) -> httpx.HTTPStatusError:
+    """Build an HTTPStatusError whose response carries *body* as text."""
+    request = httpx.Request("POST", "https://wb.example.com/api/launch_session")
+    response = httpx.Response(status_code, text=body, request=request)
+    return httpx.HTTPStatusError(f"{status_code}", request=request, response=response)
+
+
+class TestIdeUnavailable:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Unsupported workbench: Foo",
+            "unknown workbench value",
+            "That editor is not available on this server",
+            "no such workbench",
+            # Case-insensitivity: the classifier lowercases the body first.
+            "UNSUPPORTED WORKBENCH",
+        ],
+    )
+    def test_true_for_ide_not_installed_signals(self, body):
+        assert _ide_unavailable(_status_error(400, body)) is True
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Internal server error",
+            "launcher timed out starting the session",
+            "",  # empty body cannot be classified
+        ],
+    )
+    def test_false_for_unclassifiable_bodies(self, body):
+        # An unclassifiable 400 is a real bug and must fail, not skip.
+        assert _ide_unavailable(_status_error(400, body)) is False
+
+    def test_false_when_reading_the_body_raises(self):
+        # Defensive: a response whose .text access raises must not propagate —
+        # the helper degrades to "not classified" (fail), never crashes.
+        class _BoomResponse:
+            @property
+            def text(self) -> str:
+                raise RuntimeError("body unreadable")
+
+        class _Exc:
+            response = _BoomResponse()
+
+        assert _ide_unavailable(_Exc()) is False  # type: ignore[arg-type]

--- a/selftests/test_workbench_parallel.py
+++ b/selftests/test_workbench_parallel.py
@@ -123,6 +123,14 @@ class TestWorkbenchGroupName:
         assert wb._workbench_group_name({"rstudio"}, "test_ide_launch") == "workbench_ide_rstudio"
         assert wb._workbench_group_name({"positron"}, "test_ide_launch") == "workbench_ide_positron"
 
+    def test_api_ide_launch_groups_by_ide_like_the_ui_test(self):
+        # The API IDE-launch module (#504) carries the same IDE markers, so it
+        # shares the per-IDE group with the UI launch test.
+        assert (
+            wb._workbench_group_name({"rstudio"}, "test_ide_launch_api") == "workbench_ide_rstudio"
+        )
+        assert wb._workbench_group_name({"vscode"}, "test_ide_launch_api") == "workbench_ide_vscode"
+
     def test_non_ide_groups_by_module_stripping_test_prefix(self):
         assert wb._workbench_group_name(set(), "test_packages") == "workbench_packages"
         assert wb._workbench_group_name(set(), "test_git_ops") == "workbench_git_ops"

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,34 @@ logger = logging.getLogger(__name__)
 
 _VIP_SESSION_PREFIXES = ("VIP ", "_vip_")
 
+# Workbench Admin API session activity_state values (docs-verified against
+# docs.posit.co/ide/server-pro/admin/workbench_api). "running" is the ready
+# state; "failed"/"killed" are terminal so a waiter can fail fast instead of
+# waiting out the whole timeout.
+SESSION_ACTIVE_STATE = "running"
+SESSION_TERMINAL_FAILURE_STATES = ("failed", "killed")
+
+# IDE display name -> the exact `workbench` param value accepted by
+# launch_session. Case- and space-sensitive per the docs; do not "normalize".
+WORKBENCH_IDE_VALUES = {
+    "RStudio": "RStudio",
+    "VS Code": "VS Code",
+    "JupyterLab": "JupyterLab",
+    "Jupyter Notebook": "Jupyter Notebook",
+    "Positron": "Positron",
+}
+
+
+class WorkbenchSessionError(Exception):
+    """A launched session never reached the active state.
+
+    Raised by :meth:`WorkbenchClient.wait_for_active` when a session reaches a
+    terminal failure state or never becomes active before the timeout, so the
+    step layer can tell a deployment-side launch failure apart from an
+    HTTP/privilege error (which surfaces as ``httpx.HTTPStatusError``).
+    Parallels ``ResourceProfileDisabled`` in the workbench conftest.
+    """
+
 
 def is_vip_session(label: str) -> bool:
     """Return True if *label* matches a VIP-created session naming pattern.
@@ -29,6 +58,32 @@ def is_vip_session(label: str) -> bool:
     return any(label.startswith(prefix) for prefix in _VIP_SESSION_PREFIXES)
 
 
+def _session_activity_state(result: Any) -> str | None:
+    """Extract a single session's ``activity_state`` from a ``get_session`` result.
+
+    The Admin API's ``get_session`` result can take a few shapes depending on
+    the deployment/version: a single session dict carrying ``activity_state``
+    directly, a list of such dicts, or a dict keyed by session id.  This
+    normalizes those into the first ``activity_state`` string it finds, or
+    ``None`` when the payload has no recognizable session (a transient shape
+    the poll loop simply retries).
+    """
+    if isinstance(result, dict):
+        state = result.get("activity_state")
+        if isinstance(state, str):
+            return state
+        # dict keyed by session id -> session dict
+        for value in result.values():
+            if isinstance(value, dict) and isinstance(value.get("activity_state"), str):
+                return value["activity_state"]
+        return None
+    if isinstance(result, list):
+        for value in result:
+            if isinstance(value, dict) and isinstance(value.get("activity_state"), str):
+                return value["activity_state"]
+    return None
+
+
 class WorkbenchClient(BaseClient):
     """Minimal Workbench HTTP wrapper."""
 
@@ -37,15 +92,22 @@ class WorkbenchClient(BaseClient):
         base_url: str,
         api_key: str = "",
         *,
+        auth_scheme: str = "Key",
         timeout: float | None = None,
         insecure: bool = False,
         ca_bundle: Path | None = None,
         auth: httpx.Auth | None = None,
         cookies: httpx.Cookies | None = None,
     ) -> None:
+        # ``auth_scheme`` selects the ``Authorization`` header prefix. Default
+        # ``"Key"`` preserves the pre-existing UI-cleanup behavior; the root
+        # conftest passes ``"Bearer"`` for the Admin API (launch/get/stop),
+        # which is docs-verified to require ``Authorization: Bearer <token>``.
+        # The UI ``/api/sessions`` cleanup authenticates via cookies (see
+        # :meth:`set_cookies`), so the header scheme does not affect it.
         super().__init__(
             base_url,
-            auth_header_value=f"Key {api_key}" if api_key else "",
+            auth_header_value=f"{auth_scheme} {api_key}" if api_key else "",
             timeout=timeout,
             insecure=insecure,
             ca_bundle=ca_bundle,
@@ -69,6 +131,165 @@ class WorkbenchClient(BaseClient):
         resp = self._client.get("/api/server/settings")
         resp.raise_for_status()
         return resp.json()
+
+    def get_version(self) -> dict[str, Any]:
+        """Return the Workbench Admin API version payload.
+
+        ``GET /api/version`` → ``{"result": {"version": {...}, "features": ...}}``.
+        Used by the API-auth readiness guard to confirm the Admin API is
+        reachable and the Bearer token is accepted before any launch.  Raises
+        ``httpx.HTTPStatusError`` on a non-2xx (the guard maps 401/403 to a
+        skip and re-raises anything else).
+        """
+        resp = self._client.get("/api/version")
+        resp.raise_for_status()
+        return resp.json()
+
+    # -- Admin API (session launch/inspect/stop) ----------------------------
+
+    def launch_session(
+        self,
+        workbench: str,
+        *,
+        username: str | None = None,
+        name: str | None = None,
+        launch_parameters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Launch a session via the Admin API and return the ``result`` dict.
+
+        ``POST /api/launch_session`` with ``{"method": "launch_session",
+        "kwparams": {...}}``.  The IDE is selected by the ``workbench`` field
+        (one of :data:`WORKBENCH_IDE_VALUES`), *not* ``editor``.  A
+        super-admin token may pass ``username`` to launch on behalf of that
+        user.  ``name`` sets the session label (VIP passes a ``"VIP ..."`` name
+        so :func:`is_vip_session` matches it for cleanup).  ``launch_parameters``
+        is only required when Launcher-backed sessions are enabled; on Local
+        Launcher it is omitted rather than fabricated.
+
+        Raises ``httpx.HTTPStatusError`` on a non-2xx so the step layer can
+        decide skip-vs-fail from the status code.  Returns the ``result``
+        payload (``{"id", "url", "project_id"}``).
+        """
+        kwparams: dict[str, Any] = {"workbench": workbench}
+        if username is not None:
+            kwparams["username"] = username
+        if name is not None:
+            kwparams["name"] = name
+        if launch_parameters is not None:
+            kwparams["launch_parameters"] = launch_parameters
+        resp = self._client.post(
+            "/api/launch_session",
+            json={"method": "launch_session", "kwparams": kwparams},
+        )
+        resp.raise_for_status()
+        return resp.json()["result"]
+
+    def get_session(
+        self,
+        session_id: str | None = None,
+        *,
+        username: str | None = None,
+        fields: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Return the Admin API ``result`` for one or more sessions.
+
+        ``POST /api/get_session``.  Note the field is ``session_id``
+        (**singular**, comma-joined for multiple ids) — this differs from
+        :meth:`stop_session`'s plural ``session_ids``; the API is inconsistent
+        here.  The optional user filter is sent as ``user`` (from *username*).
+        Raises ``httpx.HTTPStatusError`` on a non-2xx.
+        """
+        kwparams: dict[str, Any] = {}
+        if session_id is not None:
+            kwparams["session_id"] = session_id
+        if username is not None:
+            kwparams["user"] = username
+        if fields is not None:
+            kwparams["fields"] = fields
+        resp = self._client.post(
+            "/api/get_session",
+            json={"method": "get_session", "kwparams": kwparams},
+        )
+        resp.raise_for_status()
+        return resp.json()["result"]
+
+    def stop_session(
+        self,
+        session_ids: str | Iterable[str],
+        *,
+        force_quit: bool = False,
+        suspend: bool = False,
+    ) -> bool:
+        """Best-effort stop of one or more sessions via the Admin API.
+
+        ``POST /api/stop_session`` with ``kwparams["session_ids"]``
+        (**plural**, comma-joined — differs from :meth:`get_session`'s singular
+        ``session_id``).  Like :meth:`quit_session`, this never raises: teardown
+        must not mask the test result.  Returns ``True`` when the call returned
+        a status below 400.
+        """
+        if isinstance(session_ids, str):
+            ids = session_ids
+        else:
+            ids = ",".join(str(sid) for sid in session_ids)
+        kwparams: dict[str, Any] = {"session_ids": ids}
+        if force_quit:
+            kwparams["force_quit"] = True
+        if suspend:
+            kwparams["suspend"] = True
+        try:
+            resp = self._client.post(
+                "/api/stop_session",
+                json={"method": "stop_session", "kwparams": kwparams},
+            )
+            return resp.status_code < 400
+        except Exception:
+            return False
+
+    def wait_for_active(
+        self,
+        session_id: str,
+        *,
+        username: str | None = None,
+        timeout: float,
+        poll_interval: float = 2.0,
+    ) -> str:
+        """Poll ``get_session`` until the session is active; return its state.
+
+        Returns ``"running"`` (:data:`SESSION_ACTIVE_STATE`) once the session
+        reaches it.  Fails fast by raising :class:`WorkbenchSessionError` if the
+        session hits a terminal failure state
+        (:data:`SESSION_TERMINAL_FAILURE_STATES`) so a dead session does not
+        wait out the full *timeout*, and raises :class:`WorkbenchSessionError`
+        on timeout naming the last-observed state.
+
+        The docs recommend the ``timestamp`` long-poll on ``get_session``; a
+        simple bounded poll (``time.monotonic`` deadline + ``time.sleep``) is
+        sufficient here and matches the repo's UI-poll style.
+        """
+        deadline = time.monotonic() + timeout
+        last_state = "unknown"
+        while True:
+            result = self.get_session(
+                session_id, username=username, fields=["id", "activity_state", "running"]
+            )
+            last_state = _session_activity_state(result) or last_state
+            if last_state == SESSION_ACTIVE_STATE:
+                return last_state
+            if last_state in SESSION_TERMINAL_FAILURE_STATES:
+                raise WorkbenchSessionError(
+                    f"Workbench session {session_id!r} reached terminal state "
+                    f"{last_state!r} instead of {SESSION_ACTIVE_STATE!r}. The "
+                    "deployment could not launch the session — verify the launcher, "
+                    "the session image, and available CPU/memory/quota."
+                )
+            if time.monotonic() >= deadline:
+                raise WorkbenchSessionError(
+                    f"Workbench session {session_id!r} did not reach "
+                    f"{SESSION_ACTIVE_STATE!r} within {timeout:.0f}s "
+                    f"(last observed state: {last_state!r})."
+                )
+            time.sleep(poll_interval)
 
     # -- Sessions -----------------------------------------------------------
 

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -101,6 +101,11 @@ def workbench_client(
     client = WorkbenchClient(
         vip_config.workbench.url,
         api_key=vip_config.workbench.api_key,
+        # The Workbench Admin API (IDE-launch under --api-auth) requires an
+        # ``Authorization: Bearer <token>`` header. The UI-facing /api/sessions
+        # cleanup path authenticates via cookies, so this scheme is only
+        # consumed by the Admin API methods.
+        auth_scheme="Bearer",
         insecure=vip_config.insecure,
         ca_bundle=vip_config.ca_bundle,
         auth=auth,

--- a/src/vip_tests/workbench/test_ide_launch_api.feature
+++ b/src/vip_tests/workbench/test_ide_launch_api.feature
@@ -1,0 +1,29 @@
+@workbench @api_auth
+Feature: Workbench IDE launch via the Admin API
+  As a Posit Team administrator whose Workbench is behind non-scriptable SSO
+  I want to verify each IDE launches using only a Workbench API token
+  So that I can confirm session-launch works without a browser login
+
+  Scenario: RStudio session launches via the API and becomes active
+    Given a Workbench API token that can launch sessions
+    When I launch the "RStudio" IDE for the test user via the API
+    Then the session reaches the active state
+    And the session is stopped via the API
+
+  Scenario: VS Code session launches via the API and becomes active
+    Given a Workbench API token that can launch sessions
+    When I launch the "VS Code" IDE for the test user via the API
+    Then the session reaches the active state
+    And the session is stopped via the API
+
+  Scenario: JupyterLab session launches via the API and becomes active
+    Given a Workbench API token that can launch sessions
+    When I launch the "JupyterLab" IDE for the test user via the API
+    Then the session reaches the active state
+    And the session is stopped via the API
+
+  Scenario: Positron session launches via the API and becomes active
+    Given a Workbench API token that can launch sessions
+    When I launch the "Positron" IDE for the test user via the API
+    Then the session reaches the active state
+    And the session is stopped via the API

--- a/src/vip_tests/workbench/test_ide_launch_api.py
+++ b/src/vip_tests/workbench/test_ide_launch_api.py
@@ -1,0 +1,201 @@
+"""Step definitions for Workbench IDE launch via the Admin API (--api-auth).
+
+Under ``--api-auth`` with a Workbench **super-admin** token these scenarios run
+the IDE-launch checks purely through the Workbench Admin API — no browser is
+used. Each scenario launches an IDE on behalf of the test user, polls until the
+session is ``running``, then stops it. This is the Workbench analog of the
+Connect API-key path: valuable for SSO-fronted deployments where browser auth
+is not scriptable but an admin can mint an API token.
+
+Layer 2 only: these steps are thin and talk exclusively to ``WorkbenchClient``.
+There is deliberately no ``page``/Playwright import anywhere in this module —
+that is the "API-only interaction" guarantee.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+
+from vip.clients.workbench import (
+    WORKBENCH_IDE_VALUES,
+    WorkbenchSessionError,
+)
+from vip.timeouts import scaled
+from vip_tests.workbench.conftest import unique_session_name
+
+pytestmark = pytest.mark.order(20)
+
+_FILENAME = "test_ide_launch_api.py"
+
+
+@pytest.mark.workbench
+@pytest.mark.rstudio
+@scenario("test_ide_launch_api.feature", "RStudio session launches via the API and becomes active")
+def test_launch_rstudio_api():
+    pass
+
+
+@pytest.mark.workbench
+@pytest.mark.vscode
+@scenario("test_ide_launch_api.feature", "VS Code session launches via the API and becomes active")
+def test_launch_vscode_api():
+    pass
+
+
+@pytest.mark.workbench
+@pytest.mark.jupyter
+@scenario(
+    "test_ide_launch_api.feature",
+    "JupyterLab session launches via the API and becomes active",
+)
+def test_launch_jupyter_api():
+    pass
+
+
+@pytest.mark.workbench
+@pytest.mark.positron
+@scenario("test_ide_launch_api.feature", "Positron session launches via the API and becomes active")
+def test_launch_positron_api():
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _api_privilege_skip(code: int) -> str:
+    """Build the actionable skip message for a 401/403 from the Admin API."""
+    return (
+        f"Workbench Admin API returned HTTP {code}. IDE-launch over the API requires a "
+        "super-admin token (admin tokens cannot launch sessions) on an Enhanced/Advanced "
+        "deployment with workbench-api-super-admin-enabled=1 in rserver.conf. Verify the "
+        "token type and that VIP_WORKBENCH_API_KEY is a super-admin token."
+    )
+
+
+def _ide_unavailable(exc: httpx.HTTPStatusError) -> bool:
+    """Return True if a 400 body signals the requested IDE is not available.
+
+    An IDE that is simply not installed on the deployment should *skip*
+    (mirrors the UI test's "IDE not available … skip"), whereas an
+    unclassifiable 400 is a real bug and should fail. Reads the response body
+    defensively — never raises.
+    """
+    try:
+        body = exc.response.text.lower()
+    except Exception:
+        return False
+    signals = ("unsupported", "unknown workbench", "not available", "no such workbench")
+    return any(signal in body for signal in signals)
+
+
+# ---------------------------------------------------------------------------
+# Teardown safety net
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wb_api_state(workbench_client):
+    """Hold the launched session id across steps; stop it on teardown if it leaks.
+
+    Best-effort: if a scenario errors before the "session is stopped" step, this
+    finalizer force-quits any still-tracked session so it does not orphan. Never
+    raises — mirrors ``session_context``'s finalizer in the UI launch test. The
+    end-of-run ``_wb_cleanup_state`` sweep in conftest re-sweeps VIP-named
+    sessions via the API key as a further backstop.
+    """
+    state: dict = {"client": None, "username": None, "session_id": None, "ide": None}
+    yield state
+    sid = state.get("session_id")
+    client = state.get("client")
+    if sid and client is not None:
+        try:
+            client.stop_session(sid, force_quit=True)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Steps
+# ---------------------------------------------------------------------------
+
+
+@given("a Workbench API token that can launch sessions", target_fixture="wb_api")
+def wb_api_ready(workbench_client, vip_config, test_username, wb_api_state):
+    """Guard: skip gracefully unless a launch-capable API token + user are present.
+
+    Workbench API-auth is opt-in and tier-gated, so a missing token/user or an
+    unreachable/unauthorized Admin API is a *skip* (not a fail) — the correct
+    layer for the graceful degradation the request calls for.
+    """
+    if workbench_client is None:
+        pytest.skip("Workbench is not configured")
+    if not vip_config.workbench.api_key:
+        pytest.skip(
+            "Workbench API IDE-launch requires an API token. "
+            "Set VIP_WORKBENCH_API_KEY to a super-admin token and run with --api-auth."
+        )
+    if not test_username:
+        pytest.skip(
+            "Workbench API launch-on-behalf requires a target user. "
+            "Set VIP_TEST_USERNAME (or [auth] username) to the test account to launch as."
+        )
+    # Confirm the API is reachable and the token is accepted before any launch.
+    try:
+        workbench_client.get_version()
+    except httpx.HTTPStatusError as exc:
+        code = exc.response.status_code
+        if code in (401, 403):
+            pytest.skip(_api_privilege_skip(code))
+        raise
+    except httpx.HTTPError as exc:
+        pytest.skip(f"Workbench Admin API not reachable at {workbench_client.base_url}: {exc}")
+    wb_api_state["client"] = workbench_client
+    wb_api_state["username"] = test_username
+    return wb_api_state
+
+
+@when(parsers.parse('I launch the "{ide}" IDE for the test user via the API'))
+def launch_ide(wb_api, ide):
+    """Launch *ide* on behalf of the test user; skip on privilege/availability."""
+    if ide not in WORKBENCH_IDE_VALUES:
+        pytest.fail(f"Unknown IDE {ide!r}; expected one of {sorted(WORKBENCH_IDE_VALUES)}")
+    name = unique_session_name(_FILENAME)  # "VIP ..." -> is_vip_session matches for cleanup
+    try:
+        result = wb_api["client"].launch_session(
+            WORKBENCH_IDE_VALUES[ide], username=wb_api["username"], name=name
+        )
+    except httpx.HTTPStatusError as exc:
+        code = exc.response.status_code
+        if code in (401, 403):
+            pytest.skip(_api_privilege_skip(code))
+        if code == 400 and _ide_unavailable(exc):
+            pytest.skip(f"{ide} is not available for launch on this Workbench deployment.")
+        raise
+    wb_api["session_id"] = result["id"]
+    wb_api["ide"] = ide
+
+
+@then("the session reaches the active state")
+def session_active(wb_api, vip_config):
+    """Poll until the launched session is running; a never-active session fails."""
+    timeout = scaled(vip_config.workbench.job_timeout)
+    try:
+        wb_api["client"].wait_for_active(
+            wb_api["session_id"], username=wb_api["username"], timeout=timeout
+        )
+    except WorkbenchSessionError as exc:
+        # Deployment couldn't bring the session up — a real failure, not a skip.
+        raise AssertionError(str(exc)) from exc
+
+
+@then("the session is stopped via the API")
+def session_stopped(wb_api):
+    """Stop the session and clear the tracked id so the finalizer is a no-op."""
+    sid = wb_api.get("session_id")
+    if sid:
+        wb_api["client"].stop_session(sid, force_quit=True)
+        wb_api["session_id"] = None

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -43,6 +43,13 @@ url = "https://workbench.example.com"
 
 # API key for a Workbench admin user.
 # Prefer setting the VIP_WORKBENCH_API_KEY environment variable.
+#
+# For `vip verify --api-auth` (browser-less IDE-launch checks), this must be a
+# SUPER-ADMIN token — admin tokens cannot launch sessions. Requires the
+# Enhanced or Advanced tier with `workbench-api-super-admin-enabled=1` in
+# rserver.conf. Generate with:
+#   rstudio-server generate-api-token super-admin 'vip' <token-owner-username>
+# The IDE-launch tests launch on behalf of [auth] username / VIP_TEST_USERNAME.
 # api_key = "..."
 #
 # Session capacity testing (requires --interactive-auth).

--- a/website/src/pages/getting-started.astro
+++ b/website/src/pages/getting-started.astro
@@ -148,6 +148,22 @@ vip verify --connect-url https://connect.example.com --api-auth</code></pre>
             This is useful in CI pipelines or environments where interactive
             login is not possible and no test user credentials are available.
           </p>
+          <p>
+            <strong>Workbench under <code>--api-auth</code>.</strong> Workbench
+            runs only the IDE-launch checks (RStudio, VS Code, JupyterLab,
+            Positron) over the Workbench Admin API — the browser-only Workbench
+            tests (capacity, sessions, jobs, runtime versions, extensions, git)
+            are skipped. This path requires a <strong>super-admin</strong> token
+            (admin tokens cannot launch sessions) on an Enhanced or Advanced
+            deployment with <code>workbench-api-super-admin-enabled=1</code> in
+            <code>rserver.conf</code>. Generate one with
+            <code>rstudio-server generate-api-token super-admin 'vip' &lt;owner&gt;</code>.
+            The checks launch sessions on behalf of <code>VIP_TEST_USERNAME</code>,
+            so set that (no password is needed) alongside the token:
+          </p>
+          <pre><code>export VIP_WORKBENCH_API_KEY="your-super-admin-token"
+export VIP_TEST_USERNAME="test-user"
+vip verify --workbench-url https://workbench.example.com --api-auth</code></pre>
 
           <h3>Credential-based auth</h3>
           <p>


### PR DESCRIPTION
Closes #504.

Under `--api-auth` with a Workbench **super-admin** API token, the four IDE-launch checks (RStudio, VS Code, JupyterLab, Positron) now run purely via the Workbench Admin API — no browser. This is the Workbench analog of Connect's API-key path (#222) for SSO-fronted deployments where browser auth isn't scriptable but an admin can mint a token.

## Changes

- **`WorkbenchClient`** (`src/vip/clients/workbench.py`): `auth_scheme` kwarg (default `"Key"` preserves the UI-cleanup path); new `get_version` / `launch_session` / `get_session` / `stop_session` / `wait_for_active`; `WorkbenchSessionError`; IDE-value and session-state constants. Encodes the API's singular `session_id` vs plural `session_ids` inconsistency.
- **New `test_ide_launch_api.{feature,py}`**: `@workbench @api_auth`, 4 scenarios, thin steps calling only `WorkbenchClient` (zero Playwright imports). Graceful skips for missing token/user and 401/403/unavailable-IDE; a teardown finalizer force-quits any leaked session.
- **`src/vip_tests/conftest.py`**: `workbench_client` passes `auth_scheme="Bearer"` for the Admin API.
- **Docs/config**: `vip.toml.example` super-admin token guidance; website `getting-started.astro` Workbench `--api-auth` coverage note.

No `plugin.py` change was needed — `_is_api_auth_only` already retains `@api_auth` tests under `--api-auth`.

## Tests (all run in CI, no products required)

- `selftests/test_clients_workbench_api.py` — client methods via `MockTransport` (Bearer header, request shapes, poll helper, IDE map)
- `selftests/test_workbench_ide_launch_api.py` — step skip/fail helpers (`_api_privilege_skip`, `_ide_unavailable`)
- `selftests/test_plugin.py` — `@workbench @api_auth` retained under `--api-auth` while plain `@workbench` is deselected
- `selftests/test_workbench_parallel.py` — per-IDE xdist grouping for the new module

Full selftest suite: **1161 passed**. `ruff check`/`format` and `mypy src/vip/` clean.

## Not covered

- **Live CI validation**: the `with-workbench` smoke image doesn't enable the super-admin API (Enhanced/Advanced tier + `workbench-api-super-admin-enabled=1`), so there's no live CI run. Requires manual validation against a real Enhanced/Advanced Workbench + super-admin token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)