### PR TITLE
fix(workbench): keep JupyterLab sessions fresh to stop launch/exec skip

### DIFF
--- a/selftests/test_workbench_jupyter_cleanup.py
+++ b/selftests/test_workbench_jupyter_cleanup.py
@@ -1,0 +1,145 @@
+"""Selftests for the JupyterLab notebook-cleanup helpers on WorkbenchClient.
+
+These cover the pure URL/header builders and the ``delete_jupyter_notebook``
+method (via an ``httpx.MockTransport``), so the contents-API teardown that keeps
+JupyterLab sessions fresh is exercised without a live Workbench.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vip.clients.workbench import (
+    WorkbenchClient,
+    jupyterlab_app_base,
+    jupyterlab_contents_delete_url,
+    jupyterlab_xsrf_headers,
+)
+
+# -- jupyterlab_app_base -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "page_url, expected",
+    [
+        # Standard per-session proxy prefix, notebook open under /lab/tree.
+        (
+            "https://wb.example.com/s/abc123/lab/tree/Untitled.ipynb",
+            "https://wb.example.com/s/abc123",
+        ),
+        # Bare /lab root.
+        ("https://wb.example.com/s/abc123/lab", "https://wb.example.com/s/abc123"),
+        # Query string and fragment are stripped.
+        (
+            "https://wb.example.com/s/xyz/lab/tree/Untitled1.ipynb?reset#cell",
+            "https://wb.example.com/s/xyz",
+        ),
+        # No /lab segment — return the URL trimmed rather than raising.
+        ("https://wb.example.com/s/abc123/", "https://wb.example.com/s/abc123"),
+        # Real Workbench shape (validated live via CDP on pwb.demo): JupyterLab
+        # inserts a /lab/workspaces/<id>/tree/<nb> segment. The base must still
+        # cut at /lab and match PageConfig.baseUrl (".../s/<sid>").
+        (
+            "https://pwb.demo.soleng.posit.it/s/0da2921f2ed72297f2efa/lab/workspaces/auto-m/tree/Untitled7.ipynb",
+            "https://pwb.demo.soleng.posit.it/s/0da2921f2ed72297f2efa",
+        ),
+    ],
+)
+def test_jupyterlab_app_base(page_url, expected):
+    assert jupyterlab_app_base(page_url) == expected
+
+
+# -- jupyterlab_contents_delete_url ------------------------------------------
+
+
+def test_contents_delete_url_basic():
+    url = jupyterlab_contents_delete_url(
+        "https://wb.example.com/s/abc123/lab/tree/Untitled.ipynb", "Untitled.ipynb"
+    )
+    assert url == "https://wb.example.com/s/abc123/api/contents/Untitled.ipynb"
+
+
+def test_contents_delete_url_quotes_spaces_and_strips_slashes():
+    url = jupyterlab_contents_delete_url("https://wb.example.com/s/abc123/lab", "/_vip run 1.ipynb")
+    # Leading slash stripped, space percent-encoded.
+    assert url == "https://wb.example.com/s/abc123/api/contents/_vip%20run%201.ipynb"
+
+
+# -- jupyterlab_xsrf_headers -------------------------------------------------
+
+
+def test_xsrf_headers_present():
+    assert jupyterlab_xsrf_headers({"_xsrf": "tok123"}) == {"X-XSRFToken": "tok123"}
+
+
+def test_xsrf_headers_absent():
+    assert jupyterlab_xsrf_headers({"other": "v"}) == {}
+
+
+# -- delete_jupyter_notebook (MockTransport) ---------------------------------
+
+
+def _client_with_handler(handler) -> WorkbenchClient:
+    wc = WorkbenchClient("https://wb.example.com")
+    wc._client.close()
+    wc._client = httpx.Client(
+        base_url="https://wb.example.com",
+        transport=httpx.MockTransport(handler),
+    )
+    return wc
+
+
+def test_delete_notebook_success_sends_xsrf_and_targets_contents_api():
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["xsrf"] = request.headers.get("X-XSRFToken")
+        return httpx.Response(204)
+
+    wc = _client_with_handler(handler)
+    ok = wc.delete_jupyter_notebook(
+        "https://wb.example.com/s/abc123/lab/tree/Untitled.ipynb",
+        "Untitled.ipynb",
+        {"_xsrf": "tok123"},
+    )
+    assert ok is True
+    assert seen["method"] == "DELETE"
+    assert seen["path"] == "/s/abc123/api/contents/Untitled.ipynb"
+    assert seen["xsrf"] == "tok123"
+
+
+def test_delete_notebook_404_treated_as_success():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    wc = _client_with_handler(handler)
+    assert (
+        wc.delete_jupyter_notebook("https://wb.example.com/s/abc/lab", "Untitled.ipynb", {}) is True
+    )
+
+
+def test_delete_notebook_server_error_is_false():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    wc = _client_with_handler(handler)
+    assert (
+        wc.delete_jupyter_notebook(
+            "https://wb.example.com/s/abc/lab", "Untitled.ipynb", {"_xsrf": "t"}
+        )
+        is False
+    )
+
+
+def test_delete_notebook_transport_error_is_false():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    wc = _client_with_handler(handler)
+    assert (
+        wc.delete_jupyter_notebook("https://wb.example.com/s/abc/lab", "Untitled.ipynb", {})
+        is False
+    )

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -29,6 +29,57 @@ def is_vip_session(label: str) -> bool:
     return any(label.startswith(prefix) for prefix in _VIP_SESSION_PREFIXES)
 
 
+def jupyterlab_app_base(page_url: str) -> str:
+    """Return the JupyterLab app-root URL from a session page URL.
+
+    A Workbench JupyterLab session is served under a per-session proxy prefix,
+    e.g. ``https://wb.example.com/s/abc123/lab/tree/Untitled.ipynb``.  The
+    JupyterLab server (and its ``/api/contents`` REST surface) is mounted at the
+    segment ending in ``/lab`` — everything *before* ``/lab`` is the app base
+    (``https://wb.example.com/s/abc123``).  The returned value has no trailing
+    slash.  If the URL has no ``/lab`` segment (unexpected), the input is
+    returned with any query/fragment and trailing slash stripped, so callers
+    still get a usable base rather than raising mid-teardown.
+    """
+    # Drop query string and fragment first — the contents API path is built
+    # fresh, so anything after ``?``/``#`` is irrelevant and would corrupt the base.
+    core = page_url.split("?", 1)[0].split("#", 1)[0]
+    marker = "/lab"
+    idx = core.find(marker)
+    if idx != -1:
+        return core[:idx].rstrip("/")
+    return core.rstrip("/")
+
+
+def jupyterlab_contents_delete_url(page_url: str, notebook_name: str) -> str:
+    """Build the ``DELETE /api/contents/<notebook>`` URL for a JupyterLab session.
+
+    *page_url* is the current session page URL (see :func:`jupyterlab_app_base`);
+    *notebook_name* is the notebook's filename as shown on its dock tab (e.g.
+    ``"Untitled.ipynb"``).  The name is URL-quoted so spaces/special characters
+    in a renamed notebook do not break the path.  Any leading slashes on the
+    name are stripped so the result is always ``<app_base>/api/contents/<name>``.
+    """
+    from urllib.parse import quote
+
+    base = jupyterlab_app_base(page_url)
+    clean = notebook_name.strip().lstrip("/")
+    return f"{base}/api/contents/{quote(clean)}"
+
+
+def jupyterlab_xsrf_headers(cookies: dict[str, str]) -> dict[str, str]:
+    """Return the XSRF header JupyterLab requires for mutating contents-API calls.
+
+    JupyterLab protects non-GET ``/api`` requests with a double-submit token:
+    the ``_xsrf`` cookie value must be echoed back in the ``X-XSRFToken`` header.
+    Returns ``{"X-XSRFToken": <value>}`` when the cookie is present, or an empty
+    dict when it is absent (older/token-auth deployments) so the caller can still
+    attempt the request without sending a bogus header.
+    """
+    token = cookies.get("_xsrf")
+    return {"X-XSRFToken": token} if token else {}
+
+
 class WorkbenchClient(BaseClient):
     """Minimal Workbench HTTP wrapper."""
 
@@ -75,6 +126,39 @@ class WorkbenchClient(BaseClient):
     def set_cookies(self, cookies: dict[str, str]) -> None:
         """Set cookies on the client instance for authenticated requests."""
         self._client.cookies.update(cookies)
+
+    def delete_jupyter_notebook(
+        self, page_url: str, notebook_name: str, cookies: dict[str, str]
+    ) -> bool:
+        """Delete a notebook file from a live JupyterLab session's contents API.
+
+        Sends ``DELETE <app_base>/api/contents/<notebook_name>`` authenticated
+        with the browser session *cookies* and the ``X-XSRFToken`` header
+        JupyterLab requires for mutating calls (see
+        :func:`jupyterlab_contents_delete_url` / :func:`jupyterlab_xsrf_headers`).
+
+        This exists so a test that creates a notebook can remove it *before the
+        session is quit* — the contents API only exists while the session is
+        alive — so JupyterLab's layout-restorer stops reopening stale
+        ``Untitled*.ipynb`` tabs (and eagerly starting their kernels) on every
+        subsequent session launch, which widens the launch/exec interaction race.
+
+        Returns True when the server accepts the delete (HTTP < 400, including
+        the ``204`` success and a ``404`` for an already-absent file), False on
+        any other status or transport error.  Never raises — teardown cleanup is
+        a best-effort safety net, not an assertion.
+        """
+        url = jupyterlab_contents_delete_url(page_url, notebook_name)
+        headers = jupyterlab_xsrf_headers(cookies)
+        try:
+            # Set cookies on the client instance (per-request cookies= is
+            # deprecated in httpx and its persistence semantics are ambiguous).
+            self._client.cookies.update(cookies)
+            resp = self._client.request("DELETE", url, headers=headers)
+        except Exception:
+            return False
+        # 404 → already gone, treat as success (idempotent teardown).
+        return resp.status_code < 400 or resp.status_code == 404
 
     def list_sessions(self) -> list[dict[str, Any]]:
         """List active sessions for the authenticated user."""

--- a/src/vip_tests/workbench/pages/jupyterlab_session.py
+++ b/src/vip_tests/workbench/pages/jupyterlab_session.py
@@ -26,6 +26,19 @@ class JupyterLabSession:
     DIALOG = ".jp-Dialog"
     DIALOG_ACCEPT = ".jp-Dialog .jp-Dialog-button.jp-mod-accept"
 
+    # Kernel execution-status indicator on the notebook toolbar. JupyterLab sets
+    # its ``data-status`` to "idle" once the kernel is connected and ready, and
+    # "busy" while a cell is running. Gating the first cell run on "idle" avoids
+    # typing/running before the kernel has finished connecting, which drops the
+    # input and produces the spurious "kernel did not produce output" timeout.
+    KERNEL_STATUS = ".jp-Notebook-ExecutionIndicator"
+    KERNEL_STATUS_IDLE = ".jp-Notebook-ExecutionIndicator[data-status='idle']"
+
+    # Current (active) notebook tab in the dock area. Its label text is the
+    # notebook's filename (e.g. "Untitled.ipynb"), used to build the contents-API
+    # path for teardown deletion.
+    CURRENT_TAB_LABEL = ".lm-DockPanel-tabBar .lm-TabBar-tab.jp-mod-current .lm-TabBar-tabLabel"
+
     # Sidebar
     FILE_BROWSER = ".jp-FileBrowser"
     SIDEBAR_LEFT = ".jp-SideBar.jp-mod-left"

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -73,15 +73,26 @@ def test_launch_positron():
 
 
 @pytest.fixture
-def session_context(page: Page, workbench_url: str):
+def session_context(page: Page, workbench_url: str, workbench_client):
     """Holds session name across steps, with best-effort cleanup on skip/fail.
 
     If a session was started (``name`` is set) and the test aborted before the
     "session is cleaned up" step ran, this finalizer navigates back to the
     homepage and quits the session to prevent resource leaks.
