### PR TITLE
fix(workbench): harden Workbench Job flow against write/chooser races

### DIFF
--- a/src/vip_tests/workbench/pages/rstudio_session.py
+++ b/src/vip_tests/workbench/pages/rstudio_session.py
@@ -89,8 +89,20 @@ class RStudioSession:
         "#rstudio_dlg_ok, button:text-is('Start'), button:text-is('Submit')"
     )
 
-    # Job status (shared between Background and Workbench Jobs)
+    # Job status (shared between Background and Workbench Jobs).
+    #
+    # On the Workbench Jobs (Launcher) panel the completed status renders as a
+    # single leaf DIV whose text fuses the word and a timestamp, e.g.
+    # "Succeeded 4:25 PM", inside a GWT-obfuscated class (not "job-status").
+    # An exact-match (:text-is('Succeeded')) or span-only selector therefore
+    # never matches, so job completion polling timed out at the full job
+    # timeout even though the job succeeded. ``:text('Succeeded')`` selects the
+    # smallest element *containing* the substring on any tag, matching that
+    # fused leaf. Verified live over CDP against Workbench 2026.07.0. The prior
+    # exact/span selectors are kept as fallbacks for the Background Jobs panel
+    # and older builds.
     JOB_STATUS_SUCCEEDED = (
+        "*:text('Succeeded'), *:text('Completed'), "
         "span:text-is('Succeeded'), span:text-is('Completed'), "
         "[class*='job-status']:text-is('Succeeded')"
     )

--- a/src/vip_tests/workbench/test_jobs.py
+++ b/src/vip_tests/workbench/test_jobs.py
@@ -222,11 +222,42 @@ def _run_console_command(page: Page, r_cmd: str) -> None:
 
 @when("the user writes a test R script file via the console")
 def write_test_script(page: Page):
-    """Write the test R script to a file using writeLines() in the R console."""
+    """Write the test R script to a file using writeLines() and confirm it landed.
+
+    The console is an Ace editor driven by real keystrokes, which can be dropped
+    if the console has not fully settled after the IDE loads. A dropped
+    ``writeLines()`` leaves no file, and the Workbench Job file chooser then
+    silently rejects Open (the file must exist), so the readonly script field
+    stays empty and the failure only surfaces later as an opaque empty-field
+    error. Verify ``file.exists()`` right here so a dropped write fails loudly at
+    its source with the path, rather than masquerading as a chooser regression.
+    """
     escaped = _JOB_SCRIPT_CONTENT.replace('"', '\\"')
     # writeLines tilde-expands the path, so the file lands in the session home
     # directory — the same location the file chooser and cleanup step target.
     _run_console_command(page, f'writeLines("{escaped}", "{_JOB_SCRIPT_PATH}")')
+    _assert_script_file_exists(page)
+
+
+def _assert_script_file_exists(page: Page) -> None:
+    """Fail loudly if the test script is not on disk after the write step.
+
+    Emits a unique sentinel alongside ``file.exists()`` and reads it back from
+    the console output, so a dropped ``writeLines()`` (or a write to an
+    unexpected directory) is caught at the write step — before the file chooser
+    turns it into an empty-script-field mystery.
+    """
+    marker = "VIP_JOB_SCRIPT_CHECK"
+    _run_console_command(page, f'cat("{marker}:", file.exists("{_JOB_SCRIPT_PATH}"), "\\n")')
+    output = page.locator(ConsolePaneSelectors.OUTPUT_ELEMENT)
+    expect(
+        output,
+        (
+            f"Test R script {_JOB_SCRIPT_PATH!r} was not created by the console write step — "
+            f"the writeLines() keystrokes may have been dropped before the console settled, or "
+            f"the file landed outside the session home directory"
+        ),
+    ).to_contain_text(f"{marker}: TRUE", timeout=TIMEOUT_CODE_EXEC)
 
 
 @when("the user runs the script as a Background Job")
@@ -289,7 +320,7 @@ def run_as_workbench_job(page: Page, job_context: dict):
         new_btn.wait_for(state="visible", timeout=TIMEOUT_DIALOG)
     except PlaywrightTimeoutError:
         pytest.skip("Run Script as Workbench Job button not found")
-    new_btn.click()
+    _open_workbench_job_dialog(page, new_btn)
 
     # Select the script via the file chooser. Unlike the Background Job dialog,
     # the Workbench Job dialog's script field (#rstudio_tbb_text_pro_job_script)
@@ -304,6 +335,49 @@ def run_as_workbench_job(page: Page, job_context: dict):
     submit_btn = page.locator(RStudioSession.WORKBENCH_JOB_SUBMIT_BUTTON)
     expect(submit_btn).to_be_visible(timeout=TIMEOUT_QUICK)
     submit_btn.click()
