### PR TITLE
fix(workbench): drive file chooser for Workbench Job script selection

### DIFF
--- a/selftests/test_pages.py
+++ b/selftests/test_pages.py
@@ -119,3 +119,21 @@ class TestRStudioSessionWorkbenchJobsSelectors:
         assert "#rstudio_tb_startworkbenchjob" in RStudioSession.WORKBENCH_JOB_NEW_BUTTON
         assert "Start Workbench Job" in RStudioSession.WORKBENCH_JOB_NEW_BUTTON
         assert "#rstudio_dlg_ok" in RStudioSession.WORKBENCH_JOB_SUBMIT_BUTTON
+
+    def test_script_field_targets_the_readonly_picker_by_id(self):
+        # The Workbench Job script field is a readonly FileChooserTextBox; the
+        # step must never fill() it. Guard the exact id so a future selector
+        # broadening does not accidentally reintroduce the .fill() timeout bug.
+        assert RStudioSession.WORKBENCH_JOB_SCRIPT_INPUT == "#rstudio_tbb_text_pro_job_script"
+
+    def test_script_browse_button_targets_current_id(self):
+        # Browse... button that opens the Choose File dialog (verified live CDP).
+        assert (
+            "#rstudio_tbb_button_pro_job_script"
+            in RStudioSession.WORKBENCH_JOB_SCRIPT_BROWSE_BUTTON
+        )
+
+    def test_file_chooser_selectors_target_current_ids(self):
+        assert "#file_dialog_name_prompt" in RStudioSession.FILE_CHOOSER_NAME_INPUT
+        assert "#rstudio_file_accept_open" in RStudioSession.FILE_CHOOSER_OPEN_BUTTON
+        assert "Open" in RStudioSession.FILE_CHOOSER_OPEN_BUTTON

--- a/src/vip_tests/workbench/pages/rstudio_session.py
+++ b/src/vip_tests/workbench/pages/rstudio_session.py
@@ -63,6 +63,26 @@ class RStudioSession:
         "#rstudio_tb_startworkbenchjob, button:text-is('Start Workbench Job'), "
         "button:text-is('Run Script as Workbench Job')"
     )
