### PR TITLE
fix(workbench): bound JupyterLab cell-run retry timeout

### DIFF
--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -448,9 +448,16 @@ def _run_jupyter_cell_and_get_output(
 
     Returns True once the output area shows ``2``; False if all *attempts* are
     exhausted without output (the caller decides whether that is a skip).
+
+    The first attempt gets the full ``TIMEOUT_CODE_EXEC`` budget (a healthy but
+    cold kernel can be slow to produce its first result in Docker CI).  Retries
+    exist only to recover a *lost* keystroke against an already-live kernel,
+    which resolves in seconds, so they use the shorter ``TIMEOUT_DIALOG`` budget
+    — keeping the worst-case failure path bounded instead of ``attempts ×`` the
+    full timeout.
     """
     cell_output = notebook_panel.locator(JupyterLabSession.CELL_OUTPUT).first
-    for _attempt in range(attempts):
+    for attempt in range(attempts):
         # A leftover kernel dialog can reappear between attempts; clear it first.
         _accept_open_dialogs(page)
 
@@ -467,8 +474,9 @@ def _run_jupyter_cell_and_get_output(
             continue
 
         cell_input.press("Shift+Enter")
+        output_timeout = TIMEOUT_CODE_EXEC if attempt == 0 else TIMEOUT_DIALOG
         try:
-            expect(cell_output).to_contain_text("2", timeout=TIMEOUT_CODE_EXEC)
+            expect(cell_output).to_contain_text("2", timeout=output_timeout)
             return True
         except AssertionError:
             # No output yet — loop and re-issue the run.


### PR DESCRIPTION
## Summary

Follow-up to #532. The JupyterLab type-and-run retry loop in `jupyterlab_executes_code` waited the full `TIMEOUT_CODE_EXEC` (30s) on **every** attempt, so a genuinely stuck cell took up to ~90s to reach the skip.

Retries exist to recover a *lost keystroke* against an already-live kernel, which resolves in seconds — only the first attempt needs the full cold-kernel budget. This gives attempt 1 `TIMEOUT_CODE_EXEC` and subsequent attempts the shorter `TIMEOUT_DIALOG` (10s), bounding the worst-case failure path without changing the happy path.

## Verification

- ruff 0.15.0 + mypy clean.
- Live `vip verify --filter launch_jupyter` runs on the installed build:
  - `pwb.demo.soleng.posit.it` (Workbench 2026.07, interactive) — 3/4 passed; the one failure was an upstream *session-never-reached-Active-in-90s* startup timeout, unrelated to this change.
  - `workbench-helm.local.cofer.me` (Workbench 2026.06, headless, 5× serial) — 4/5 passed; the one skip was the accurate "UI-interaction timeout, not kernel death" message on a 140s-slow session start.

## Known follow-up

On very slow cold starts the shortened retry budget can still lose (helm run 5). A future improvement is to gate retries on the kernel-status indicator reaching `idle` before re-running, so a still-connecting kernel waits rather than burning a short retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)