+
+
+def _open_workbench_job_dialog(page: Page, new_btn) -> None:
+    """Click the "Start Workbench Job" toolbar button until its dialog opens.
+
+    The button is a GWT toolbar widget whose first click does not always open
+    the "Run Script as Workbench Job" dialog — the click can land before the
+    handler is armed, leaving the dialog closed and the later Browse-button
+    wait to skip as if the feature were absent. Re-click a few times, checking
+    for the Browse button (the dialog's first interactive control) between
+    attempts, so a dropped first click self-heals instead of masquerading as a
+    capability gap. Verified live over CDP against Workbench 2026.07.0.
+    """
+    browse_btn = page.locator(RStudioSession.WORKBENCH_JOB_SCRIPT_BROWSE_BUTTON).first
+    for _ in range(3):
+        new_btn.click()
+        try:
+            browse_btn.wait_for(state="visible", timeout=TIMEOUT_DIALOG)
+            return
+        except PlaywrightTimeoutError:
+            continue
+    # Final attempt surfaces the real state to _select_workbench_job_script,
+    # which skips with a precise message if the Browse button never appears.
+    new_btn.click()
+
+
+def _fill_until_stable(locator, value: str, attempts: int = 5) -> None:
+    """Fill *locator* with *value*, re-filling until the value stays put.
+
+    The Workbench Job file chooser clears its name field ~1s after it first
+    appears (GWT finishes initializing it), silently wiping an early fill(). Fill
+    the field, wait past that reset window, and re-fill if it was cleared, so the
+    value survives into the Open click regardless of when the reset lands.
+    """
+    for _ in range(attempts):
+        locator.fill(value)
+        # Wait out the chooser's post-init reset, then check the value held.
+        locator.page.wait_for_timeout(TIMEOUT_QUICK // 4)
+        if locator.input_value() == value:
+            return
+    # One last fill; the caller's downstream check reports an empty script field
+    # with a precise message if the value still refuses to stick.
+    locator.fill(value)
 
 
 def _select_workbench_job_script(page: Page, script_filename: str) -> None:
@@ -330,7 +404,13 @@ def _select_workbench_job_script(page: Page, script_filename: str) -> None:
         name_input.wait_for(state="visible", timeout=TIMEOUT_DIALOG)
     except PlaywrightTimeoutError:
         pytest.skip("Workbench Job file chooser did not open")
-    name_input.fill(script_filename)
+
+    # The chooser clears the name field ~1s after it first appears, as GWT
+    # finishes initializing it. A fill() that lands before that reset is wiped,
+    # so Open then submits an empty name and the readonly script field stays
+    # empty. Fill, then re-fill through the reset until the value sticks, before
+    # clicking Open. Verified live over CDP against Workbench 2026.07.0.
+    _fill_until_stable(name_input, script_filename)
 
     open_btn = page.locator(RStudioSession.FILE_CHOOSER_OPEN_BUTTON).first
     expect(open_btn).to_be_visible(timeout=TIMEOUT_QUICK)


### PR DESCRIPTION
## Summary

`test_workbench_job[chromium]` failed with an opaque *"script field stayed empty after choosing '~/test_job_vip.R'"* error. That single symptom masked **three distinct defects** in the Workbench Job (Launcher) submission flow. Each was reproduced live over CDP against a real deployment (`pwb.demo`, Workbench 2026.07.0) before fixing, and the fix was verified by installing this branch as a uv tool and running the test to a green pass twice consecutively.

## The three bugs

1. **Fire-and-forget console write (root cause of the reported failure).** `write_test_script` typed `writeLines(...)` into the Ace console without confirming the file landed. The Ace console silently drops keystrokes if it hasn't settled after IDE load, so the script was never created, the file chooser silently rejected Open, and the readonly script field stayed empty — surfacing far downstream as the opaque error. Now the write step asserts `file.exists()` via a console sentinel, failing loudly at the source.

2. **Wrong completion selector.** `JOB_STATUS_SUCCEEDED` used `span:text-is('Succeeded')`, but the Launcher panel renders `"Succeeded <time>"` fused in a single obfuscated-class `DIV`. The exact-match/span-only selector never matched, so completion polling ran out the full 120s timeout even though the job had succeeded. Now matches by substring on any tag, keeping the exact/span selectors as fallbacks.

3. **Two GWT races.** The "Start Workbench Job" toolbar button does not reliably open its dialog on the first click, and the Choose File name field is cleared ~1s after it appears during GWT init (wiping an early `fill()`). Now re-click until the dialog opens, and re-fill the name field through the reset until the value sticks.

## Testing

- `test_workbench_job[chromium]` — **PASSED** twice consecutively against `pwb.demo` (Workbench 2026.07.0).
- `test_background_job` still skips for a pre-existing, unrelated reason (that deployment has no Background Jobs tab).
- 1131 selftests pass; ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)