+    # The "Run Script as Workbench Job" dialog's script-path field
+    # (#rstudio_tbb_text_pro_job_script) is a readonly FileChooserTextBox on
+    # Launcher deployments -- it CANNOT be typed into. The script is chosen via
+    # its adjacent "Browse..." button (#rstudio_tbb_button_pro_job_script),
+    # which opens a "Choose File" dialog. Verified live over CDP against
+    # Workbench 2026.07.0, and in rstudio-pro source (FileChooserTextBox is
+    # constructed readOnly=true unless browseButtonDisabled, which is only true
+    # for local-launcher sessions without path mapping -- readonly since 2021).
+    WORKBENCH_JOB_SCRIPT_INPUT = "#rstudio_tbb_text_pro_job_script"
+    WORKBENCH_JOB_SCRIPT_BROWSE_BUTTON = (
+        "#rstudio_tbb_button_pro_job_script, "
+        "#rstudio_tbb_text_pro_job_script ~ button:has-text('Browse')"
+    )
+    # The "Choose File" dialog opened by the Browse button. Its name field is a
+    # real editable input; typing a filename + clicking Open populates the
+    # readonly script box above. The file must already exist or Open is rejected.
+    FILE_CHOOSER_NAME_INPUT = "#file_dialog_name_prompt"
+    FILE_CHOOSER_OPEN_BUTTON = "#rstudio_file_accept_open, button:text-is('Open')"
+    FILE_CHOOSER_CANCEL_BUTTON = "#rstudio_file_cancel_open, button:text-is('Cancel')"
+
     # The submission dialog's OK button (#rstudio_dlg_ok) is captioned "Start"
     # ("Submit" kept as a text fallback for older builds).
     WORKBENCH_JOB_SUBMIT_BUTTON = (

--- a/src/vip_tests/workbench/test_jobs.feature
+++ b/src/vip_tests/workbench/test_jobs.feature
@@ -10,6 +10,7 @@ Feature: Workbench job execution
     And the user writes a test R script file via the console
     And the user runs the script as a Background Job
     Then the Background Job completes with expected output
+    And the test script file is removed
     And the job test session is cleaned up
 
   Scenario: Workbench Job runs and completes
@@ -21,4 +22,5 @@ Feature: Workbench job execution
     And the user writes a test R script file via the console
     And the user runs the script as a Workbench Job
     Then the Workbench Job completes with expected output
+    And the test script file is removed
     And the job test session is cleaned up

--- a/src/vip_tests/workbench/test_jobs.py
+++ b/src/vip_tests/workbench/test_jobs.py
@@ -190,30 +190,33 @@ def rstudio_ide_loaded(page: Page):
     expect(page.locator(ConsolePaneSelectors.INPUT)).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
 
 
-@when("the user writes a test R script file via the console")
-def write_test_script(page: Page):
-    """Write the test R script to a file using writeLines() in the R console."""
+def _run_console_command(page: Page, r_cmd: str) -> None:
+    """Type a single-line R expression into the console and submit it.
+
+    The console input is an Ace editor <div>, not a real <input>/<textarea>,
+    so Locator.fill() raises "Element is not an <input>...". Select-all +
+    delete clears any leftover text, then real keystrokes are typed into the
+    focused hidden Ace textarea (matches test_packages.py). ControlOrMeta maps
+    select-all to Cmd+A on macOS, where Ctrl+A is "go to line start" and would
+    not clear the input.
+    """
     console_input = page.locator(ConsolePaneSelectors.INPUT)
     expect(console_input).to_be_visible(timeout=TIMEOUT_DIALOG)
     console_input.click()
-
-    # Build the writeLines() call as a single-line R expression.
-    escaped = _JOB_SCRIPT_CONTENT.replace('"', '\\"')
-    r_cmd = f'writeLines("{escaped}", "{_JOB_SCRIPT_FILENAME}")'
-    # The console input is an Ace editor <div>, not a real <input>/<textarea>,
-    # so Locator.fill() raises "Element is not an <input>...". Select-all +
-    # delete to clear any leftover text, then type real keystrokes into the
-    # focused hidden Ace textarea (matches test_packages.py). Use ControlOrMeta
-    # so select-all maps to Cmd+A on macOS, where Ctrl+A is "go to line start"
-    # and would not clear the input.
     page.keyboard.press("ControlOrMeta+a")
     page.keyboard.press("Backspace")
     console_input.type(r_cmd)
     console_input.press("Enter")
-
     # Wait for the prompt to return (console is ready for next command).
     time.sleep(1)
     expect(console_input).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
+
+
+@when("the user writes a test R script file via the console")
+def write_test_script(page: Page):
+    """Write the test R script to a file using writeLines() in the R console."""
+    escaped = _JOB_SCRIPT_CONTENT.replace('"', '\\"')
+    _run_console_command(page, f'writeLines("{escaped}", "{_JOB_SCRIPT_FILENAME}")')
 
 
 @when("the user runs the script as a Background Job")
@@ -278,18 +281,60 @@ def run_as_workbench_job(page: Page, job_context: dict):
         pytest.skip("Run Script as Workbench Job button not found")
     new_btn.click()
 
-    # Fill in the script path in the submission dialog.
-    script_input = page.locator(RStudioSession.BACKGROUND_JOB_SCRIPT_INPUT)
-    try:
-        script_input.wait_for(state="visible", timeout=TIMEOUT_DIALOG)
-    except PlaywrightTimeoutError:
-        pytest.skip("Workbench Job script input not found")
-    script_input.fill(_JOB_SCRIPT_FILENAME)
+    # Select the script via the file chooser. Unlike the Background Job dialog,
+    # the Workbench Job dialog's script field (#rstudio_tbb_text_pro_job_script)
+    # is a readonly FileChooserTextBox on Launcher deployments -- calling
+    # fill() on it times out with "element is not editable". Instead click its
+    # "Browse..." button, type the filename into the Choose File dialog, and
+    # click Open, which populates the readonly field. (Verified live over CDP
+    # against Workbench 2026.07.0.)
+    _select_workbench_job_script(page, _JOB_SCRIPT_FILENAME)
 
     # Submit.
     submit_btn = page.locator(RStudioSession.WORKBENCH_JOB_SUBMIT_BUTTON)
     expect(submit_btn).to_be_visible(timeout=TIMEOUT_QUICK)
     submit_btn.click()
+
+
+def _select_workbench_job_script(page: Page, script_filename: str) -> None:
+    """Choose *script_filename* in the Workbench Job dialog via its file chooser.
+
+    The script-path field is a readonly picker, so the path is set by driving
+    the "Browse..." button → "Choose File" dialog → type name → Open, mirroring
+    the RStudio Pro UI's only supported interaction. Skips gracefully if the
+    dialog's controls are not present (an unexpected build variant) rather than
+    hanging on an opaque timeout.
+    """
+    browse_btn = page.locator(RStudioSession.WORKBENCH_JOB_SCRIPT_BROWSE_BUTTON).first
+    try:
+        browse_btn.wait_for(state="visible", timeout=TIMEOUT_DIALOG)
+    except PlaywrightTimeoutError:
+        pytest.skip("Workbench Job script Browse button not found in the submission dialog")
+    browse_btn.click()
+
+    # The Choose File dialog's name field IS editable -- type the filename there.
+    name_input = page.locator(RStudioSession.FILE_CHOOSER_NAME_INPUT)
+    try:
+        name_input.wait_for(state="visible", timeout=TIMEOUT_DIALOG)
+    except PlaywrightTimeoutError:
+        pytest.skip("Workbench Job file chooser did not open")
+    name_input.fill(script_filename)
+
+    open_btn = page.locator(RStudioSession.FILE_CHOOSER_OPEN_BUTTON).first
+    expect(open_btn).to_be_visible(timeout=TIMEOUT_QUICK)
+    open_btn.click()
+
+    # Confirm the readonly script field was populated before submitting -- if
+    # the chosen file was rejected (e.g. it does not exist), the field stays
+    # empty and submitting would fail with a less actionable error.
+    script_field = page.locator(RStudioSession.WORKBENCH_JOB_SCRIPT_INPUT)
+    try:
+        expect(script_field).not_to_have_value("", timeout=TIMEOUT_DIALOG)
+    except AssertionError:
+        pytest.skip(
+            f"Workbench Job script field was not populated after choosing "
+            f"{script_filename!r} — the file may not exist in the session home directory"
+        )
 
 
 def _wait_for_job_completion(page: Page, job_timeout_s: int) -> None:
@@ -335,6 +380,23 @@ def workbench_job_completed(page: Page, vip_config: VIPConfig):
             f"Expected job output {_JOB_EXPECTED_OUTPUT!r} not found in job output: "
             f"{output_text[:200]!r}"
         )
