### PR TITLE
ci: harden release/publish for 1.0 (attestations, published-artifact smoke, version guard)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,3 +59,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Smoke-test the pushed image
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          ref="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME#v}"
+          docker pull "$ref"
+          docker run --rm "$ref" version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,7 +116,11 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: build
+    # Also gate on release: PyPI publishes are irreversible, so never publish a
+    # version when the GitHub release / constraints step failed — fix and re-run
+    # (the release job is idempotent) rather than strand a version on PyPI
+    # without its matching release assets.
+    needs: [build, release]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
 
   release:
     name: Attach locked constraints to release
+    # Gate on build so the tag/version-alignment assertion also protects the
+    # GitHub release: a mistagged tag fails build and never publishes a release.
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,3 +117,5 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          attestations: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,16 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Assert tag matches pyproject version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          proj_version="$(uv version --short)"
+          if [ "$tag_version" != "$proj_version" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (=$tag_version) does not match pyproject version $proj_version"
+            exit 1
+          fi
+          echo "Tag and pyproject version agree: $proj_version"
+
       - name: Build wheel and sdist
         run: uv build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,3 +129,36 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
+
+  smoke-published:
+    name: Smoke-test published package
+    needs: publish
+    runs-on: ubuntu-latest
+    # Installs from public PyPI and runs the CLI — needs no GITHUB_TOKEN scopes.
+    permissions: {}
+    steps:
+      - name: Resolve release version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      # PyPI needs a moment to index a fresh release; retry install before asserting.
+      - name: Install the published package
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if pip install "posit-vip==${VERSION}"; then
+              echo "Installed posit-vip==${VERSION}"
+              exit 0
+            fi
+            echo "posit-vip==${VERSION} not indexed yet (attempt $attempt/6); waiting 20s"
+            sleep 20
+          done
+          echo "::error::posit-vip==${VERSION} never became installable from PyPI"
+          exit 1
+
+      - name: Verify the CLI runs
+        run: |
+          vip --version
+          vip --version | grep -qF "${VERSION}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -102,6 +102,39 @@ pin or cap in `pyproject.toml` and updates `uv.lock` in one PR, which CI gates
 before merge. The next release then ships the tested set. To bump a pin by hand,
 edit the constraint and run `just relock` in the same commit.
 
+## Releasing
+
+Releases are automated. On every push to `main` that isn't itself a release
+commit, `release.yml` runs `python-semantic-release`
+(`semantic-release version --push --tag --changelog --no-vcs-release`): it reads
+the conventional-commit history, bumps the version in `pyproject.toml` and
+`src/vip/__init__.py`, updates `CHANGELOG.md`, and pushes a `vX.Y.Z` tag.
+
+The tag push triggers two workflows:
+
+- `publish.yml` -- builds the wheel/sdist, asserts the tag matches the
+  `pyproject.toml` version, attaches the locked constraints file to the GitHub
+  release via draft-then-publish (so the asset lands before immutable releases
+  lock it), publishes to PyPI with PEP 740 attestations, then smoke-tests the
+  published package by installing `posit-vip==<version>` from PyPI and running
+  `vip --version`.
+- `docker.yml` -- builds and pushes the container image to
+  `ghcr.io/posit-dev/vip`, then pulls the pushed tag back and runs `vip version`
+  as a sanity check.
+
+### Versioning and the 1.0 cutover
+
+`[tool.semantic_release]` sets `major_on_zero = false` on purpose: while the
+project is on `0.x`, a breaking change bumps the **minor** version rather than
+jumping to `1.0.0`. This keeps the automated pipeline from ever cutting 1.0 on
+its own.
+
+Shipping 1.0 is a **deliberate, manual act**. When the project is ready, open a
+dedicated, reviewed PR that either sets `major_on_zero = true` (so the next
+breaking change bumps to `1.0.0`) or hand-sets `version = "1.0.0"` in
+`pyproject.toml` and tags `v1.0.0`. Automating the 0.x->1.0 transition is
+intentionally out of scope.
+
 ## Design principles
 
 - **Non-destructive** — tests create, verify, and clean up their own content.


### PR DESCRIPTION
## What

Hardens the release/publish pipeline for 1.0 (Child D of #409).

- **PyPI attestations** — make PEP 740 attestations explicit on the publish
  step (`attestations: true`) instead of relying on the action's implicit
  default under Trusted Publishing.
- **Tag/version alignment guard** — the `build` job now fails loudly if the
  pushed tag doesn't match `pyproject.toml`'s version, so a mistagged release
  can never publish.
- **Published-artifact smoke tests** — after publish, a new `smoke-published`
  job installs `posit-vip==<version>` from PyPI (with retry for indexing lag)
  and runs `vip --version`; `docker.yml` pulls the pushed GHCR image back and
  runs `vip version`.
- **Docs** — `docs/development.md` gains a "Releasing" section describing the
  pipeline and the deliberate, manual 0.x→1.0 cutover.

## Not in this PR (by decision)

- Docker image cosign/provenance signing — out of scope for now.
- Automated 1.0 cutover — intentionally kept a manual, reviewed act
  (`major_on_zero = false` stays; see the new docs section).

## Notes

- The immutable-release constraints work that was drafted earlier already
  merged to `main` in a more refined form, so this branch was started fresh
  from `main` and does not re-include it.
- The publish/docker changes only execute on a `v*` tag push, so they can't be
  exercised on this PR — they'll first run on the next real release. `ci:`
  prefix so this PR doesn't itself trigger a version bump.

Addresses #422 (Child D).