+
+    For JupyterLab, if the test recorded a created notebook
+    (``jupyter_notebook``), it is deleted via the session's contents API
+    **while the session is still alive** (the API vanishes once the session is
+    quit) so JupyterLab's layout-restorer stops reopening stale ``Untitled*``
+    notebooks — and pre-starting their kernels — on the next launch.
     """
-    ctx: dict = {"name": None, "ide_type": None, "cleaned_up": False}
+    ctx: dict = {"name": None, "ide_type": None, "cleaned_up": False, "jupyter_notebook": None}
     yield ctx
+
+    # Delete the JupyterLab notebook first, before any navigation away from the
+    # live session (the contents API is only reachable in-session). Best-effort.
+    _delete_jupyter_notebook_if_any(page, workbench_client, ctx)
+
     if not ctx.get("name") or ctx.get("cleaned_up"):
         return
     try:
@@ -95,6 +106,24 @@ def session_context(page: Page, workbench_url: str):
                 quit_btn.click()
     except Exception:
         # Best-effort cleanup — don't mask the original failure/skip.
+        pass
+
+
+def _delete_jupyter_notebook_if_any(page: Page, workbench_client, ctx: dict) -> None:
+    """Delete the JupyterLab notebook recorded in *ctx* via the contents API.
+
+    Runs while the session page is still live so the per-session contents API is
+    reachable.  Uses the browser's own session cookies (captured from the page
+    context) so it authenticates as the same user.  Best-effort — swallows every
+    error so teardown never masks the original test outcome.
+    """
+    notebook = ctx.get("jupyter_notebook")
+    if not notebook or workbench_client is None:
+        return
+    try:
+        cookies = {c["name"]: c["value"] for c in page.context.cookies()}
+        workbench_client.delete_jupyter_notebook(page.url, notebook, cookies)
+    except Exception:
         pass
 
 
@@ -369,13 +398,98 @@ def _accept_open_dialogs(page: Page, *, attempts: int = 20) -> None:
         page.wait_for_timeout(1000)
 
 
+def _wait_for_jupyter_kernel_idle(page: Page, *, timeout: int) -> None:
+    """Wait (best-effort) for the notebook kernel status to read ``idle``.
+
+    JupyterLab's execution indicator carries ``data-status='idle'`` once the
+    kernel is connected and ready.  Running a cell before then can drop the
+    typed input or queue behind kernel startup, which surfaces as the spurious
+    "kernel did not produce output" timeout.  Best-effort: if the indicator
+    never reports idle (older JupyterLab without the attribute, or a slow
+    connect), we fall through and let the output assertion be the source of
+    truth.  Never raises.
+    """
+    try:
+        page.locator(JupyterLabSession.KERNEL_STATUS_IDLE).first.wait_for(
+            state="visible", timeout=timeout
+        )
+    except (PlaywrightTimeoutError, PlaywrightError):
+        pass
+
+
+def _current_notebook_name(page: Page) -> str | None:
+    """Return the active notebook tab's filename (e.g. ``Untitled.ipynb``).
+
+    Reads the label of the current dock tab so teardown can delete exactly the
+    notebook this test created.  Returns ``None`` if the label cannot be read.
+    """
+    try:
+        label = page.locator(JupyterLabSession.CURRENT_TAB_LABEL).first
+        if label.count() == 0:
+            return None
+        text = (label.text_content(timeout=TIMEOUT_QUICK) or "").strip()
+        return text or None
+    except (PlaywrightTimeoutError, PlaywrightError):
+        return None
+
+
+def _run_jupyter_cell_and_get_output(
+    page: Page, notebook_panel, cell_input, *, attempts: int = 3
+) -> bool:
+    """Type ``1 + 1`` into *cell_input*, run it, and return whether ``2`` appears.
+
+    Guards against the two observed race modes (issue #478 / #484):
+
+    - **Dropped input:** asserts the editor actually contains ``1 + 1`` before
+      running.  If the click landed before CodeMirror was ready, the text is
+      re-typed on the next attempt.
+    - **Lost run keystroke:** re-issues ``Shift+Enter`` each attempt if no output
+      has appeared yet.
+
+    Returns True once the output area shows ``2``; False if all *attempts* are
+    exhausted without output (the caller decides whether that is a skip).
+    """
+    cell_output = notebook_panel.locator(JupyterLabSession.CELL_OUTPUT).first
+    for _attempt in range(attempts):
+        # A leftover kernel dialog can reappear between attempts; clear it first.
+        _accept_open_dialogs(page)
+
+        cell_input.click()
+        # Assert the editor received the text before running, rather than
+        # firing Shift+Enter blind at an editor that may have dropped the input.
+        if "1 + 1" not in (cell_input.text_content() or ""):
+            cell_input.type("1 + 1")
+
+        try:
+            expect(cell_input).to_contain_text("1 + 1", timeout=TIMEOUT_QUICK)
+        except AssertionError:
+            # Input still not registered — retry the whole type step.
+            continue
+
+        cell_input.press("Shift+Enter")
+        try:
+            expect(cell_output).to_contain_text("2", timeout=TIMEOUT_CODE_EXEC)
+            return True
+        except AssertionError:
+            # No output yet — loop and re-issue the run.
+            continue
+    return False
+
+
 @then("JupyterLab can execute code in a notebook")
-def jupyterlab_executes_code(page: Page):
+def jupyterlab_executes_code(page: Page, session_context: dict):
     """Open a new notebook from the launcher and execute ``1 + 1``.
 
     Clicks the first available notebook kernel card in the JupyterLab launcher,
-    waits for the notebook to open, types an expression into the first code
-    cell, runs it, and asserts that ``2`` appears in the cell output area.
+    waits for the notebook to open and the kernel to reach idle, asserts the
+    code cell received ``1 + 1`` before running it (retrying the run), and
+    asserts that ``2`` appears in the cell output area.
+
+    Records the created notebook's filename on ``session_context`` so the
+    ``session_context`` finalizer can delete it via the contents API *before*
+    the session is quit — leftover ``Untitled*.ipynb`` files are otherwise
+    reopened (with eagerly-started kernels) by JupyterLab's layout-restorer on
+    every subsequent launch, widening the launch/exec interaction race.
 
     Skips gracefully if no notebook kernel cards are available (e.g., when
     the Docker image lacks a working kernel).
@@ -445,6 +559,11 @@ def jupyterlab_executes_code(page: Page):
     # once — accepting the default makes the cell interactive (issue #478).
     _accept_open_dialogs(page)
 
+    # Record the notebook filename now so teardown can delete it even if the
+    # execution below fails/skips (a leftover notebook is exactly what we want
+    # gone). The launcher creates "Untitled.ipynb"; the tab label is the source.
+    session_context["jupyter_notebook"] = _current_notebook_name(page)
+
     # Click into the first code cell input of the active notebook and type.
     cell_input = notebook_panel.locator(JupyterLabSession.CELL_INPUT).first
     expect(cell_input).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
@@ -460,21 +579,19 @@ def jupyterlab_executes_code(page: Page):
     # skip message instead of an opaque "intercepts pointer events" timeout.
     _accept_open_dialogs(page)
 
-    cell_input.click()
-    cell_input.type("1 + 1")
+    # Gate on the kernel reaching idle before typing/running. Running while the
+    # kernel is still connecting drops the input and produces the spurious
+    # "kernel did not produce output" timeout that this step used to misreport
+    # as kernel death.
+    _wait_for_jupyter_kernel_idle(page, timeout=TIMEOUT_CODE_EXEC)
 
-    # Run the cell with Shift+Enter
-    cell_input.press("Shift+Enter")
-
-    # Assert the output area shows 2.  The kernel may be slow to start in
-    # Docker CI, so allow a generous timeout before skipping.
-    cell_output = notebook_panel.locator(JupyterLabSession.CELL_OUTPUT).first
-    try:
-        expect(cell_output).to_contain_text("2", timeout=TIMEOUT_CODE_EXEC)
-    except AssertionError:
+    # Type-and-run with input verification and run retries. Returns False only
+    # after exhausting retries with no output.
+    if not _run_jupyter_cell_and_get_output(page, notebook_panel, cell_input):
         pytest.skip(
-            "JupyterLab kernel did not produce output within timeout — "
-            "kernel may not be fully functional in this environment"
+            "JupyterLab notebook UI did not surface cell output within timeout — "
+            "the cell run raced session hydration (kernel reachability is verified "
+            "separately; this is a UI-interaction timeout, not kernel death)"
         )
 
 


### PR DESCRIPTION
## Problem

`test_launch_jupyter` (`jupyterlab_executes_code`) intermittently skips with **"JupyterLab kernel did not produce output within timeout — kernel may not be fully functional"** on deployments with accumulated notebooks. The message is a misdiagnosis: the kernel is healthy. JupyterLab's layout-restorer reopens leftover `Untitled*.ipynb` tabs and eagerly starts their kernels on session boot, widening the click/type/run interaction race so the cell-output assertion times out.

## Fix

1. **Gate the first cell run on kernel idle** — wait for `.jp-Notebook-ExecutionIndicator[data-status='idle']` before typing/running, instead of racing kernel connect.
2. **Type-before-run + run retry** — assert the editor actually received `1 + 1` before `Shift+Enter`, and retry the run (guards dropped input and a lost run keystroke).
3. **Reword the skip** — it is a UI-interaction timeout, not kernel death.
4. **Delete the test-created notebook via the contents API** before the session is quit (cookie auth + `X-XSRFToken`), so the layout-restorer stops reopening stale notebooks (and pre-starting their kernels) on subsequent launches. VIP only deletes the notebook it created.

New pure helpers (`jupyterlab_app_base`, `jupyterlab_contents_delete_url`, `jupyterlab_xsrf_headers`) + `WorkbenchClient.delete_jupyter_notebook`, all unit-tested.

## Verification

- **Static:** ruff 0.15.0 (lint + format), mypy, and full selftest suite (1143 + 13 new) pass; `test_ide_launch` collects clean.
- **Live CDP:** all four DOM/API assumptions validated against a real Workbench JupyterLab session — the `data-status='idle'` indicator, the current-tab-label selector, the `/lab`-split app-base (matches JupyterLab's own `PageConfig.baseUrl`), and the contents `DELETE` (returned **HTTP 204**, notebook gone from listing). The live listing also confirmed the root cause: 8 leftover `Untitled*.ipynb` files accumulated on the box.
- **End-to-end `vip verify --filter launch_jupyter`:**
  - `workbench-helm.local.cofer.me` (Workbench **2026.06**, headless-auth) → **PASSED**
  - `pwb.demo.soleng.posit.it` (Workbench **2026.07**, interactive-auth) → **PASSED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)