+
+
+@then("the test script file is removed")
+def remove_test_script(page: Page):
+    """Delete the test R script from the session home directory via the console.
+
+    The job test writes ``test_job_vip.R`` into the session's working directory
+    (persistent shared storage on Workbench). Quitting the session does not
+    remove it, so without this step the file accumulates across runs. Runs
+    before the session-quit step while the console is still available.
+    Best-effort: file cleanup must never fail the job result, so any error
+    (console gone, command not accepted) is swallowed.
+    """
+    try:
+        _run_console_command(page, f'suppressWarnings(file.remove("{_JOB_SCRIPT_FILENAME}"))')
+    except Exception:
+        pass
 
 
 @then("the job test session is cleaned up")

--- a/src/vip_tests/workbench/test_jobs.py
+++ b/src/vip_tests/workbench/test_jobs.py
@@ -38,6 +38,14 @@ pytestmark = pytest.mark.order(60)
 # R script that the job runs — output used for verification.
 _JOB_SCRIPT_CONTENT = 'Sys.sleep(2)\ncat("hello from job\\n")'
 _JOB_SCRIPT_FILENAME = "test_job_vip.R"
+# Absolute, home-anchored path used for every file operation on the script.
+# The R console writes and removes it, the Background Job dialog fills it, and
+# the Workbench Job file chooser selects it. Anchoring to ~ (rather than a bare
+# relative name resolved against the session's getwd()) guarantees the write
+# step, the file chooser, and the cleanup step all reference the SAME file
+# regardless of the working directory. R (writeLines/file.remove) and the
+# RStudio file chooser both tilde-expand this path.
+_JOB_SCRIPT_PATH = f"~/{_JOB_SCRIPT_FILENAME}"
 _JOB_EXPECTED_OUTPUT = "hello from job"
 
 _FILENAME = Path(__file__).name
@@ -216,7 +224,9 @@ def _run_console_command(page: Page, r_cmd: str) -> None:
 def write_test_script(page: Page):
     """Write the test R script to a file using writeLines() in the R console."""
     escaped = _JOB_SCRIPT_CONTENT.replace('"', '\\"')
-    _run_console_command(page, f'writeLines("{escaped}", "{_JOB_SCRIPT_FILENAME}")')
+    # writeLines tilde-expands the path, so the file lands in the session home
+    # directory — the same location the file chooser and cleanup step target.
+    _run_console_command(page, f'writeLines("{escaped}", "{_JOB_SCRIPT_PATH}")')
 
 
 @when("the user runs the script as a Background Job")
@@ -249,7 +259,7 @@ def run_as_background_job(page: Page, job_context: dict):
         script_input.wait_for(state="visible", timeout=TIMEOUT_DIALOG)
     except PlaywrightTimeoutError:
         pytest.skip("Background Job script input not found")
-    script_input.fill(_JOB_SCRIPT_FILENAME)
+    script_input.fill(_JOB_SCRIPT_PATH)
 
     # Submit the job.
     run_btn = page.locator(RStudioSession.BACKGROUND_JOB_RUN_BUTTON)
@@ -288,7 +298,7 @@ def run_as_workbench_job(page: Page, job_context: dict):
     # "Browse..." button, type the filename into the Choose File dialog, and
     # click Open, which populates the readonly field. (Verified live over CDP
     # against Workbench 2026.07.0.)
-    _select_workbench_job_script(page, _JOB_SCRIPT_FILENAME)
+    _select_workbench_job_script(page, _JOB_SCRIPT_PATH)
 
     # Submit.
     submit_btn = page.locator(RStudioSession.WORKBENCH_JOB_SUBMIT_BUTTON)
@@ -303,7 +313,9 @@ def _select_workbench_job_script(page: Page, script_filename: str) -> None:
     the "Browse..." button → "Choose File" dialog → type name → Open, mirroring
     the RStudio Pro UI's only supported interaction. Skips gracefully if the
     dialog's controls are not present (an unexpected build variant) rather than
-    hanging on an opaque timeout.
+    hanging on an opaque timeout. Once the dialog IS open and Open is clicked,
+    an empty script field is a real defect (not a capability gap), so it fails
+    rather than skips.
     """
     browse_btn = page.locator(RStudioSession.WORKBENCH_JOB_SCRIPT_BROWSE_BUTTON).first
     try:
@@ -324,17 +336,20 @@ def _select_workbench_job_script(page: Page, script_filename: str) -> None:
     expect(open_btn).to_be_visible(timeout=TIMEOUT_QUICK)
     open_btn.click()
 
-    # Confirm the readonly script field was populated before submitting -- if
-    # the chosen file was rejected (e.g. it does not exist), the field stays
-    # empty and submitting would fail with a less actionable error.
+    # Confirm the readonly script field was populated before submitting. By this
+    # point the dialog opened and Open was clicked, so Workbench Jobs IS
+    # available on this deployment -- an empty field is a genuine regression
+    # (rejected file, changed chooser contract), not a capability gap. Fail
+    # loudly with the chosen path rather than skipping and masking the defect.
     script_field = page.locator(RStudioSession.WORKBENCH_JOB_SCRIPT_INPUT)
-    try:
-        expect(script_field).not_to_have_value("", timeout=TIMEOUT_DIALOG)
-    except AssertionError:
-        pytest.skip(
-            f"Workbench Job script field was not populated after choosing "
-            f"{script_filename!r} — the file may not exist in the session home directory"
-        )
+    expect(
+        script_field,
+        (
+            f"Workbench Job script field stayed empty after choosing {script_filename!r} via "
+            f"the file chooser — the file may not exist at that path, or the chooser contract "
+            f"changed"
+        ),
+    ).not_to_have_value("", timeout=TIMEOUT_DIALOG)
 
 
 def _wait_for_job_completion(page: Page, job_timeout_s: int) -> None:
@@ -386,15 +401,16 @@ def workbench_job_completed(page: Page, vip_config: VIPConfig):
 def remove_test_script(page: Page):
     """Delete the test R script from the session home directory via the console.
 
-    The job test writes ``test_job_vip.R`` into the session's working directory
+    The job test writes ``test_job_vip.R`` into the session home directory
     (persistent shared storage on Workbench). Quitting the session does not
-    remove it, so without this step the file accumulates across runs. Runs
-    before the session-quit step while the console is still available.
-    Best-effort: file cleanup must never fail the job result, so any error
-    (console gone, command not accepted) is swallowed.
+    remove it, so without this step the file accumulates across runs. Removes
+    the same home-anchored path the write step created. Runs before the
+    session-quit step while the console is still available. Best-effort: file
+    cleanup must never fail the job result, so any error (console gone, command
+    not accepted) is swallowed.
     """
     try:
-        _run_console_command(page, f'suppressWarnings(file.remove("{_JOB_SCRIPT_FILENAME}"))')
+        _run_console_command(page, f'suppressWarnings(file.remove("{_JOB_SCRIPT_PATH}"))')
     except Exception:
         pass
 


### PR DESCRIPTION
## Problem

`workbench/test_jobs.py::test_workbench_job[chromium]` fails with:

```
Locator.fill: Timeout 30000ms exceeded.
  locator resolved to <input readonly ... id="rstudio_tbb_text_pro_job_script"/>
  - element is not editable
```

The "Run Script as Workbench Job" dialog's script-path field is a **readonly** `FileChooserTextBox` on Launcher deployments — `.fill()` on it can never succeed. PR #513 correctly fixed the stale *navigation* selectors (tab/panel/button), which let the test reach this step for the first time and thereby unmasked this long-standing incompatibility (the field has been readonly-by-default in rstudio-pro since 2021).

## Root cause (verified live)

Investigated the live RStudio Pro DOM over CDP against **Workbench 2026.07.0**. The script is selected via a file chooser, not typed:

| Step | Element |
|---|---|
| Jobs tab | `#rstudio_workbench_tab_workbench_jobs` |
| Start button | `#rstudio_tb_startworkbenchjob` |
| Script field (**readonly**) | `#rstudio_tbb_text_pro_job_script` |
| **Browse…** | `#rstudio_tbb_button_pro_job_script` |
| Choose File name input (editable) | `#file_dialog_name_prompt` |
| Open | `#rstudio_file_accept_open` |
| Submit ("Start") | `#rstudio_dlg_ok` |

## Fix

- **`rstudio_session.py`**: add `WORKBENCH_JOB_SCRIPT_INPUT` (the readonly picker), `WORKBENCH_JOB_SCRIPT_BROWSE_BUTTON`, and `FILE_CHOOSER_*` selectors.
- **`test_jobs.py`**: `_select_workbench_job_script()` drives Browse → Choose File → type filename → Open, and asserts the readonly field actually populated before submitting (graceful skip otherwise). Replaces the broken `.fill()`.
- **`test_jobs.feature` / `.py`**: new **"the test script file is removed"** step — the job writes `test_job_vip.R` into the session home dir (persistent shared storage), which quitting the session does not clean up. This removes it so it doesn't accumulate across runs.
- **`test_pages.py`**: guard the exact selector IDs, including pinning `WORKBENCH_JOB_SCRIPT_INPUT` so the `.fill()` regression cannot silently return.

## Verification

Ran the full flow live (create script via console → select via file chooser → submit → verify job status → remove script) against **both** RStudio Pro sessions, exercising the exact page-object IDs:

- **`pwb.demo.soleng.posit.it`** (Local launcher) → job **Succeeded**
- **`dev.current.posit.team`** (Kubernetes launcher) → job **Running** (submitted successfully)

Same selectors work across both launcher backends. Test script removed from both session home dirs afterward.

`ruff check`/`format` clean; **1131 selftests pass** (incl. the new `test_pages.py` guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)