### PR TITLE
fix(workbench): reliable Workbench→Connect terminal publish with actionable skips

### DIFF
--- a/selftests/test_publish_to_connect_fixtures.py
+++ b/selftests/test_publish_to_connect_fixtures.py
@@ -105,11 +105,30 @@ class TestSharedShinyBundle:
     _R_VERSIONS = ["4.3.1", "4.6.0", "4.4.2"]
 
     def test_workbench_fixture_defined_in_conftest(self):
-        """The Workbench shiny_bundle_files fixture must exist in conftest."""
+        """The Workbench shiny_bundle_spec fixture must exist in conftest."""
         source = _WORKBENCH_CONFTEST.read_text()
         names = _fixture_names_in(source)
-        assert "shiny_bundle_files" in names, (
-            f"Expected fixture 'shiny_bundle_files' in {_WORKBENCH_CONFTEST}"
+        assert "shiny_bundle_spec" in names, (
+            f"Expected fixture 'shiny_bundle_spec' in {_WORKBENCH_CONFTEST}"
+        )
+
+    def test_manifest_raw_url_points_at_public_repo_at_ref(self):
+        """The manifest download URL must be the public raw URL pinned to a ref."""
+        from vip_tests.connect.bundles import MANIFEST_REPO_PATH, manifest_raw_url
+
+        url = manifest_raw_url("v9.9.9")
+        assert url == (
+            "https://raw.githubusercontent.com/posit-dev/vip/v9.9.9/" + MANIFEST_REPO_PATH
+        )
+
+    def test_manifest_url_ref_matches_installed_version(self):
+        """The Workbench fixture pins the download to the installed VIP tag, so a
+        released manifest always matches the app.R checksum shipped with it."""
+        from vip import __version__
+        from vip_tests.connect.bundles import manifest_raw_url
+
+        assert manifest_raw_url(f"v{__version__}").endswith(
+            f"/v{__version__}/src/vip_tests/connect/shiny_manifest.json"
         )
 
     def test_bundle_has_appR_and_manifest(self):

--- a/selftests/test_publish_to_connect_fixtures.py
+++ b/selftests/test_publish_to_connect_fixtures.py
@@ -95,72 +95,67 @@ class TestCleanupFixturesPromotedToRoot:
 
 
 # ---------------------------------------------------------------------------
-# Tests — python_shiny_bundle_path fixture
+# Tests — shared Shiny bundle (Connect + Workbench use the SAME bundle)
 # ---------------------------------------------------------------------------
 
+import json  # noqa: E402
 
-class TestPythonShinyBundlePath:
-    def test_fixture_defined_in_workbench_conftest(self):
-        """python_shiny_bundle_files fixture must be in workbench conftest."""
+
+class TestSharedShinyBundle:
+    _R_VERSIONS = ["4.3.1", "4.6.0", "4.4.2"]
+
+    def test_workbench_fixture_defined_in_conftest(self):
+        """The Workbench shiny_bundle_files fixture must exist in conftest."""
         source = _WORKBENCH_CONFTEST.read_text()
         names = _fixture_names_in(source)
-        assert "python_shiny_bundle_files" in names, (
-            f"Expected fixture 'python_shiny_bundle_files' in {_WORKBENCH_CONFTEST}"
+        assert "shiny_bundle_files" in names, (
+            f"Expected fixture 'shiny_bundle_files' in {_WORKBENCH_CONFTEST}"
         )
 
-    def test_bundle_files_mapping_has_expected_entries(self):
-        """The content-only bundle mapping must carry app.py + requirements.txt."""
-        from vip_tests.workbench.conftest import _python_shiny_bundle_files
+    def test_bundle_has_appR_and_manifest(self):
+        """The shared builder returns an R app.R + manifest.json (not Python)."""
+        from vip_tests.connect.bundles import build_shiny_bundle_files
 
-        files = _python_shiny_bundle_files()
-        assert set(files) == {"app.py", "requirements.txt"}
-        assert "shiny" in files["requirements.txt"]
+        files = build_shiny_bundle_files(self._R_VERSIONS)
+        assert set(files) == {"app.R", "manifest.json"}
+        assert "shinyApp(" in files["app.R"]
+        assert 'fluidPage("VIP test")' in files["app.R"]
 
-    def test_bundle_files_app_py_is_valid_python(self):
-        """app.py content must parse as valid Python."""
-        from vip_tests.workbench.conftest import _python_shiny_bundle_files
+    def test_manifest_is_shiny_appmode_with_newest_r(self):
+        """Manifest platform is patched to the newest installed R; appmode=shiny."""
+        from vip_tests.connect.bundles import build_shiny_bundle_files
 
-        try:
-            ast.parse(_python_shiny_bundle_files()["app.py"])
-        except SyntaxError as exc:
-            raise AssertionError(f"app.py contains invalid Python: {exc}") from exc
+        files = build_shiny_bundle_files(self._R_VERSIONS)
+        manifest = json.loads(files["manifest.json"])
+        assert manifest["metadata"]["appmode"] == "shiny"
+        assert manifest["platform"] == "4.6.0"  # newest of _R_VERSIONS
 
-    def test_bundle_creates_app_py(self, tmp_path):
-        """The fixture must create app.py in the returned directory."""
-        from vip_tests.workbench.conftest import _write_python_shiny_bundle
+    def test_manifest_checksum_matches_appR(self):
+        """The manifest's app.R checksum must match the app.R bytes we ship,
+        or ``rsconnect deploy manifest`` rejects the bundle."""
+        import hashlib
 
-        bundle_dir = _write_python_shiny_bundle(tmp_path)
-        app_py = bundle_dir / "app.py"
-        assert app_py.exists(), f"app.py not found in bundle directory {bundle_dir}"
+        from vip_tests.connect.bundles import build_shiny_bundle_files
 
-    def test_bundle_creates_requirements_txt(self, tmp_path):
-        """The fixture must create requirements.txt in the returned directory."""
-        from vip_tests.workbench.conftest import _write_python_shiny_bundle
+        files = build_shiny_bundle_files(self._R_VERSIONS)
+        manifest = json.loads(files["manifest.json"])
+        expected = manifest["files"]["app.R"]["checksum"]
+        actual = hashlib.md5(files["app.R"].encode(), usedforsecurity=False).hexdigest()
+        assert actual == expected, "app.R content drifted from its manifest checksum"
 
-        bundle_dir = _write_python_shiny_bundle(tmp_path)
-        req_txt = bundle_dir / "requirements.txt"
-        assert req_txt.exists(), f"requirements.txt not found in {bundle_dir}"
-        assert "shiny" in req_txt.read_text()
+    def test_connect_and_workbench_use_identical_bundle(self):
+        """The Connect deploy test and Workbench publish test must ship the
+        byte-identical bundle -- both route through build_shiny_bundle_files."""
+        from vip_tests.connect import bundles, test_content_deploy
 
-    def test_app_py_is_valid_python(self, tmp_path):
-        """app.py must parse as valid Python."""
-        from vip_tests.workbench.conftest import _write_python_shiny_bundle
+        # Connect's _get_bundle for the shiny item delegates to the shared builder.
+        class _FakeConnect:
+            def r_versions(self):
+                return TestSharedShinyBundle._R_VERSIONS
 
-        bundle_dir = _write_python_shiny_bundle(tmp_path)
-        source = (bundle_dir / "app.py").read_text()
-        try:
-            ast.parse(source)
-        except SyntaxError as exc:
-            raise AssertionError(f"app.py contains invalid Python: {exc}") from exc
-
-    def test_app_py_contains_shiny_app(self, tmp_path):
-        """app.py must define a Shiny App object."""
-        from vip_tests.workbench.conftest import _write_python_shiny_bundle
-
-        bundle_dir = _write_python_shiny_bundle(tmp_path)
-        source = (bundle_dir / "app.py").read_text()
-        assert "App(" in source, "app.py must contain a Shiny App(...) call"
-        assert "app_ui" in source, "app.py must define app_ui"
+        connect_bundle = test_content_deploy._get_bundle("vip-shiny-test", _FakeConnect())
+        shared_bundle = bundles.build_shiny_bundle_files(self._R_VERSIONS)
+        assert connect_bundle == shared_bundle
 
 
 # ---------------------------------------------------------------------------

--- a/selftests/test_publish_to_connect_fixtures.py
+++ b/selftests/test_publish_to_connect_fixtures.py
@@ -5,8 +5,8 @@ Verifies that ``_connect_created_guids``, ``_connect_content_cleanup``, and
 ``src/vip_tests/conftest.py`` (and therefore visible to all test packages)
 and are no longer duplicated in ``src/vip_tests/connect/conftest.py``.
 
-Also verifies the ``python_shiny_bundle_path`` fixture produces a directory
-with the expected files.
+Also verifies the ``python_shiny_bundle_files`` fixture produces the expected
+bundle contents (materialized server-side by the deploy step, not on disk).
 """
 
 from __future__ import annotations
@@ -101,12 +101,29 @@ class TestCleanupFixturesPromotedToRoot:
 
 class TestPythonShinyBundlePath:
     def test_fixture_defined_in_workbench_conftest(self):
-        """python_shiny_bundle_path fixture must be in workbench conftest."""
+        """python_shiny_bundle_files fixture must be in workbench conftest."""
         source = _WORKBENCH_CONFTEST.read_text()
         names = _fixture_names_in(source)
-        assert "python_shiny_bundle_path" in names, (
-            f"Expected fixture 'python_shiny_bundle_path' in {_WORKBENCH_CONFTEST}"
+        assert "python_shiny_bundle_files" in names, (
+            f"Expected fixture 'python_shiny_bundle_files' in {_WORKBENCH_CONFTEST}"
         )
+
+    def test_bundle_files_mapping_has_expected_entries(self):
+        """The content-only bundle mapping must carry app.py + requirements.txt."""
+        from vip_tests.workbench.conftest import _python_shiny_bundle_files
+
+        files = _python_shiny_bundle_files()
+        assert set(files) == {"app.py", "requirements.txt"}
+        assert "shiny" in files["requirements.txt"]
+
+    def test_bundle_files_app_py_is_valid_python(self):
+        """app.py content must parse as valid Python."""
+        from vip_tests.workbench.conftest import _python_shiny_bundle_files
+
+        try:
+            ast.parse(_python_shiny_bundle_files()["app.py"])
+        except SyntaxError as exc:
+            raise AssertionError(f"app.py contains invalid Python: {exc}") from exc
 
     def test_bundle_creates_app_py(self, tmp_path):
         """The fixture must create app.py in the returned directory."""

--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -898,7 +898,12 @@ class TestTerminalRun:
 
         typed_cmd = self._typed_cmd(page)
         assert "&&" not in typed_cmd
-        assert 'echo "VIP_DONE_deadbeef:$?"' in typed_cmd
+        # rc is captured once ($?) then written to both the output file and the
+        # one-line sentinel file, so the marker is always recorded even on
+        # failure (the #439 guarantee).
+        assert "rc=$?" in typed_cmd
+        assert 'echo "VIP_DONE_deadbeef:$rc" >> ' in typed_cmd
+        assert 'echo "VIP_DONE_deadbeef:$rc" > ' in typed_cmd
 
     def test_returns_output_on_success(self, monkeypatch):
         self._patch_common(monkeypatch)
@@ -968,6 +973,22 @@ class TestTerminalRun:
         monkeypatch.setattr(exec_mod, "_read_vscode_editor_text", mock_read)
         return mock_read
 
+    def test_writes_marker_to_sentinel_file(self, monkeypatch):
+        """The marker is written to BOTH the output file and a one-line sentinel
+        file. VS Code polls the sentinel to dodge Monaco's viewport
+        virtualization (which can hide the marker on a long output file)."""
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(
+            exec_mod, "read_file", MagicMock(return_value="ok\nVIP_DONE_deadbeef:0")
+        )
+        page = MagicMock()
+
+        exec_mod.terminal_run(page, "echo ok", timeout=1_000)
+
+        typed_cmd = self._typed_cmd(page)
+        assert "/tmp/vip_term_" in typed_cmd  # output file
+        assert "/tmp/vip_done_" in typed_cmd  # one-line sentinel file
+
     def test_vscode_returns_output_on_success(self, monkeypatch):
         """The VS Code editor-open polling path has its own copy of the
         marker-parsing logic and must be covered independently of the
@@ -990,7 +1011,10 @@ class TestTerminalRun:
             exec_mod.terminal_run(page, "git clone ...", timeout=1_000)
 
         assert error_output in str(excinfo.value)
-        mock_read.assert_called_once()
+        # A single poll suffices: the sentinel (donefile) read detects the
+        # marker, then one more read fetches the output for the error message.
+        # Two reads, not a timeout loop.
+        assert mock_read.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -16,6 +16,7 @@ No live Workbench deployment or Playwright browser is required.
 
 from __future__ import annotations
 
+import base64
 import re
 from unittest.mock import MagicMock
 
@@ -24,6 +25,7 @@ import pytest
 import vip_tests.workbench.exec as exec_mod
 from vip_tests.workbench.exec import (
     ExecError,
+    _b64_write_cmd,
     _detect_ide,
     _extract_between_markers,
     _make_sentinels,
@@ -37,6 +39,7 @@ from vip_tests.workbench.exec import (
     ensure_positron_console,
     file_exists,
     read_file,
+    write_bundle,
 )
 from vip_tests.workbench.pages import PositronSession, RStudioSession, VSCodeSession
 
@@ -954,3 +957,82 @@ class TestTerminalRun:
 
         assert error_output in str(excinfo.value)
         mock_read.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _b64_write_cmd
+# ---------------------------------------------------------------------------
+
+
+class TestB64WriteCmd:
+    """The server-side file-write command must round-trip arbitrary content."""
+
+    def test_payload_decodes_back_to_content(self):
+        content = 'x = 1\nprint("hi $USER `date`")\n'
+        cmd = _b64_write_cmd("/tmp/app.py", content)
+        # Extract the base64 token between "printf %s " and " | base64 -d".
+        token = cmd.split("printf %s ", 1)[1].split(" | ", 1)[0]
+        assert base64.b64decode(token).decode("utf-8") == content
+
+    def test_path_is_shell_quoted(self):
+        cmd = _b64_write_cmd("/tmp/dir with space/app.py", "data")
+        assert "> '/tmp/dir with space/app.py'" in cmd
+
+    def test_no_raw_content_metacharacters_leak(self):
+        """Shell metacharacters in content must not appear unencoded in the cmd."""
+        cmd = _b64_write_cmd("/tmp/f", "rm -rf /; $(evil) `boom`")
+        assert "rm -rf /" not in cmd
+        assert "$(evil)" not in cmd
+        assert "`boom`" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# write_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBundle:
+    def test_creates_dir_and_writes_each_file(self, monkeypatch):
+        calls: list[str] = []
+        monkeypatch.setattr(exec_mod, "terminal_run", lambda page, cmd, **kw: calls.append(cmd))
+        page = MagicMock()
+
+        result = write_bundle(
+            page,
+            "/tmp/bundle",
+            {"app.py": "APP", "requirements.txt": "shiny\n"},
+            readback_lang="python",
+        )
+
+        assert result == "/tmp/bundle"
+        # First command must create the bundle dir.
+        assert calls[0] == "mkdir -p /tmp/bundle"
+        # Each file is written via a base64 pipe to its dest path.
+        assert any("base64 -d > /tmp/bundle/app.py" in c for c in calls)
+        assert any("base64 -d > /tmp/bundle/requirements.txt" in c for c in calls)
+        # The app.py payload round-trips.
+        app_cmd = next(c for c in calls if "/tmp/bundle/app.py" in c)
+        token = app_cmd.split("printf %s ", 1)[1].split(" | ", 1)[0]
+        assert base64.b64decode(token).decode("utf-8") == "APP"
+
+    def test_creates_parent_dir_for_nested_file(self, monkeypatch):
+        calls: list[str] = []
+        monkeypatch.setattr(exec_mod, "terminal_run", lambda page, cmd, **kw: calls.append(cmd))
+        page = MagicMock()
+
+        write_bundle(page, "/tmp/bundle", {"www/index.html": "<html>"})
+
+        # The nested file's parent must be created before the write.
+        assert "mkdir -p /tmp/bundle/www" in calls
+        parent_idx = calls.index("mkdir -p /tmp/bundle/www")
+        write_idx = next(i for i, c in enumerate(calls) if "/tmp/bundle/www/index.html" in c)
+        assert parent_idx < write_idx
+
+    def test_propagates_terminal_run_failure(self, monkeypatch):
+        def boom(page, cmd, **kw):
+            raise ExecError("write failed")
+
+        monkeypatch.setattr(exec_mod, "terminal_run", boom)
+
+        with pytest.raises(ExecError, match="write failed"):
+            write_bundle(MagicMock(), "/tmp/bundle", {"app.py": "APP"})

--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -874,6 +874,26 @@ class TestTerminalRun:
 
         assert result == "hello"
 
+    def test_wraps_cmd_in_subshell_before_redirect(self, monkeypatch):
+        """*cmd* must be grouped in ``( ... )`` before the ``> tmpfile`` redirect.
+
+        Regression guard: an ``||``/``&&`` inside *cmd* would otherwise bind the
+        redirect to only its last operand, so a short-circuited command (e.g.
+        ``command -v python3 || command -v python``) sends its output to the
+        visible terminal instead of the capture file -- terminal_run then returns
+        "" with exit 0 and the caller builds an empty ``'' -m venv`` invocation."""
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(
+            exec_mod, "read_file", MagicMock(return_value="/usr/bin/python3\nVIP_DONE_deadbeef:0")
+        )
+        page = MagicMock()
+
+        exec_mod.terminal_run(page, "command -v python3 || command -v python", timeout=1_000)
+
+        typed_cmd = page.locator.return_value.type.call_args[0][0]
+        assert typed_cmd.startswith("( command -v python3 || command -v python ) > ")
+        assert " > /tmp/vip_term_deadbeef.txt 2>&1;" in typed_cmd
+
     def test_raises_exec_error_immediately_on_nonzero_exit(self, monkeypatch):
         """Fast failure must surface as an immediate ExecError with the real
         output, not a 120s timeout with the output discarded."""

--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -834,6 +834,30 @@ class TestReadFileRouting:
 
 
 # ---------------------------------------------------------------------------
+# _visible_terminal_input
+# ---------------------------------------------------------------------------
+
+
+class TestVisibleTerminalInput:
+    """A session may hold more than one terminal (VS Code's Python extension
+    spawns one to activate a venv), so the input must be resolved by the
+    ``:visible`` filter + ``.last`` -- a bare ``.xterm-helper-textarea`` locator
+    matches multiple elements and trips Playwright strict mode on click/type."""
+
+    def test_filters_to_visible_and_last(self):
+        from vip_tests.workbench.exec import _visible_terminal_input
+        from vip_tests.workbench.pages import VSCodeSession
+
+        page = MagicMock()
+        _visible_terminal_input(page)
+
+        selector = page.locator.call_args[0][0]
+        assert selector == f"{VSCodeSession.TERMINAL_INPUT}:visible"
+        # ``.last`` is what disambiguates a transient two-terminal tie.
+        assert page.locator.return_value.last is _visible_terminal_input(page)
+
+
+# ---------------------------------------------------------------------------
 # terminal_run
 # ---------------------------------------------------------------------------
 
@@ -851,6 +875,16 @@ class TestTerminalRun:
         monkeypatch.setattr(exec_mod, "_ensure_terminal_open", lambda p, timeout=30_000: None)
         monkeypatch.setattr(exec_mod.uuid, "uuid4", lambda: _FixedUUID())
 
+    @staticmethod
+    def _typed_cmd(page):
+        """The command string terminal_run typed into the (visible) terminal.
+
+        terminal_run resolves the input via ``_visible_terminal_input``, which
+        returns ``page.locator(...).last``, so the ``.type()`` call lands on the
+        ``.last`` child mock rather than ``page.locator.return_value``.
+        """
+        return page.locator.return_value.last.type.call_args[0][0]
+
     def test_writes_done_marker_unconditionally(self, monkeypatch):
         """The marker must be appended with ``;`` so it is written even when
         *cmd* fails -- ``&&`` silently drops it on non-zero exit (#439)."""
@@ -862,7 +896,7 @@ class TestTerminalRun:
 
         exec_mod.terminal_run(page, "false", timeout=1_000)
 
-        typed_cmd = page.locator.return_value.type.call_args[0][0]
+        typed_cmd = self._typed_cmd(page)
         assert "&&" not in typed_cmd
         assert 'echo "VIP_DONE_deadbeef:$?"' in typed_cmd
 
@@ -893,7 +927,7 @@ class TestTerminalRun:
 
         exec_mod.terminal_run(page, "command -v python3 || command -v python", timeout=1_000)
 
-        typed_cmd = page.locator.return_value.type.call_args[0][0]
+        typed_cmd = self._typed_cmd(page)
         assert typed_cmd.startswith("( command -v python3 || command -v python ) > ")
         assert " > /tmp/vip_term_deadbeef.txt 2>&1;" in typed_cmd
 

--- a/src/vip_tests/connect/bundles.py
+++ b/src/vip_tests/connect/bundles.py
@@ -1,0 +1,61 @@
+"""Shared content bundles for Connect deployment.
+
+Single source of truth for the content VIP deploys, so the Connect deploy test
+(``connect/test_content_deploy.py``) and the Workbench publish test
+(``workbench/test_publish_to_connect.py``) use byte-identical bundles.  The
+Workbench test writes these files into the session's own filesystem via the IDE
+terminal and deploys them with ``rsconnect deploy manifest`` (which, unlike
+``deploy shiny``, deploys any content type -- including R -- from a prepared
+``manifest.json`` and builds server-side, so no local R is required).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+# The minimal R Shiny app: a page containing only the text "VIP test" and an
+# empty server.  Its MD5 is baked into shiny_manifest.json's files block, so
+# this string must not change without regenerating that checksum.
+_SHINY_APP_R = (
+    "library(shiny)\n"
+    'ui <- fluidPage("VIP test")\n'
+    "server <- function(input, output, session) {}\n"
+    "shinyApp(ui, server)\n"
+)
+
+
+def _latest_version(versions: list[str]) -> str:
+    """Return the highest version string by numeric component.
+
+    Connect's server_settings list installations in install order, not by
+    version, so picking [0] can return the oldest R/Python.  Choosing the
+    newest matches the regenerated manifests, which target current packages.
+    """
+
+    def key(v: str) -> tuple:
+        parts = []
+        for p in v.split("."):
+            try:
+                parts.append((0, int(p)))
+            except ValueError:
+                parts.append((1, p))
+        return tuple(parts)
+
+    return max(versions, key=key)
+
+
+def build_shiny_bundle_files(r_versions: list[str]) -> dict[str, str]:
+    """Return the R Shiny bundle as ``{filename: content}``.
+
+    Loads the reference ``shiny_manifest.json`` (the full transitive package
+    closure) and patches its ``platform`` to the newest R installed on the
+    server, exactly as the Connect deploy test does.  Callers must skip when
+    *r_versions* is empty (no R on Connect ⇒ nothing to build against).
+
+    Returns ``{"app.R": ..., "manifest.json": ...}`` -- suitable both for an
+    API bundle upload and for ``rsconnect deploy manifest``.
+    """
+    manifest = json.loads((pathlib.Path(__file__).parent / "shiny_manifest.json").read_text())
+    manifest["platform"] = _latest_version(r_versions)
+    return {"app.R": _SHINY_APP_R, "manifest.json": json.dumps(manifest)}

--- a/src/vip_tests/connect/bundles.py
+++ b/src/vip_tests/connect/bundles.py
@@ -24,6 +24,25 @@ _SHINY_APP_R = (
     "shinyApp(ui, server)\n"
 )
 
+# Location of the reference manifest in the public repo.  The Workbench publish
+# test cannot read the pytest host's filesystem from inside the session, so it
+# downloads this manifest into the session over HTTPS instead of typing its
+# ~80 KB through the terminal.  Kept next to the manifest itself so both stay in
+# sync.
+MANIFEST_REPO = "posit-dev/vip"
+MANIFEST_REPO_PATH = "src/vip_tests/connect/shiny_manifest.json"
+
+
+def manifest_raw_url(ref: str) -> str:
+    """Return the raw GitHub URL for ``shiny_manifest.json`` at *ref*.
+
+    *ref* is any git ref the public repo exposes (a release tag like
+    ``v0.58.7``, a branch, or a commit SHA).  Pinning to the installed version's
+    tag keeps the downloaded manifest in lockstep with the ``_SHINY_APP_R``
+    checksum shipped in the same release.
+    """
+    return f"https://raw.githubusercontent.com/{MANIFEST_REPO}/{ref}/{MANIFEST_REPO_PATH}"
+
 
 def _latest_version(versions: list[str]) -> str:
     """Return the highest version string by numeric component.

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 from pytest_bdd import scenario, then, when
 
+from vip_tests.connect.bundles import _latest_version, build_shiny_bundle_files
 from vip_tests.connect.conftest import _make_tar_gz
 
 _GIT_REPO_URL = "https://github.com/posit-dev/connect-extensions"
@@ -89,26 +90,6 @@ def deploy_state():
 # ---------------------------------------------------------------------------
 
 
-def _latest_version(versions: list[str]) -> str:
-    """Return the highest version string by numeric component.
-
-    Connect's server_settings list installations in install order, not by
-    version, so picking [0] can return the oldest R/Python.  Choosing the
-    newest matches the regenerated manifests, which target current packages.
-    """
-
-    def key(v: str) -> tuple:
-        parts = []
-        for p in v.split("."):
-            try:
-                parts.append((0, int(p)))
-            except ValueError:
-                parts.append((1, p))
-        return tuple(parts)
-
-    return max(versions, key=key)
-
-
 def _get_bundle(name: str, connect_client) -> dict[str, str]:
     """Return the bundle files for *name*, building manifests dynamically.
 
@@ -155,17 +136,7 @@ def _get_bundle(name: str, connect_client) -> dict[str, str]:
         r_versions = connect_client.r_versions()
         if not r_versions:
             pytest.skip("No R versions available on Connect — cannot deploy Shiny")
-        manifest = json.loads((pathlib.Path(__file__).parent / "shiny_manifest.json").read_text())
-        manifest["platform"] = _latest_version(r_versions)
-        return {
-            "app.R": (
-                "library(shiny)\n"
-                'ui <- fluidPage("VIP test")\n'
-                "server <- function(input, output, session) {}\n"
-                "shinyApp(ui, server)\n"
-            ),
-            "manifest.json": json.dumps(manifest),
-        }
+        return build_shiny_bundle_files(r_versions)
 
     if name == "vip-dash-test":
         py_versions = connect_client.python_versions()

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -34,6 +34,7 @@ from vip.workbench_ui import (
 from vip.workbench_ui import (
     vip_names_from_select_labels as _vip_names_from_select_labels,  # noqa: F401
 )
+from vip_tests.connect.bundles import build_shiny_bundle_files
 from vip_tests.workbench.pages import Homepage, LoginPage
 
 logger = logging.getLogger(__name__)
@@ -912,60 +913,33 @@ def workbench_accessible_and_logged_in(
 
 
 # ---------------------------------------------------------------------------
-# Bundle path fixtures
+# Bundle fixtures
 # ---------------------------------------------------------------------------
-
-_PYTHON_SHINY_APP = '''\
-"""Minimal Python Shiny VIP test application."""
-
-from shiny import App, ui
-
-app_ui = ui.page_fixed(
-    ui.h1("VIP Python Shiny Test"),
-    ui.p("Deployed by VIP from a Workbench session."),
-)
-
-
-def server(input, output, session):
-    pass
-
-
-app = App(app_ui, server)
-'''
-
-
-def _python_shiny_bundle_files() -> dict[str, str]:
-    """Return the Python Shiny bundle as a ``{filename: content}`` mapping.
-
-    The bundle is content-only (no filesystem location) so it can be
-    materialized wherever the deploy runs -- in the tests, written into the
-    Workbench session's own filesystem via the IDE terminal so ``rsconnect``
-    finds it locally regardless of where pytest is invoked.
-    """
-    return {"app.py": _PYTHON_SHINY_APP, "requirements.txt": "shiny\n"}
-
-
-def _write_python_shiny_bundle(bundle_dir: Path) -> Path:
-    """Write a minimal Python Shiny bundle (app.py + requirements.txt) into bundle_dir.
-
-    Returns *bundle_dir* for convenience so callers can write::
-
-        path = _write_python_shiny_bundle(some_dir)
-    """
-    for name, content in _python_shiny_bundle_files().items():
-        (bundle_dir / name).write_text(content)
-    return bundle_dir
 
 
 @pytest.fixture(scope="session")
-def python_shiny_bundle_files() -> dict[str, str]:
-    """Session-scoped Python Shiny bundle as a ``{filename: content}`` mapping.
+def shiny_bundle_files(connect_client) -> dict[str, str]:
+    """Session-scoped R Shiny bundle as a ``{filename: content}`` mapping.
 
-    Returns the bundle contents rather than a path: the deploy step writes them
-    into the Workbench session's filesystem via the IDE terminal (see
-    ``exec.write_bundle``), so the bundle is always local to the ``rsconnect``
-    process that consumes it -- the test no longer requires pytest to run on the
-    Workbench server (previously the bundle was created on the pytest host, so a
-    remote runner produced a path ``rsconnect`` could not see).
+    Returns the *exact* bundle the Connect deploy test uses -- built by the
+    shared ``connect.bundles.build_shiny_bundle_files`` so the two suites can
+    never drift -- consisting of the minimal ``app.R`` (``fluidPage("VIP test")``
+    with an empty server) plus the reference ``shiny_manifest.json`` with its
+    ``platform`` patched to the newest R installed on Connect.
+
+    The deploy step writes these files into the Workbench session's filesystem
+    via the IDE terminal (see ``exec.write_bundle``) and deploys them with
+    ``rsconnect deploy manifest``, which -- unlike ``deploy shiny`` -- deploys
+    any content type (including R) from a prepared manifest and builds it
+    server-side, so no local R is required.  Returning contents (not a path)
+    means the test no longer requires pytest to run on the Workbench server.
+
+    Skips when Connect is unavailable or has no R installed, since the manifest
+    ``platform`` must match a real server R version.
     """
-    return _python_shiny_bundle_files()
+    if connect_client is None:
+        pytest.skip("Connect is not configured — cannot build the shared Shiny bundle")
+    r_versions = connect_client.r_versions()
+    if not r_versions:
+        pytest.skip("No R versions available on Connect — cannot build the Shiny bundle")
+    return build_shiny_bundle_files(r_versions)

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -932,6 +932,9 @@ def shiny_bundle_spec(connect_client) -> dict[str, str]:
       public repo, pinned to the installed VIP version's tag.  The manifest
       carries the full 30-package dependency closure (~80 KB), far too large to
       type reliably through the terminal, so the session downloads it directly.
+    - ``manifest_url_fallback``: the same raw URL at ``main``.  A dev/unreleased
+      checkout (version bumped, tag not yet pushed) 404s on the tag; the deploy
+      script falls back to this before concluding the manifest is unreachable.
     - ``platform``: the newest R installed on Connect, patched into the
       downloaded manifest exactly as ``build_shiny_bundle_files`` does, so the
       Workbench and Connect bundles stay identical.
@@ -951,5 +954,6 @@ def shiny_bundle_spec(connect_client) -> dict[str, str]:
     return {
         "app_r": _SHINY_APP_R,
         "manifest_url": manifest_raw_url(f"v{__version__}"),
+        "manifest_url_fallback": manifest_raw_url("main"),
         "platform": _latest_version(r_versions),
     }

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -34,7 +34,7 @@ from vip.workbench_ui import (
 from vip.workbench_ui import (
     vip_names_from_select_labels as _vip_names_from_select_labels,  # noqa: F401
 )
-from vip_tests.connect.bundles import build_shiny_bundle_files
+from vip_tests.connect.bundles import _SHINY_APP_R, _latest_version, manifest_raw_url
 from vip_tests.workbench.pages import Homepage, LoginPage
 
 logger = logging.getLogger(__name__)
@@ -918,28 +918,38 @@ def workbench_accessible_and_logged_in(
 
 
 @pytest.fixture(scope="session")
-def shiny_bundle_files(connect_client) -> dict[str, str]:
-    """Session-scoped R Shiny bundle as a ``{filename: content}`` mapping.
+def shiny_bundle_spec(connect_client) -> dict[str, str]:
+    """Coordinates for materializing the shared R Shiny bundle in a session.
 
-    Returns the *exact* bundle the Connect deploy test uses -- built by the
-    shared ``connect.bundles.build_shiny_bundle_files`` so the two suites can
-    never drift -- consisting of the minimal ``app.R`` (``fluidPage("VIP test")``
-    with an empty server) plus the reference ``shiny_manifest.json`` with its
-    ``platform`` patched to the newest R installed on Connect.
+    Returns the pieces the deploy step needs to reconstruct -- inside the
+    Workbench session's own filesystem -- the *same* bundle the Connect deploy
+    test uses:
 
-    The deploy step writes these files into the Workbench session's filesystem
-    via the IDE terminal (see ``exec.write_bundle``) and deploys them with
-    ``rsconnect deploy manifest``, which -- unlike ``deploy shiny`` -- deploys
-    any content type (including R) from a prepared manifest and builds it
-    server-side, so no local R is required.  Returning contents (not a path)
-    means the test no longer requires pytest to run on the Workbench server.
+    - ``app_r``: the minimal ``app.R`` (``fluidPage("VIP test")`` + empty
+      server), small enough to type into the terminal.  Its MD5 is the checksum
+      baked into ``shiny_manifest.json``.
+    - ``manifest_url``: raw URL of the reference ``shiny_manifest.json`` in the
+      public repo, pinned to the installed VIP version's tag.  The manifest
+      carries the full 30-package dependency closure (~80 KB), far too large to
+      type reliably through the terminal, so the session downloads it directly.
+    - ``platform``: the newest R installed on Connect, patched into the
+      downloaded manifest exactly as ``build_shiny_bundle_files`` does, so the
+      Workbench and Connect bundles stay identical.
 
-    Skips when Connect is unavailable or has no R installed, since the manifest
-    ``platform`` must match a real server R version.
+    Skips when Connect is unavailable or has no R installed (the manifest
+    ``platform`` must match a real server R version).  The download itself may
+    also fail at deploy time (firewalled session) -- that is handled in the step
+    as a skip, since it is an environment constraint, not a publishing defect.
     """
+    from vip import __version__
+
     if connect_client is None:
         pytest.skip("Connect is not configured — cannot build the shared Shiny bundle")
     r_versions = connect_client.r_versions()
     if not r_versions:
         pytest.skip("No R versions available on Connect — cannot build the Shiny bundle")
-    return build_shiny_bundle_files(r_versions)
+    return {
+        "app_r": _SHINY_APP_R,
+        "manifest_url": manifest_raw_url(f"v{__version__}"),
+        "platform": _latest_version(r_versions),
+    }

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -934,6 +934,17 @@ app = App(app_ui, server)
 '''
 
 
+def _python_shiny_bundle_files() -> dict[str, str]:
+    """Return the Python Shiny bundle as a ``{filename: content}`` mapping.
+
+    The bundle is content-only (no filesystem location) so it can be
+    materialized wherever the deploy runs -- in the tests, written into the
+    Workbench session's own filesystem via the IDE terminal so ``rsconnect``
+    finds it locally regardless of where pytest is invoked.
+    """
+    return {"app.py": _PYTHON_SHINY_APP, "requirements.txt": "shiny\n"}
+
+
 def _write_python_shiny_bundle(bundle_dir: Path) -> Path:
     """Write a minimal Python Shiny bundle (app.py + requirements.txt) into bundle_dir.
 
@@ -941,20 +952,20 @@ def _write_python_shiny_bundle(bundle_dir: Path) -> Path:
 
         path = _write_python_shiny_bundle(some_dir)
     """
-    (bundle_dir / "app.py").write_text(_PYTHON_SHINY_APP)
-    (bundle_dir / "requirements.txt").write_text("shiny\n")
+    for name, content in _python_shiny_bundle_files().items():
+        (bundle_dir / name).write_text(content)
     return bundle_dir
 
 
 @pytest.fixture(scope="session")
-def python_shiny_bundle_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Create a session-scoped Python Shiny test bundle in a temp directory.
+def python_shiny_bundle_files() -> dict[str, str]:
+    """Session-scoped Python Shiny bundle as a ``{filename: content}`` mapping.
 
-    Writes a minimal ``app.py`` and ``requirements.txt`` to a fresh temp
-    directory and returns the path.  The bundle is suitable for
-    ``rsconnect deploy shiny <path>``.  Using ``tmp_path_factory`` means the
-    files are created at test-run time on the machine running VIP (which must
-    be the Workbench server, or a host whose /tmp is reachable from the
-    Workbench session terminal).
+    Returns the bundle contents rather than a path: the deploy step writes them
+    into the Workbench session's filesystem via the IDE terminal (see
+    ``exec.write_bundle``), so the bundle is always local to the ``rsconnect``
+    process that consumes it -- the test no longer requires pytest to run on the
+    Workbench server (previously the bundle was created on the pytest host, so a
+    remote runner produced a path ``rsconnect`` could not see).
     """
-    return _write_python_shiny_bundle(tmp_path_factory.mktemp("python_shiny_bundle"))
+    return _python_shiny_bundle_files()

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -825,10 +825,13 @@ def terminal_run(
     Strategy:
     1. Ensure the IDE terminal is open (activate the RStudio Terminal tab or
        create a VS Code/Positron terminal) so its input is present.
-    2. Type ``{cmd} > {tmpfile} 2>&1; echo "{done_marker}:$?" >> {tmpfile}`` in the
-       terminal input (``.xterm-helper-textarea``).  The marker is appended
-       with ``;`` rather than ``&&`` so it is always written, even when *cmd*
-       fails -- see issue #439.
+    2. Type ``( {cmd} ) > {tmpfile} 2>&1; echo "{done_marker}:$?" >> {tmpfile}``
+       in the terminal input (``.xterm-helper-textarea``).  *cmd* is wrapped in
+       a subshell so the redirect captures its whole output even when *cmd*
+       contains ``||`` / ``&&`` (shell precedence would otherwise bind the
+       redirect to the last operand only).  The marker is appended with ``;``
+       rather than ``&&`` so it is always written, even when *cmd* fails -- see
+       issue #439.
     3. Press Enter to execute.
     4. Poll for the done marker:
        - RStudio/Positron: call ``read_file`` (console eval, fresh each call).
@@ -862,7 +865,13 @@ def terminal_run(
     """
     done_marker = f"VIP_DONE_{uuid.uuid4().hex}"
     tmpfile = f"/tmp/vip_term_{uuid.uuid4().hex}.txt"
-    shell_cmd = f'{cmd} > {tmpfile} 2>&1; echo "{done_marker}:$?" >> {tmpfile}'
+    # Wrap *cmd* in a subshell so the ``> {tmpfile}`` redirect captures the
+    # entire command's stdout/stderr regardless of any ``||`` / ``&&`` / ``;``
+    # inside *cmd*. Without the group, shell precedence binds the redirect to
+    # only the last operand -- e.g. ``command -v python3 || command -v python``
+    # sends the ``python3`` hit to the visible terminal, not the file, so
+    # terminal_run returns "" with exit 0 (which then runs ``'' -m venv``).
+    shell_cmd = f'( {cmd} ) > {tmpfile} 2>&1; echo "{done_marker}:$?" >> {tmpfile}'
 
     ide = _detect_ide(page)
 

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -898,14 +898,27 @@ def terminal_run(
         during live validation.
     """
     done_marker = f"VIP_DONE_{uuid.uuid4().hex}"
-    tmpfile = f"/tmp/vip_term_{uuid.uuid4().hex}.txt"
+    uid = uuid.uuid4().hex
+    tmpfile = f"/tmp/vip_term_{uid}.txt"
+    # Separate one-line sentinel file holding only the done marker + exit code.
+    # The VS Code readback opens files in the Monaco editor, which *virtualizes*
+    # long content (only the viewport renders), so on a long log the marker --
+    # always the last line -- can be scrolled out of view and never detected,
+    # timing out a command that actually finished. Polling a dedicated one-line
+    # file sidesteps virtualization entirely; the full output is read from
+    # tmpfile once the marker appears.
+    donefile = f"/tmp/vip_done_{uid}.txt"
     # Wrap *cmd* in a subshell so the ``> {tmpfile}`` redirect captures the
     # entire command's stdout/stderr regardless of any ``||`` / ``&&`` / ``;``
     # inside *cmd*. Without the group, shell precedence binds the redirect to
     # only the last operand -- e.g. ``command -v python3 || command -v python``
     # sends the ``python3`` hit to the visible terminal, not the file, so
     # terminal_run returns "" with exit 0 (which then runs ``'' -m venv``).
-    shell_cmd = f'( {cmd} ) > {tmpfile} 2>&1; echo "{done_marker}:$?" >> {tmpfile}'
+    shell_cmd = (
+        f"( {cmd} ) > {tmpfile} 2>&1; rc=$?; "
+        f'echo "{done_marker}:$rc" >> {tmpfile}; '
+        f'echo "{done_marker}:$rc" > {donefile}'
+    )
 
     ide = _detect_ide(page)
 
@@ -923,27 +936,37 @@ def terminal_run(
     poll_interval = 1.0
 
     if ide == "vscode":
-        # VS Code: poll by opening the file in the Monaco editor, reading
-        # .view-lines, and closing+re-opening to force a disk re-read each poll.
-        # NOTE: This path is UNVALIDATED pending a live git_ops run.
+        # VS Code: poll the one-line sentinel file (donefile) in the Monaco
+        # editor. It is a single line, so Monaco's viewport virtualization
+        # cannot hide it (the failure mode when polling the full, possibly long,
+        # output file). Once the marker appears, read the full output from
+        # tmpfile once for the return value.
         while time.monotonic() < deadline:
             try:
-                _open_file_in_vscode_editor(page, tmpfile, timeout=5_000)
-                content = _read_vscode_editor_text(page, timeout=5_000)
+                _open_file_in_vscode_editor(page, donefile, timeout=5_000)
+                marker_text = _read_vscode_editor_text(page, timeout=5_000)
                 _close_active_editor(page)
-                parsed = _parse_done_marker(content, done_marker)
-                if parsed is not None:
-                    output, exit_code = parsed
-                    if exit_code != 0:
-                        raise ExecError(
-                            f"terminal_run: command {cmd!r} exited with status "
-                            f"{exit_code}: {output}"
-                        )
-                    return output
-            except ExecError:
-                raise
             except Exception:
-                pass
+                marker_text = ""
+            parsed = _parse_done_marker(marker_text, done_marker)
+            if parsed is not None:
+                _, exit_code = parsed
+                # Read the actual command output (best-effort; the marker already
+                # gave us the exit status, so a flaky output read is non-fatal).
+                output = ""
+                try:
+                    _open_file_in_vscode_editor(page, tmpfile, timeout=5_000)
+                    full = _read_vscode_editor_text(page, timeout=5_000)
+                    _close_active_editor(page)
+                    out_parsed = _parse_done_marker(full, done_marker)
+                    output = out_parsed[0] if out_parsed is not None else full
+                except Exception:
+                    pass
+                if exit_code != 0:
+                    raise ExecError(
+                        f"terminal_run: command {cmd!r} exited with status {exit_code}: {output}"
+                    )
+                return output
             time.sleep(poll_interval)
     else:
         # RStudio / Positron: poll via DOM console eval (read_file handles routing).

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -783,6 +783,22 @@ def _detect_ide(page: Page) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _visible_terminal_input(page: Page):
+    """The active integrated-terminal input, as a single-element locator.
+
+    A session can accumulate more than one terminal — notably, VS Code's Python
+    extension spawns a second terminal to auto-activate a newly created venv — so
+    the bare ``.xterm-helper-textarea`` selector matches multiple elements and
+    Playwright's strict mode rejects ``.click()`` / ``.type()`` on it. Only the
+    active terminal is visible, so filter to ``:visible``; ``.last`` breaks a
+    transient tie while VS Code is mid-switch between terminals. Every keystroke
+    goes to the active terminal anyway, and each ``terminal_run`` is
+    self-contained (absolute tmpfile paths + marker readback), so which terminal
+    receives it does not matter as long as it is a live shell.
+    """
+    return page.locator(f"{VSCodeSession.TERMINAL_INPUT}:visible").last
+
+
 def _ensure_terminal_open(page: Page, timeout: int = 30_000) -> None:
     """Make the IDE's integrated terminal input visible before use.
 
@@ -793,8 +809,7 @@ def _ensure_terminal_open(page: Page, timeout: int = 30_000) -> None:
     ``.xterm-helper-textarea`` is already present. This helper is idempotent —
     it returns immediately when a terminal input is already visible.
     """
-    terminal_input = page.locator(VSCodeSession.TERMINAL_INPUT)
-    if terminal_input.count() > 0 and terminal_input.first.is_visible():
+    if page.locator(f"{VSCodeSession.TERMINAL_INPUT}:visible").count() > 0:
         return
 
     if page.locator(RStudioSession.CONTAINER).count() > 0:
@@ -808,7 +823,7 @@ def _ensure_terminal_open(page: Page, timeout: int = 30_000) -> None:
     elif page.locator(VSCodeSession.WORKBENCH).count() > 0:
         # VS Code / Positron: open the integrated terminal (creates one if none).
         page.keyboard.press("Control+`")
-    expect(terminal_input).to_be_visible(timeout=timeout)
+    expect(_visible_terminal_input(page)).to_be_visible(timeout=timeout)
 
 
 def terminal_run(
@@ -878,7 +893,7 @@ def terminal_run(
     ide = _detect_ide(page)
 
     _ensure_terminal_open(page, timeout=timeout)
-    terminal_input = page.locator(VSCodeSession.TERMINAL_INPUT)
+    terminal_input = _visible_terminal_input(page)
     terminal_input.click()
     terminal_input.type(shell_cmd)
     terminal_input.press("Enter")

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -709,9 +709,26 @@ def _open_file_in_vscode_editor(page: Page, abspath: str, timeout: int = 30_000)
 
 
 def _read_vscode_editor_text(page: Page, timeout: int = 30_000) -> str:
-    """Return the inner text of the active Monaco editor view-lines."""
+    """Return the inner text of the active Monaco editor view-lines.
+
+    Monaco *virtualizes* ``.view-lines``: only the lines in the current viewport
+    are in the DOM. terminal_run appends its done marker to the LAST line of the
+    output file, so on a long log (e.g. an rsconnect deploy transcript) the
+    marker is scrolled out of view and never appears in ``.view-lines`` --
+    terminal_run then polls until timeout despite the command having finished.
+    Jump to the end of the file first so the final lines (with the marker) are
+    the ones rendered.
+    """
     loc = page.locator(".editor-instance .view-lines").first
     expect(loc).to_be_visible(timeout=timeout)
+    # Ctrl+End moves the cursor to the file's end, scrolling the last lines into
+    # the rendered viewport. Meta+End covers the macOS keybinding.
+    try:
+        page.keyboard.press("Control+End")
+        page.keyboard.press("Meta+End")
+    except Exception:
+        pass
+    page.wait_for_timeout(150)
     return loc.inner_text()
 
 

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -894,7 +894,11 @@ def terminal_run(
 
     _ensure_terminal_open(page, timeout=timeout)
     terminal_input = _visible_terminal_input(page)
-    terminal_input.click()
+    # Focus rather than click: the xterm textarea only needs keyboard focus to
+    # receive input, and a pointer click is intercepted by the terminal panel's
+    # "Terminal actions" toolbar overlay (which sits over the textarea), timing
+    # out the click. focus() is not subject to pointer-event interception.
+    terminal_input.focus()
     terminal_input.type(shell_cmd)
     terminal_input.press("Enter")
 

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -16,7 +16,9 @@ by selftests/test_workbench_exec.py.
 
 from __future__ import annotations
 
+import base64
 import re
+import shlex
 import time
 import uuid
 
@@ -942,6 +944,84 @@ def terminal_run(
     raise ExecError(
         f"terminal_run timed out after {timeout}ms waiting for done marker in {tmpfile!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Server-side file materialization
+# ---------------------------------------------------------------------------
+
+
+def _b64_write_cmd(path: str, content: str) -> str:
+    """Build a shell command that writes *content* to *path* on the server.
+
+    The content is base64-encoded on the client and decoded on the server, so
+    arbitrary bytes (newlines, quotes, ``$``, backticks) survive the terminal
+    typing path intact -- a heredoc or ``echo`` would be mangled by the shell's
+    own interpretation of the characters ``terminal_run`` types verbatim.
+
+    ``base64 -d`` is coreutils/BusyBox-portable; the payload is a single token
+    (base64 emits no shell metacharacters) piped into ``base64 -d > path``.
+    """
+    payload = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    return f"printf %s {payload} | base64 -d > {shlex.quote(path)}"
+
+
+def write_bundle(
+    page: Page,
+    bundle_dir: str,
+    files: dict[str, str],
+    *,
+    timeout: int = 30_000,
+    readback_lang: str = "r",
+) -> str:
+    """Materialize *files* under *bundle_dir* on the Workbench server.
+
+    Writes each ``{filename: content}`` entry into *bundle_dir* using the IDE
+    session terminal (via :func:`terminal_run`), so the bundle exists on the
+    machine where subsequent terminal commands run -- not on the host running
+    pytest.  This decouples the test from where VIP is invoked: the bundle is
+    always local to the ``rsconnect`` process that consumes it.
+
+    Filenames may include subdirectories (e.g. ``www/index.html``); the parent
+    directory is created before each file is written.
+
+    Args:
+        page: Playwright page for an active IDE session.
+        bundle_dir: Absolute server-side directory to create and populate.
+        files: Mapping of relative filename to file content.
+        timeout: Max milliseconds for each underlying terminal command.
+        readback_lang: Readback language for :func:`terminal_run` (``"python"``
+            for pure VS Code sessions without an R console).
+
+    Returns:
+        *bundle_dir*, for convenient chaining into a deploy command.
+
+    Raises:
+        ExecError: A directory creation or file write command failed.
+    """
+    terminal_run(
+        page,
+        f"mkdir -p {shlex.quote(bundle_dir)}",
+        timeout=timeout,
+        readback_lang=readback_lang,
+    )
+    for filename, content in files.items():
+        dest = f"{bundle_dir}/{filename}"
+        parent = dest.rsplit("/", 1)[0]
+        if parent and parent != bundle_dir:
+            terminal_run(
+                page,
+                f"mkdir -p {shlex.quote(parent)}",
+                timeout=timeout,
+                readback_lang=readback_lang,
+            )
+        terminal_run(
+            page,
+            _b64_write_cmd(dest, content),
+            timeout=timeout,
+            readback_lang=readback_lang,
+        )
+    return bundle_dir
 
 
 # ---------------------------------------------------------------------------

--- a/src/vip_tests/workbench/test_ide_launch.py
+++ b/src/vip_tests/workbench/test_ide_launch.py
@@ -372,10 +372,12 @@ def vscode_terminal_accessible(page: Page):
     """
     expect(page.locator(VSCodeSession.WORKBENCH)).to_be_visible(timeout=TIMEOUT_IDE_LOAD)
 
-    # Open the integrated terminal with the standard VS Code shortcut
+    # Open the integrated terminal with the standard VS Code shortcut. Filter to
+    # the visible input so a session with more than one terminal does not trip
+    # Playwright's strict mode on the bare ``.xterm-helper-textarea`` locator.
     page.keyboard.press("Control+`")
 
-    terminal_input = page.locator(VSCodeSession.TERMINAL_INPUT)
+    terminal_input = page.locator(f"{VSCodeSession.TERMINAL_INPUT}:visible").last
     expect(terminal_input).to_be_visible(timeout=TIMEOUT_CODE_EXEC)
 
 

--- a/src/vip_tests/workbench/test_publish_to_connect.feature
+++ b/src/vip_tests/workbench/test_publish_to_connect.feature
@@ -9,6 +9,7 @@ Feature: Publish from Workbench to Connect
     And the user opens a VS Code session
     When the user deploys the Python Shiny app via the terminal
     Then the app is reachable on Connect
+    And the deployed app is removed from Connect
 
   Scenario: User deploys via Posit Publisher extension
     Given the user is logged in to Workbench

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -31,7 +31,7 @@ from vip_tests.workbench.conftest import (
     wait_for_session_active,
     workbench_login,
 )
-from vip_tests.workbench.exec import ExecError, terminal_run
+from vip_tests.workbench.exec import ExecError, terminal_run, write_bundle
 from vip_tests.workbench.pages import Homepage, NewSessionDialog, VSCodeSession
 
 pytestmark = pytest.mark.order(60)
@@ -181,7 +181,7 @@ def open_vscode_session(page: Page, publish_context: dict):
 def deploy_python_shiny_via_terminal(
     page: Page,
     publish_context: dict,
-    python_shiny_bundle_path: Path,
+    python_shiny_bundle_files: dict,
     connect_url: str,
     vip_config,
     connect_client,
@@ -189,10 +189,13 @@ def deploy_python_shiny_via_terminal(
 ):
     """Run ``rsconnect deploy shiny`` in the VS Code terminal and register the GUID.
 
-    ``rsconnect-python`` is not assumed to be on PATH.  We create a throwaway
-    venv from whatever ``python3`` the session provides, install
-    ``rsconnect-python`` into it, deploy with that venv's ``rsconnect``, and
-    tear the venv down afterwards.  A missing ``python3`` fails the preflight.
+    The Shiny bundle is written into the Workbench session's own filesystem via
+    the IDE terminal (``write_bundle``), so ``rsconnect`` finds it locally no
+    matter where pytest runs -- the bundle is never assumed to exist on the
+    pytest host.  ``rsconnect-python`` is not assumed to be on PATH either: we
+    create a throwaway venv from whatever ``python3`` the session provides,
+    install ``rsconnect-python`` into it, deploy with that venv's ``rsconnect``,
+    and tear the venv and bundle down afterwards.  A missing ``python3`` skips.
     """
     # Open the integrated terminal.
     page.keyboard.press("Control+`")
@@ -230,9 +233,20 @@ def deploy_python_shiny_via_terminal(
 
     title = f"vip_test_shiny_{unique_session_name(_FILENAME)}"
     venv_dir = f"/tmp/vip_rsconnect_venv_{uuid.uuid4().hex}"
+    bundle_dir = f"/tmp/vip_shiny_bundle_{uuid.uuid4().hex}"
     rsconnect_bin = f"{venv_dir}/bin/rsconnect"
 
     try:
+        # Materialize the bundle in the session's own filesystem so rsconnect
+        # finds it locally (the pytest host's /tmp is not visible here).
+        write_bundle(
+            page,
+            bundle_dir,
+            python_shiny_bundle_files,
+            timeout=_VENV_QUICK_TIMEOUT_MS,
+            readback_lang="python",
+        )
+
         # Create the venv and install rsconnect-python into it.
         terminal_run(
             page,
@@ -250,7 +264,7 @@ def deploy_python_shiny_via_terminal(
         output = terminal_run(
             page,
             (
-                f"{rsconnect_bin} deploy shiny {python_shiny_bundle_path} "
+                f"{rsconnect_bin} deploy shiny {bundle_dir} "
                 f"--server {connect_url} "
                 f"--api-key {vip_config.connect.api_key} "
                 f"--title {title}"
@@ -259,19 +273,21 @@ def deploy_python_shiny_via_terminal(
             readback_lang="python",
         )
     finally:
-        # Tear down the throwaway venv regardless of deploy outcome.
-        try:
-            terminal_run(
-                page,
-                f"rm -rf {venv_dir}",
-                timeout=_VENV_QUICK_TIMEOUT_MS,
-                readback_lang="python",
-            )
-        except ExecError:
-            warnings.warn(
-                f"Failed to remove temporary venv at {venv_dir}; manual cleanup may be required.",
-                stacklevel=2,
-            )
+        # Tear down the throwaway venv and bundle regardless of deploy outcome.
+        for path, label in ((venv_dir, "venv"), (bundle_dir, "bundle")):
+            try:
+                terminal_run(
+                    page,
+                    f"rm -rf {path}",
+                    timeout=_VENV_QUICK_TIMEOUT_MS,
+                    readback_lang="python",
+                )
+            except ExecError:
+                warnings.warn(
+                    f"Failed to remove temporary {label} at {path}; "
+                    "manual cleanup may be required.",
+                    stacklevel=2,
+                )
 
     # Primary: stable API title lookup (version-independent).
     content = connect_client._find_content_by_name(title)

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -12,6 +12,7 @@ excludes the tests when either product is absent.
 
 from __future__ import annotations
 
+import base64
 import re
 import shlex
 import time
@@ -34,24 +35,106 @@ from vip_tests.workbench.conftest import (
     wait_for_session_active,
     workbench_login,
 )
-from vip_tests.workbench.exec import ExecError, terminal_run, write_bundle
+from vip_tests.workbench.exec import ExecError, terminal_run
 from vip_tests.workbench.pages import Homepage, NewSessionDialog, VSCodeSession
 
 pytestmark = pytest.mark.order(60)
 
 _FILENAME = Path(__file__).name
 
-# Timeout for rsconnect deploy, which bundles, uploads, and deploys.
-_DEPLOY_TIMEOUT_MS = 180_000
+# Timeout for the combined setup+deploy command. With uv the venv+install take
+# ~1s and --no-verify skips rsconnect's multi-minute boot wait, so the whole
+# command finishes well under a minute; the ceiling is bounded so a hang cannot
+# consume the 5-minute suite budget.
+_DEPLOY_TIMEOUT_MS = 120_000
 
-# Timeout for the short venv-management commands (create, pip install, cleanup).
-_VENV_SETUP_TIMEOUT_MS = 120_000
+# Timeout for the short cleanup commands (rm -rf).
 _VENV_QUICK_TIMEOUT_MS = 30_000
 
 # Post-deploy reachability polling (deploy runs --no-verify, so the Shiny
 # process may still be booting when the deploy command returns).
 _REACHABILITY_TIMEOUT_S = 60
 _REACHABILITY_POLL_S = 3
+
+
+def _log(message: str) -> None:
+    """Emit a timestamped progress line so a long deploy step is not mistaken
+    for a hang. Visible under ``pytest -s`` / ``--verbose``."""
+    print(f"    [{time.strftime('%H:%M:%S')}] vip-publish: {message}", flush=True)
+
+
+def _build_deploy_script(
+    *,
+    bundle_dir: str,
+    manifest_path: str,
+    venv_dir: str,
+    app_r: str,
+    manifest_url: str,
+    platform: str,
+    connect_url: str,
+    api_key: str,
+    title: str,
+) -> str:
+    """Return a single shell command that assembles the bundle and deploys it.
+
+    Collapsing setup+deploy into one command is deliberate: every keystroke is
+    typed before anything runs, so the venv-activation terminal VS Code spawns
+    cannot hijack a later command (the multi-terminal race). The script:
+
+    1. writes ``app.R`` (base64-decoded so content survives the terminal),
+    2. downloads the reference manifest (``curl -fsS``; tags VIP_DL_FAIL on
+       network failure) and patches its ``platform`` with whatever python is
+       available,
+    3. provisions ``rsconnect`` — ``uv`` (venv+install in ~1s) when present,
+       else ``python -m venv`` + ``pip`` — tagging VIP_NO_PY if no interpreter,
+    4. runs ``rsconnect deploy manifest ... --no-verify``.
+
+    Failure tags (VIP_NO_PY / VIP_DL_FAIL) let the caller map environment
+    problems to skips while real deploy errors stay failures. Values are
+    shlex.quote'd; the title contains spaces (unique_session_name).
+    """
+    app_r_b64 = base64.b64encode(app_r.encode()).decode("ascii")
+    q_bundle = shlex.quote(bundle_dir)
+    q_manifest = shlex.quote(manifest_path)
+    q_venv = shlex.quote(venv_dir)
+    q_url = shlex.quote(manifest_url)
+    q_platform = shlex.quote(platform)
+    q_server = shlex.quote(connect_url)
+    q_key = shlex.quote(api_key)
+    q_title = shlex.quote(title)
+    # Patch platform with a python one-liner; PYBIN is resolved below. The
+    # manifest path and platform are passed as argv (shell-quoted) so Python
+    # receives the platform as a string -- interpolating it into the Python
+    # source would emit ``m['platform']=4.6.1`` (a SyntaxError), since the
+    # version is not a valid Python literal.
+    patch = (
+        '"$PYBIN" -c '
+        "'import json,sys; p=sys.argv[1]; m=json.load(open(p)); "
+        'm["platform"]=sys.argv[2]; json.dump(m,open(p,"w"))\' '
+        f"{q_manifest} {q_platform}"
+    )
+    return (
+        f"set -e; "
+        f"mkdir -p {q_bundle}; "
+        f"printf %s {app_r_b64} | base64 -d > {q_bundle}/app.R; "
+        # Resolve a python interpreter for the manifest patch (uv provides one too).
+        f'PYBIN="$(command -v python3 || command -v python || true)"; '
+        # Download the manifest (network/firewall -> VIP_DL_FAIL).
+        f"curl -fsS -o {q_manifest} {q_url} || {{ echo VIP_DL_FAIL; exit 21; }}; "
+        # Patch platform if we have a python; harmless to skip if not.
+        f'if [ -n "$PYBIN" ]; then {patch}; fi; '
+        # Provision rsconnect: prefer uv (fast), else python venv + pip.
+        f"if command -v uv >/dev/null 2>&1; then "
+        f"  uv venv {q_venv} >/dev/null && "
+        f"  uv pip install --python {q_venv}/bin/python --quiet rsconnect-python >/dev/null; "
+        f'elif [ -n "$PYBIN" ]; then '
+        f'  "$PYBIN" -m venv {q_venv} && '
+        f"  {q_venv}/bin/pip install --quiet --upgrade rsconnect-python; "
+        f"else echo VIP_NO_PY; exit 22; fi; "
+        # Deploy (--no-verify: skip rsconnect's multi-minute boot probe).
+        f"{q_venv}/bin/rsconnect deploy manifest {q_manifest} "
+        f"--server {q_server} --api-key {q_key} --title {q_title} --no-verify"
+    )
 
 
 @scenario(
@@ -225,121 +308,53 @@ def deploy_python_shiny_via_terminal(
     terminal_input = page.locator(f"{VSCodeSession.TERMINAL_INPUT}:visible").last
     expect(terminal_input).to_be_visible(timeout=TIMEOUT_SESSION_START)
 
-    # Preflight: a Python interpreter must be on PATH to build the venv.
-    # Prefer ``python3`` but accept ``python`` so sessions without the
-    # ``python3`` symlink still qualify. Absence of Python is an environment
-    # precondition, not a publishing defect, so skip rather than fail here --
-    # only a genuine deploy failure below should FAIL the check.
-    try:
-        python_bin = terminal_run(
-            page,
-            "command -v python3 || command -v python",
-            timeout=_VENV_QUICK_TIMEOUT_MS,
-            readback_lang="python",
-        ).strip()
-    except ExecError:
-        pytest.skip(
-            "Neither python3 nor python is on PATH in the Workbench session; "
-            "cannot create a venv to install rsconnect-python for deployment."
-        )
-
-    # A blank result means the readback captured no interpreter path (e.g. the
-    # command's stdout escaped the redirect). Skip rather than build an empty
-    # ``python_bin`` that would run as ``'' -m venv`` (exit 127, "-m: command
-    # not found").
-    if not python_bin:
-        pytest.skip(
-            "Could not resolve a python3/python interpreter path in the Workbench "
-            "session; the preflight returned no output, so a venv for "
-            "rsconnect-python cannot be created."
-        )
-
     title = f"vip_test_shiny_{unique_session_name(_FILENAME)}"
     venv_dir = f"/tmp/vip_rsconnect_venv_{uuid.uuid4().hex}"
     bundle_dir = f"/tmp/vip_shiny_bundle_{uuid.uuid4().hex}"
-    rsconnect_bin = f"{venv_dir}/bin/rsconnect"
-
     manifest_path = f"{bundle_dir}/manifest.json"
-    try:
-        # Assemble the bundle in the session's own filesystem so rsconnect finds
-        # it locally (the pytest host's /tmp is not visible here). app.R is tiny
-        # and typed directly; the ~80 KB manifest is fetched over HTTPS.
-        write_bundle(
-            page,
-            bundle_dir,
-            {"app.R": shiny_bundle_spec["app_r"]},
-            timeout=_VENV_QUICK_TIMEOUT_MS,
-            readback_lang="python",
-        )
 
-        # Download the reference manifest into the session. A firewalled session
-        # cannot reach the public repo -- treat that as an environment skip, not
-        # a deploy failure. curl -fsS makes HTTP errors non-zero so ExecError
-        # fires instead of silently writing an error page.
-        manifest_url = shiny_bundle_spec["manifest_url"]
+    _log("assembling bundle + provisioning rsconnect (single command)")
+    try:
+        # Run the entire setup+deploy as ONE shell command. Doing it in a single
+        # terminal_run (rather than ~6) is what makes this reliable: every
+        # keystroke is typed before any command runs, so the venv-activation
+        # terminal that VS Code's Python extension spawns cannot steal a later
+        # command (the multi-terminal race that hung earlier). It is also far
+        # faster -- uv creates the venv and installs rsconnect in ~1s vs ~40s for
+        # python -m venv + pip -- and keeps output short so the Monaco-editor
+        # readback never has to scroll past a virtualized long log.
+        setup_script = _build_deploy_script(
+            bundle_dir=bundle_dir,
+            manifest_path=manifest_path,
+            venv_dir=venv_dir,
+            app_r=shiny_bundle_spec["app_r"],
+            manifest_url=shiny_bundle_spec["manifest_url"],
+            platform=shiny_bundle_spec["platform"],
+            connect_url=connect_url,
+            api_key=vip_config.connect.api_key,
+            title=title,
+        )
         try:
-            terminal_run(
+            output = terminal_run(
                 page,
-                f"curl -fsS -o {manifest_path} {manifest_url}",
-                timeout=_VENV_QUICK_TIMEOUT_MS,
+                setup_script,
+                timeout=_DEPLOY_TIMEOUT_MS,
                 readback_lang="python",
             )
         except ExecError as exc:
-            pytest.skip(
-                f"Could not download the Shiny manifest from {manifest_url} in the "
-                f"Workbench session (network/firewall constraint): {exc}"
-            )
-
-        # Patch the manifest platform to the server's newest R, matching what the
-        # Connect deploy test does, so both suites deploy an identical bundle.
-        platform = shiny_bundle_spec["platform"]
-        terminal_run(
-            page,
-            (
-                f"{python_bin} -c "
-                f""""import json; p='{manifest_path}'; """
-                f"m=json.load(open(p)); m['platform']='{platform}'; "
-                f'''json.dump(m,open(p,'w'))"'''
-            ),
-            timeout=_VENV_QUICK_TIMEOUT_MS,
-            readback_lang="python",
-        )
-
-        # Create the venv and install rsconnect-python into it.
-        terminal_run(
-            page,
-            f"{python_bin} -m venv {venv_dir}",
-            timeout=_VENV_SETUP_TIMEOUT_MS,
-            readback_lang="python",
-        )
-        terminal_run(
-            page,
-            f"{venv_dir}/bin/pip install --quiet --upgrade rsconnect-python",
-            timeout=_VENV_SETUP_TIMEOUT_MS,
-            readback_lang="python",
-        )
-
-        # shlex.quote every interpolated value: the title contains spaces
-        # (unique_session_name → "VIP <file> - <worker>-<ns>"), which the shell
-        # would otherwise split into extra args ("Got unexpected extra
-        # arguments"); the api-key and URL are quoted defensively too.
-        # --no-verify: skip rsconnect's own post-deploy content probe, which
-        # blocks for minutes waiting for the Shiny process to boot and pushes the
-        # step past its timeout / the 5-minute suite budget. The "Then the app is
-        # reachable on Connect" step verifies reachability with a bounded retry
-        # instead. The bundle still builds server-side; we only skip the wait.
-        output = terminal_run(
-            page,
-            (
-                f"{rsconnect_bin} deploy manifest {shlex.quote(manifest_path)} "
-                f"--server {shlex.quote(connect_url)} "
-                f"--api-key {shlex.quote(vip_config.connect.api_key)} "
-                f"--title {shlex.quote(title)} "
-                f"--no-verify"
-            ),
-            timeout=_DEPLOY_TIMEOUT_MS,
-            readback_lang="python",
-        )
+            # The combined script tags its own failure modes so we can map an
+            # environment problem (no python/uv, unreachable repo) to a skip
+            # while a genuine rsconnect failure stays a hard failure.
+            msg = str(exc)
+            if "VIP_NO_PY" in msg:
+                pytest.skip("Neither uv nor python3/python is available in the Workbench session")
+            if "VIP_DL_FAIL" in msg:
+                pytest.skip(
+                    f"Could not download the Shiny manifest from "
+                    f"{shiny_bundle_spec['manifest_url']} (network/firewall constraint)"
+                )
+            raise
+        _log("deploy command returned")
     finally:
         # Tear down the throwaway venv and bundle regardless of deploy outcome.
         for path, label in ((venv_dir, "venv"), (bundle_dir, "bundle")):
@@ -369,6 +384,7 @@ def deploy_python_shiny_via_terminal(
         content_url = ""
 
     if guid:
+        _log(f"deployed content guid={guid}")
         _connect_created_guids.append(guid)
         publish_context["content_guid"] = guid
         publish_context["content_url"] = content_url
@@ -401,11 +417,12 @@ def deploy_via_publisher_ui(page: Page):
 
 @then("the app is reachable on Connect")
 def app_reachable_on_connect(publish_context: dict, connect_client):
-    """Verify the deployed content is accessible via HTTP.
+    """Verify the deployed content serves a live page via the Connect API.
 
     Deploy runs with ``--no-verify``, so the Shiny process may still be booting.
-    Poll the content URL with a bounded budget rather than assuming it is up the
-    instant the deploy command returns.
+    Using the Connect API key, poll the content URL with a bounded budget until
+    it returns a live page (HTTP < 400 whose body carries the app's "VIP test"
+    marker), rather than assuming it is up the instant the deploy returns.
     """
     guid = publish_context.get("content_guid")
     assert guid, "No content GUID was recorded by the deploy step"
@@ -415,20 +432,26 @@ def app_reachable_on_connect(publish_context: dict, connect_client):
     if not url:
         return
 
+    _log(f"verifying live app via Connect API at {url}")
     deadline = time.monotonic() + _REACHABILITY_TIMEOUT_S
     last_status = None
     while time.monotonic() < deadline:
         try:
             resp = connect_client.fetch_content(url)
             last_status = resp.status_code
-            if resp.status_code < 400:
+            # A booted Shiny app returns its HTML shell containing the UI text.
+            if resp.status_code < 400 and "vip test" in resp.text.lower():
+                _log(f"live app confirmed (HTTP {resp.status_code}, 'VIP test' rendered)")
                 return
+            # Page reachable but content not yet rendered — keep polling.
+            if resp.status_code < 400:
+                last_status = f"{resp.status_code} (marker not yet present)"
         except Exception as exc:  # transient during first-boot
             last_status = repr(exc)
         time.sleep(_REACHABILITY_POLL_S)
 
     raise AssertionError(
-        f"Deployed content at {url!r} was not reachable within "
+        f"Deployed content at {url!r} was not confirmed live within "
         f"{_REACHABILITY_TIMEOUT_S}s (last result: {last_status})"
     )
 
@@ -445,5 +468,7 @@ def deployed_app_removed_from_connect(publish_context: dict, connect_client):
     guid = publish_context.get("content_guid")
     assert guid, "No content GUID was recorded by the deploy step"
 
+    _log(f"removing deployed content guid={guid}")
     removed = connect_client._delete_content_verified(guid)
     assert removed, f"Deployed content {guid} was not removed from Connect"
+    _log("deployed content removed")

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import re
 import shlex
+import time
 import uuid
 import warnings
 from pathlib import Path
@@ -46,6 +47,11 @@ _DEPLOY_TIMEOUT_MS = 180_000
 # Timeout for the short venv-management commands (create, pip install, cleanup).
 _VENV_SETUP_TIMEOUT_MS = 120_000
 _VENV_QUICK_TIMEOUT_MS = 30_000
+
+# Post-deploy reachability polling (deploy runs --no-verify, so the Shiny
+# process may still be booting when the deploy command returns).
+_REACHABILITY_TIMEOUT_S = 60
+_REACHABILITY_POLL_S = 3
 
 
 @scenario(
@@ -317,13 +323,19 @@ def deploy_python_shiny_via_terminal(
         # (unique_session_name → "VIP <file> - <worker>-<ns>"), which the shell
         # would otherwise split into extra args ("Got unexpected extra
         # arguments"); the api-key and URL are quoted defensively too.
+        # --no-verify: skip rsconnect's own post-deploy content probe, which
+        # blocks for minutes waiting for the Shiny process to boot and pushes the
+        # step past its timeout / the 5-minute suite budget. The "Then the app is
+        # reachable on Connect" step verifies reachability with a bounded retry
+        # instead. The bundle still builds server-side; we only skip the wait.
         output = terminal_run(
             page,
             (
                 f"{rsconnect_bin} deploy manifest {shlex.quote(manifest_path)} "
                 f"--server {shlex.quote(connect_url)} "
                 f"--api-key {shlex.quote(vip_config.connect.api_key)} "
-                f"--title {shlex.quote(title)}"
+                f"--title {shlex.quote(title)} "
+                f"--no-verify"
             ),
             timeout=_DEPLOY_TIMEOUT_MS,
             readback_lang="python",
@@ -389,17 +401,36 @@ def deploy_via_publisher_ui(page: Page):
 
 @then("the app is reachable on Connect")
 def app_reachable_on_connect(publish_context: dict, connect_client):
-    """Verify the deployed content is accessible via HTTP."""
+    """Verify the deployed content is accessible via HTTP.
+
+    Deploy runs with ``--no-verify``, so the Shiny process may still be booting.
+    Poll the content URL with a bounded budget rather than assuming it is up the
+    instant the deploy command returns.
+    """
     guid = publish_context.get("content_guid")
     assert guid, "No content GUID was recorded by the deploy step"
 
     content = connect_client.get_content(guid)
     url = publish_context.get("content_url") or content.get("content_url", "")
-    if url:
-        resp = connect_client.fetch_content(url)
-        assert resp.status_code < 400, (
-            f"Deployed content at {url!r} returned HTTP {resp.status_code}"
-        )
+    if not url:
+        return
+
+    deadline = time.monotonic() + _REACHABILITY_TIMEOUT_S
+    last_status = None
+    while time.monotonic() < deadline:
+        try:
+            resp = connect_client.fetch_content(url)
+            last_status = resp.status_code
+            if resp.status_code < 400:
+                return
+        except Exception as exc:  # transient during first-boot
+            last_status = repr(exc)
+        time.sleep(_REACHABILITY_POLL_S)
+
+    raise AssertionError(
+        f"Deployed content at {url!r} was not reachable within "
+        f"{_REACHABILITY_TIMEOUT_S}s (last result: {last_status})"
+    )
 
 
 @then("the deployed app is removed from Connect")

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -42,17 +42,24 @@ pytestmark = pytest.mark.order(60)
 
 _FILENAME = Path(__file__).name
 
-# Timeout for the combined setup+deploy command. With uv the venv+install take
-# ~1s and --no-verify skips rsconnect's multi-minute boot wait, so the whole
-# command finishes well under a minute; the ceiling is bounded so a hang cannot
-# consume the 5-minute suite budget.
-_DEPLOY_TIMEOUT_MS = 120_000
+# Timeout for the combined setup+deploy command. `--no-verify` skips ONLY
+# rsconnect's client-side post-deploy app-boot probe; it does NOT skip the
+# server-side deployment task -- rsconnect's emit_task_log()/wait_for_task()
+# runs unconditionally and blocks until Connect finishes restoring the manifest's
+# full package closure. On a cold Connect package cache that restore compiles the
+# ~30-package R closure from source and routinely runs many minutes, so the
+# ceiling must be generous (a tight bound would fail a healthy-but-slow build).
+# Bounded so a genuine hang still cannot run unbounded; this test is @slow-tagged
+# and excluded from `verify --basic`.
+_DEPLOY_TIMEOUT_MS = 900_000  # 15 min
 
 # Timeout for the short cleanup commands (rm -rf).
 _VENV_QUICK_TIMEOUT_MS = 30_000
 
-# Post-deploy reachability polling (deploy runs --no-verify, so the Shiny
-# process may still be booting when the deploy command returns).
+# Post-deploy reachability polling. rsconnect exit 0 already means the server-side
+# build finished (see above), but deploy runs with --no-verify so the Shiny
+# worker process may still be booting when the command returns; poll the content
+# URL for a bounded window until it serves.
 _REACHABILITY_TIMEOUT_S = 60
 _REACHABILITY_POLL_S = 3
 
@@ -70,6 +77,7 @@ def _build_deploy_script(
     venv_dir: str,
     app_r: str,
     manifest_url: str,
+    manifest_url_fallback: str,
     platform: str,
     connect_url: str,
     api_key: str,
@@ -82,22 +90,38 @@ def _build_deploy_script(
     cannot hijack a later command (the multi-terminal race). The script:
 
     1. writes ``app.R`` (base64-decoded so content survives the terminal),
-    2. downloads the reference manifest (``curl -fsS``; tags VIP_DL_FAIL on
-       network failure) and patches its ``platform`` with whatever python is
-       available,
-    3. provisions ``rsconnect`` — ``uv`` (venv+install in ~1s) when present,
-       else ``python -m venv`` + ``pip`` — tagging VIP_NO_PY if no interpreter,
-    4. runs ``rsconnect deploy manifest ... --no-verify``.
+    2. preflights Connect *from inside the session* — ``curl`` the server URL and
+       map each transport failure to a distinct tag: DNS (VIP_CONNECT_DNS),
+       connect/timeout (VIP_CONNECT_UNREACHABLE), TLS trust (VIP_CONNECT_UNTRUSTED).
+       The URL the pytest host reaches is not necessarily reachable from the
+       Workbench server (split-horizon DNS, egress firewall, internal CA),
+    3. downloads the reference manifest, trying the pinned release tag first and
+       falling back to ``main`` (so an unreleased/dev version whose tag 404s still
+       works); tags VIP_DL_FAIL only if *both* fail, then patches its ``platform``
+       with whatever python is available,
+    4. provisions ``rsconnect`` — ``uv`` (venv+install in ~1s) when present,
+       else ``python -m venv`` + ``pip`` — tagging VIP_NO_PY if no interpreter and
+       VIP_NO_RSCONNECT if the install itself fails (air-gapped / no PyPI mirror),
+    5. runs ``rsconnect deploy manifest ... --no-verify``.
 
-    Failure tags (VIP_NO_PY / VIP_DL_FAIL) let the caller map environment
-    problems to skips while real deploy errors stay failures. Values are
-    shlex.quote'd; the title contains spaces (unique_session_name).
+    Failure tags let the caller map environment problems to skips while real
+    deploy errors stay failures:
+
+    - VIP_CONNECT_DNS / VIP_CONNECT_UNREACHABLE / VIP_CONNECT_UNTRUSTED — the
+      session cannot resolve / reach / trust the Connect URL,
+    - VIP_DL_FAIL — reference manifest unreachable at both the tag and ``main``,
+    - VIP_NO_PY — no python interpreter and no uv,
+    - VIP_NO_RSCONNECT — an interpreter exists but rsconnect-python could not be
+      installed (no PyPI or internal mirror reachable).
+
+    Values are shlex.quote'd; the title contains spaces (unique_session_name).
     """
     app_r_b64 = base64.b64encode(app_r.encode()).decode("ascii")
     q_bundle = shlex.quote(bundle_dir)
     q_manifest = shlex.quote(manifest_path)
     q_venv = shlex.quote(venv_dir)
     q_url = shlex.quote(manifest_url)
+    q_url_fallback = shlex.quote(manifest_url_fallback)
     q_platform = shlex.quote(platform)
     q_server = shlex.quote(connect_url)
     q_key = shlex.quote(api_key)
@@ -119,19 +143,52 @@ def _build_deploy_script(
         f"printf %s {app_r_b64} | base64 -d > {q_bundle}/app.R; "
         # Resolve a python interpreter for the manifest patch (uv provides one too).
         f'PYBIN="$(command -v python3 || command -v python || true)"; '
-        # Download the manifest (network/firewall -> VIP_DL_FAIL).
-        f"curl -fsS -o {q_manifest} {q_url} || {{ echo VIP_DL_FAIL; exit 21; }}; "
+        # -- Preflight: can THIS session resolve / reach / trust Connect? --------
+        # The URL the pytest host uses is not necessarily reachable from the
+        # Workbench server. curl's exit code separates the failure classes so the
+        # caller can skip with a message that names the actual constraint:
+        #   6  -> DNS resolution failed         (VIP_CONNECT_DNS)
+        #   60/77/35/58/59/83 -> TLS trust/cert (VIP_CONNECT_UNTRUSTED)
+        #   7/28/other        -> connect/timeout(VIP_CONNECT_UNREACHABLE)
+        # --head keeps it cheap; --max-time bounds a black-hole firewall.
+        # Capture the rc INLINE (`|| CURL_RC=$?`): a bare `curl; CURL_RC=$?` would
+        # trip `set -e` on a failing curl and abort before the rc is read.
+        # No -f here: an HTTP 404/redirect at the Connect root is fine -- we are
+        # testing transport + TLS trust, not the root page's status. -f is kept on
+        # the manifest download below, where a 4xx genuinely means "not found".
+        f"CURL_RC=0; curl -sS --head --max-time 20 -o /dev/null {q_server} || CURL_RC=$?; "
+        f'if [ "$CURL_RC" != 0 ]; then '
+        f'  if [ "$CURL_RC" = 6 ]; then echo VIP_CONNECT_DNS; exit 23; '
+        f'  elif [ "$CURL_RC" = 60 ] || [ "$CURL_RC" = 77 ] || [ "$CURL_RC" = 35 ] '
+        f'    || [ "$CURL_RC" = 58 ] || [ "$CURL_RC" = 59 ] || [ "$CURL_RC" = 83 ]; then '
+        f"    echo VIP_CONNECT_UNTRUSTED; exit 24; "
+        f"  else echo VIP_CONNECT_UNREACHABLE; exit 25; fi; "
+        f"fi; "
+        # Download the manifest: pinned release tag first, then main; only if BOTH
+        # fail is it a real environment/network problem (VIP_DL_FAIL). A dev
+        # checkout whose tag is not yet pushed 404s on the tag but resolves on main.
+        f"curl -fsS -o {q_manifest} {q_url} "
+        f"|| curl -fsS -o {q_manifest} {q_url_fallback} "
+        f"|| {{ echo VIP_DL_FAIL; exit 21; }}; "
         # Patch platform if we have a python; harmless to skip if not.
         f'if [ -n "$PYBIN" ]; then {patch}; fi; '
-        # Provision rsconnect: prefer uv (fast), else python venv + pip.
+        # Provision rsconnect: prefer uv (fast), else python venv + pip. A failed
+        # install (no PyPI / internal mirror reachable, i.e. air-gapped) is an
+        # environment constraint, not a publishing defect -> VIP_NO_RSCONNECT.
+        # Each step guards itself with `|| { echo TAG; exit N; }` (separate
+        # statements, not nested brace groups) so `set -e` cannot abort before the
+        # tag is emitted -- that untagged abort is exactly the pre-fix failure.
         f"if command -v uv >/dev/null 2>&1; then "
-        f"  uv venv {q_venv} >/dev/null && "
-        f"  uv pip install --python {q_venv}/bin/python --quiet rsconnect-python >/dev/null; "
+        f"  uv venv {q_venv} >/dev/null || {{ echo VIP_NO_RSCONNECT; exit 26; }}; "
+        f"  uv pip install --python {q_venv}/bin/python --quiet rsconnect-python >/dev/null "
+        f"    || {{ echo VIP_NO_RSCONNECT; exit 26; }}; "
         f'elif [ -n "$PYBIN" ]; then '
-        f'  "$PYBIN" -m venv {q_venv} && '
-        f"  {q_venv}/bin/pip install --quiet --upgrade rsconnect-python; "
+        f'  "$PYBIN" -m venv {q_venv} || {{ echo VIP_NO_RSCONNECT; exit 26; }}; '
+        f"  {q_venv}/bin/pip install --quiet --upgrade rsconnect-python "
+        f"    || {{ echo VIP_NO_RSCONNECT; exit 26; }}; "
         f"else echo VIP_NO_PY; exit 22; fi; "
-        # Deploy (--no-verify: skip rsconnect's multi-minute boot probe).
+        # Deploy. --no-verify skips only rsconnect's client-side app-boot probe;
+        # the command still blocks until Connect's server-side build finishes.
         f"{q_venv}/bin/rsconnect deploy manifest {q_manifest} "
         f"--server {q_server} --api-key {q_key} --title {q_title} --no-verify"
     )
@@ -290,16 +347,24 @@ def deploy_python_shiny_via_terminal(
     ``rsconnect`` finds it locally no matter where pytest runs: the tiny
     ``app.R`` is typed via the terminal, while the ~80 KB ``manifest.json`` (the
     full package closure -- far too large to type reliably) is downloaded from
-    the public repo with ``curl`` and its ``platform`` patched to the server's R.
-    A download blocked by a firewall skips (an environment constraint, not a
-    publishing defect).
+    the public repo with ``curl`` (pinned tag, falling back to ``main``) and its
+    ``platform`` patched to the server's R.
 
     ``rsconnect-python`` is not assumed to be on PATH: the whole setup+deploy
     runs as a single shell command (see ``_build_deploy_script``) that
     provisions a throwaway venv -- preferring ``uv`` (venv + install in ~1s),
     falling back to ``python -m venv`` + ``pip`` -- deploys with that venv's
-    ``rsconnect``, and the venv and bundle are torn down afterwards.  When no
-    interpreter is available the script tags ``VIP_NO_PY`` and the step skips.
+    ``rsconnect``, and the venv and bundle are torn down afterwards.
+
+    Because the deploy runs *inside the Workbench session* (not the pytest host),
+    the script preflights and tags every environment constraint on the
+    session→Connect and session→PyPI axes so each maps to an actionable skip
+    rather than an opaque failure: ``VIP_CONNECT_DNS`` /
+    ``VIP_CONNECT_UNREACHABLE`` / ``VIP_CONNECT_UNTRUSTED`` (session cannot
+    resolve/reach/trust Connect), ``VIP_DL_FAIL`` (manifest unreachable at both
+    the tag and ``main``), ``VIP_NO_PY`` (no interpreter), and
+    ``VIP_NO_RSCONNECT`` (interpreter present but rsconnect-python uninstallable,
+    e.g. air-gapped).  A genuine ``rsconnect deploy`` failure stays a hard failure.
     """
     # Open the integrated terminal. Filter to the visible input: a VS Code
     # session can end up with more than one terminal (e.g. the Python extension
@@ -331,6 +396,7 @@ def deploy_python_shiny_via_terminal(
             venv_dir=venv_dir,
             app_r=shiny_bundle_spec["app_r"],
             manifest_url=shiny_bundle_spec["manifest_url"],
+            manifest_url_fallback=shiny_bundle_spec["manifest_url_fallback"],
             platform=shiny_bundle_spec["platform"],
             connect_url=connect_url,
             api_key=vip_config.connect.api_key,
@@ -345,15 +411,41 @@ def deploy_python_shiny_via_terminal(
             )
         except ExecError as exc:
             # The combined script tags its own failure modes so we can map an
-            # environment problem (no python/uv, unreachable repo) to a skip
-            # while a genuine rsconnect failure stays a hard failure.
+            # environment problem (Connect unreachable from the session, no
+            # python/uv, no PyPI mirror, unreachable repo) to a skip while a
+            # genuine rsconnect deploy failure stays a hard failure.
             msg = str(exc)
+            if "VIP_CONNECT_DNS" in msg:
+                pytest.skip(
+                    f"The Workbench session cannot resolve the Connect host "
+                    f"{connect_url!r} (DNS failure — the URL the test host uses may "
+                    "differ from what the session can resolve, e.g. split-horizon DNS)"
+                )
+            if "VIP_CONNECT_UNTRUSTED" in msg:
+                pytest.skip(
+                    f"The Workbench session does not trust the Connect TLS certificate "
+                    f"at {connect_url!r} (self-signed / internal CA not in the session's "
+                    "trust store); rsconnect would reject the connection"
+                )
+            if "VIP_CONNECT_UNREACHABLE" in msg:
+                pytest.skip(
+                    f"The Workbench session cannot reach Connect at {connect_url!r} "
+                    "(connection refused/timeout — egress firewall or internal-only "
+                    "Connect hostname unreachable from the session)"
+                )
             if "VIP_NO_PY" in msg:
                 pytest.skip("Neither uv nor python3/python is available in the Workbench session")
+            if "VIP_NO_RSCONNECT" in msg:
+                pytest.skip(
+                    "rsconnect-python could not be installed in the Workbench session "
+                    "(no PyPI or internal package mirror reachable — likely air-gapped)"
+                )
             if "VIP_DL_FAIL" in msg:
                 pytest.skip(
                     f"Could not download the Shiny manifest from "
-                    f"{shiny_bundle_spec['manifest_url']} (network/firewall constraint)"
+                    f"{shiny_bundle_spec['manifest_url']} or its main-branch fallback "
+                    f"{shiny_bundle_spec['manifest_url_fallback']} "
+                    "(network/firewall constraint, or the ref does not exist)"
                 )
             raise
         _log("deploy command returned")
@@ -421,44 +513,106 @@ def deploy_via_publisher_ui(page: Page):
     )
 
 
+# HTTP status classification for a freshly-deployed Connect content URL,
+# confirmed against posit-dev/connect serving source:
+#   200            -> worker booted and is proxying (for a static-UI Shiny app,
+#                     Connect only proxies AFTER the worker accepts a connection,
+#                     so this is not a pre-boot loading shell); marker must render.
+#   503            -> env restore / worker boot still in progress -> keep polling.
+#   502            -> proxy round-trip failed (worker not yet listening or dropped);
+#                     usually transient in the first seconds -> keep polling.
+#   500            -> StartupError ("startup took too long" / launcher error): the
+#                     app tried to boot and Connect gave up -> runtime DEFECT (fail).
+#   401/403/404    -> unauthenticated / locked / API key lacks view permission
+#                     (Connect returns 404, not 403, to avoid leaking existence):
+#                     an auth/permission ENVIRONMENT problem, not a publish defect.
+_CONNECT_BOOTING_STATUSES = frozenset({502, 503})
+_CONNECT_AUTH_STATUSES = frozenset({401, 403, 404})
+
+
 @then("the app is reachable on Connect")
 def app_reachable_on_connect(publish_context: dict, connect_client):
     """Verify the deployed content serves a live page via the Connect API.
 
-    Deploy runs with ``--no-verify``, so the Shiny process may still be booting.
-    Using the Connect API key, poll the content URL with a bounded budget until
-    it returns a live page (HTTP < 400 whose body carries the app's "VIP test"
-    marker), rather than assuming it is up the instant the deploy returns.
+    Deploy runs with ``--no-verify``, so the Shiny worker may still be booting
+    when the deploy command returns (the server-side build itself is already
+    done — rsconnect blocks on it regardless of ``--no-verify``). Using the
+    Connect API key, poll the content URL until it returns a live page (HTTP 200
+    whose body carries the app's static "VIP test" marker).
+
+    Each status is classified rather than treated as pass/keep-polling only
+    (see ``_CONNECT_*`` tables): a 500 StartupError is a runtime defect and
+    fails; a 401/403/404 is an auth/permission environment problem and skips; a
+    502/503 is still-booting and keeps polling. The URL is always determined
+    (constructed from the GUID as a last resort) so the check can never silently
+    pass without actually fetching the app.
     """
     guid = publish_context.get("content_guid")
     assert guid, "No content GUID was recorded by the deploy step"
 
-    content = connect_client.get_content(guid)
+    # get_content raise_for_status()es; a transient 404/5xx immediately after
+    # deploy must not crash the check, so fall back to the recorded/derived URL.
+    try:
+        content = connect_client.get_content(guid)
+    except Exception:
+        content = {}
+
+    # Determine the content URL, never leaving it empty: recorded value first,
+    # then the API's content_url, then constructed from the base URL + GUID.
+    # A silent "no URL -> return" would let this step pass without a single fetch.
     url = publish_context.get("content_url") or content.get("content_url", "")
     if not url:
-        return
+        base = getattr(connect_client, "base_url", "") or ""
+        assert base, (
+            f"Could not determine a content URL for {guid} and the Connect client "
+            "exposes no base_url — cannot verify reachability"
+        )
+        url = f"{base.rstrip('/')}/content/{guid}/"
 
     _log(f"verifying live app via Connect API at {url}")
     deadline = time.monotonic() + _REACHABILITY_TIMEOUT_S
     last_status = None
+    saw_startup_error = False
     while time.monotonic() < deadline:
         try:
             resp = connect_client.fetch_content(url)
-            last_status = resp.status_code
-            # A booted Shiny app returns its HTML shell containing the UI text.
-            if resp.status_code < 400 and "vip test" in resp.text.lower():
-                _log(f"live app confirmed (HTTP {resp.status_code}, 'VIP test' rendered)")
+            status = resp.status_code
+            # 200 + rendered static marker == the app actually booted and served.
+            if status == 200 and "vip test" in resp.text.lower():
+                _log("live app confirmed (HTTP 200, 'VIP test' rendered)")
                 return
-            # Page reachable but content not yet rendered — keep polling.
-            if resp.status_code < 400:
-                last_status = f"{resp.status_code} (marker not yet present)"
-        except Exception as exc:  # transient during first-boot
+            if status == 200:
+                last_status = "200 (marker not yet rendered)"
+            elif status == 500:
+                # StartupError: a real runtime failure. Keep polling in case a
+                # later request re-triggers a launch, but remember it so the final
+                # message names the defect rather than a generic timeout.
+                saw_startup_error = True
+                last_status = "500 (Connect StartupError — app failed to boot)"
+            elif status in _CONNECT_AUTH_STATUSES:
+                pytest.skip(
+                    f"Connect returned HTTP {status} for {url!r}: the API key cannot "
+                    "view the deployed content (unauthenticated / locked / lacks "
+                    "view permission). This is an auth/permission environment "
+                    "constraint, not a publishing defect."
+                )
+            elif status in _CONNECT_BOOTING_STATUSES:
+                last_status = f"{status} (worker still booting)"
+            else:
+                last_status = str(status)
+        except Exception as exc:  # transient during first-boot (conn reset, etc.)
             last_status = repr(exc)
         time.sleep(_REACHABILITY_POLL_S)
 
+    detail = (
+        "the app reported a Connect StartupError (HTTP 500) and never served the "
+        "'VIP test' marker — a runtime failure, not a slow boot"
+        if saw_startup_error
+        else f"last result: {last_status}"
+    )
     raise AssertionError(
         f"Deployed content at {url!r} was not confirmed live within "
-        f"{_REACHABILITY_TIMEOUT_S}s (last result: {last_status})"
+        f"{_REACHABILITY_TIMEOUT_S}s ({detail})"
     )
 
 

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -22,6 +22,7 @@ import pytest
 from playwright.sync_api import Page, expect
 from pytest_bdd import given, scenario, then, when
 
+from vip.clients.connect import _VIP_CONTENT_TAG
 from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_IDE_LOAD,
@@ -359,6 +360,11 @@ def deploy_python_shiny_via_terminal(
         _connect_created_guids.append(guid)
         publish_context["content_guid"] = guid
         publish_context["content_url"] = content_url
+        # rsconnect deploy does not go through connect_client.create_content, so
+        # the content is not auto-tagged. Tag it with _vip_test explicitly so
+        # `vip cleanup` (and the end-of-run sweep) can find and remove it even if
+        # this test's own teardown below is skipped or fails. Best-effort.
+        connect_client._tag_content(guid, _VIP_CONTENT_TAG)
     else:
         warnings.warn(
             f"Could not determine GUID for deployed content '{title}'; "
@@ -394,3 +400,19 @@ def app_reachable_on_connect(publish_context: dict, connect_client):
         assert resp.status_code < 400, (
             f"Deployed content at {url!r} returned HTTP {resp.status_code}"
         )
+
+
+@then("the deployed app is removed from Connect")
+def deployed_app_removed_from_connect(publish_context: dict, connect_client):
+    """Delete the deployed content and verify it is gone.
+
+    This test creates the content, so cleaning it up is part of the scenario --
+    the run must not leave the app behind. The item is also _vip_test-tagged and
+    registered in _connect_created_guids, so `vip cleanup` and the end-of-run
+    sweep remove it as a backstop if this step is skipped.
+    """
+    guid = publish_context.get("content_guid")
+    assert guid, "No content GUID was recorded by the deploy step"
+
+    removed = connect_client._delete_content_verified(guid)
+    assert removed, f"Deployed content {guid} was not removed from Connect"

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -294,10 +294,12 @@ def deploy_python_shiny_via_terminal(
     A download blocked by a firewall skips (an environment constraint, not a
     publishing defect).
 
-    ``rsconnect-python`` is not assumed to be on PATH: we create a throwaway
-    venv from whatever ``python3`` the session provides, install
-    ``rsconnect-python`` into it, deploy with that venv's ``rsconnect``, and tear
-    the venv and bundle down afterwards.  A missing ``python3`` skips.
+    ``rsconnect-python`` is not assumed to be on PATH: the whole setup+deploy
+    runs as a single shell command (see ``_build_deploy_script``) that
+    provisions a throwaway venv -- preferring ``uv`` (venv + install in ~1s),
+    falling back to ``python -m venv`` + ``pip`` -- deploys with that venv's
+    ``rsconnect``, and the venv and bundle are torn down afterwards.  When no
+    interpreter is available the script tags ``VIP_NO_PY`` and the step skips.
     """
     # Open the integrated terminal. Filter to the visible input: a VS Code
     # session can end up with more than one terminal (e.g. the Python extension

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -208,9 +208,13 @@ def deploy_python_shiny_via_terminal(
     ``rsconnect-python`` into it, deploy with that venv's ``rsconnect``, and tear
     the venv and bundle down afterwards.  A missing ``python3`` skips.
     """
-    # Open the integrated terminal.
+    # Open the integrated terminal. Filter to the visible input: a VS Code
+    # session can end up with more than one terminal (e.g. the Python extension
+    # spawns one to activate a venv), and a bare ``.xterm-helper-textarea``
+    # locator then trips Playwright's strict mode. terminal_run re-ensures the
+    # terminal itself, so this just confirms an input is present.
     page.keyboard.press("Control+`")
-    terminal_input = page.locator(VSCodeSession.TERMINAL_INPUT)
+    terminal_input = page.locator(f"{VSCodeSession.TERMINAL_INPUT}:visible").last
     expect(terminal_input).to_be_visible(timeout=TIMEOUT_SESSION_START)
 
     # Preflight: a Python interpreter must be on PATH to build the venv.

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -415,32 +415,42 @@ def deploy_python_shiny_via_terminal(
             # python/uv, no PyPI mirror, unreachable repo) to a skip while a
             # genuine rsconnect deploy failure stays a hard failure.
             msg = str(exc)
-            if "VIP_CONNECT_DNS" in msg:
+            # Dispatch on the script's EXIT CODE, not on the tag string. The
+            # ExecError message embeds the whole command (``command {cmd!r} ...``),
+            # and the command text literally contains every ``echo VIP_*`` tag, so
+            # ``"VIP_CONNECT_DNS" in msg`` is true for *any* failure -- it would
+            # mislabel a TLS/unreachable/install failure as a DNS failure. Each
+            # tag has a unique exit code, which appears exactly once, so matching
+            # ``exited with status <code>`` is unambiguous. The tag is still echoed
+            # (visible in the captured output) for a human reading the transcript.
+            code_m = re.search(r"exited with status (\d+)", msg)
+            code = int(code_m.group(1)) if code_m else None
+            if code == 23:
                 pytest.skip(
                     f"The Workbench session cannot resolve the Connect host "
                     f"{connect_url!r} (DNS failure — the URL the test host uses may "
                     "differ from what the session can resolve, e.g. split-horizon DNS)"
                 )
-            if "VIP_CONNECT_UNTRUSTED" in msg:
+            if code == 24:
                 pytest.skip(
                     f"The Workbench session does not trust the Connect TLS certificate "
                     f"at {connect_url!r} (self-signed / internal CA not in the session's "
                     "trust store); rsconnect would reject the connection"
                 )
-            if "VIP_CONNECT_UNREACHABLE" in msg:
+            if code == 25:
                 pytest.skip(
                     f"The Workbench session cannot reach Connect at {connect_url!r} "
                     "(connection refused/timeout — egress firewall or internal-only "
                     "Connect hostname unreachable from the session)"
                 )
-            if "VIP_NO_PY" in msg:
+            if code == 22:
                 pytest.skip("Neither uv nor python3/python is available in the Workbench session")
-            if "VIP_NO_RSCONNECT" in msg:
+            if code == 26:
                 pytest.skip(
                     "rsconnect-python could not be installed in the Workbench session "
                     "(no PyPI or internal package mirror reachable — likely air-gapped)"
                 )
-            if "VIP_DL_FAIL" in msg:
+            if code == 21:
                 pytest.skip(
                     f"Could not download the Shiny manifest from "
                     f"{shiny_bundle_spec['manifest_url']} or its main-branch fallback "

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -181,21 +181,26 @@ def open_vscode_session(page: Page, publish_context: dict):
 def deploy_python_shiny_via_terminal(
     page: Page,
     publish_context: dict,
-    python_shiny_bundle_files: dict,
+    shiny_bundle_files: dict,
     connect_url: str,
     vip_config,
     connect_client,
     _connect_created_guids: list,
 ):
-    """Run ``rsconnect deploy shiny`` in the VS Code terminal and register the GUID.
+    """Run ``rsconnect deploy manifest`` in the VS Code terminal and register the GUID.
 
-    The Shiny bundle is written into the Workbench session's own filesystem via
+    Deploys the *same* Shiny bundle as the Connect deploy test (shared
+    ``connect.bundles.build_shiny_bundle_files``): a minimal R ``app.R`` plus
+    the reference ``shiny_manifest.json``.  ``deploy manifest`` -- unlike
+    ``deploy shiny``, which is Python-only -- deploys any content type from a
+    prepared manifest and builds it server-side, so the session needs no local
+    R.  The bundle is written into the Workbench session's own filesystem via
     the IDE terminal (``write_bundle``), so ``rsconnect`` finds it locally no
-    matter where pytest runs -- the bundle is never assumed to exist on the
-    pytest host.  ``rsconnect-python`` is not assumed to be on PATH either: we
-    create a throwaway venv from whatever ``python3`` the session provides,
-    install ``rsconnect-python`` into it, deploy with that venv's ``rsconnect``,
-    and tear the venv and bundle down afterwards.  A missing ``python3`` skips.
+    matter where pytest runs.  ``rsconnect-python`` is not assumed to be on
+    PATH: we create a throwaway venv from whatever ``python3`` the session
+    provides, install ``rsconnect-python`` into it, deploy with that venv's
+    ``rsconnect``, and tear the venv and bundle down afterwards.  A missing
+    ``python3`` skips.
     """
     # Open the integrated terminal.
     page.keyboard.press("Control+`")
@@ -242,7 +247,7 @@ def deploy_python_shiny_via_terminal(
         write_bundle(
             page,
             bundle_dir,
-            python_shiny_bundle_files,
+            shiny_bundle_files,
             timeout=_VENV_QUICK_TIMEOUT_MS,
             readback_lang="python",
         )
@@ -264,7 +269,7 @@ def deploy_python_shiny_via_terminal(
         output = terminal_run(
             page,
             (
-                f"{rsconnect_bin} deploy shiny {bundle_dir} "
+                f"{rsconnect_bin} deploy manifest {bundle_dir}/manifest.json "
                 f"--server {connect_url} "
                 f"--api-key {vip_config.connect.api_key} "
                 f"--title {title}"

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -181,7 +181,7 @@ def open_vscode_session(page: Page, publish_context: dict):
 def deploy_python_shiny_via_terminal(
     page: Page,
     publish_context: dict,
-    shiny_bundle_files: dict,
+    shiny_bundle_spec: dict,
     connect_url: str,
     vip_config,
     connect_client,
@@ -189,18 +189,24 @@ def deploy_python_shiny_via_terminal(
 ):
     """Run ``rsconnect deploy manifest`` in the VS Code terminal and register the GUID.
 
-    Deploys the *same* Shiny bundle as the Connect deploy test (shared
-    ``connect.bundles.build_shiny_bundle_files``): a minimal R ``app.R`` plus
-    the reference ``shiny_manifest.json``.  ``deploy manifest`` -- unlike
-    ``deploy shiny``, which is Python-only -- deploys any content type from a
-    prepared manifest and builds it server-side, so the session needs no local
-    R.  The bundle is written into the Workbench session's own filesystem via
-    the IDE terminal (``write_bundle``), so ``rsconnect`` finds it locally no
-    matter where pytest runs.  ``rsconnect-python`` is not assumed to be on
-    PATH: we create a throwaway venv from whatever ``python3`` the session
-    provides, install ``rsconnect-python`` into it, deploy with that venv's
-    ``rsconnect``, and tear the venv and bundle down afterwards.  A missing
-    ``python3`` skips.
+    Deploys the *same* Shiny bundle as the Connect deploy test: the minimal R
+    ``app.R`` plus the reference ``shiny_manifest.json``.  ``deploy manifest`` --
+    unlike ``deploy shiny``, which is Python-only -- deploys any content type
+    from a prepared manifest and builds it server-side, so the session needs no
+    local R.
+
+    The bundle is assembled inside the Workbench session's own filesystem so
+    ``rsconnect`` finds it locally no matter where pytest runs: the tiny
+    ``app.R`` is typed via the terminal, while the ~80 KB ``manifest.json`` (the
+    full package closure -- far too large to type reliably) is downloaded from
+    the public repo with ``curl`` and its ``platform`` patched to the server's R.
+    A download blocked by a firewall skips (an environment constraint, not a
+    publishing defect).
+
+    ``rsconnect-python`` is not assumed to be on PATH: we create a throwaway
+    venv from whatever ``python3`` the session provides, install
+    ``rsconnect-python`` into it, deploy with that venv's ``rsconnect``, and tear
+    the venv and bundle down afterwards.  A missing ``python3`` skips.
     """
     # Open the integrated terminal.
     page.keyboard.press("Control+`")
@@ -241,13 +247,48 @@ def deploy_python_shiny_via_terminal(
     bundle_dir = f"/tmp/vip_shiny_bundle_{uuid.uuid4().hex}"
     rsconnect_bin = f"{venv_dir}/bin/rsconnect"
 
+    manifest_path = f"{bundle_dir}/manifest.json"
     try:
-        # Materialize the bundle in the session's own filesystem so rsconnect
-        # finds it locally (the pytest host's /tmp is not visible here).
+        # Assemble the bundle in the session's own filesystem so rsconnect finds
+        # it locally (the pytest host's /tmp is not visible here). app.R is tiny
+        # and typed directly; the ~80 KB manifest is fetched over HTTPS.
         write_bundle(
             page,
             bundle_dir,
-            shiny_bundle_files,
+            {"app.R": shiny_bundle_spec["app_r"]},
+            timeout=_VENV_QUICK_TIMEOUT_MS,
+            readback_lang="python",
+        )
+
+        # Download the reference manifest into the session. A firewalled session
+        # cannot reach the public repo -- treat that as an environment skip, not
+        # a deploy failure. curl -fsS makes HTTP errors non-zero so ExecError
+        # fires instead of silently writing an error page.
+        manifest_url = shiny_bundle_spec["manifest_url"]
+        try:
+            terminal_run(
+                page,
+                f"curl -fsS -o {manifest_path} {manifest_url}",
+                timeout=_VENV_QUICK_TIMEOUT_MS,
+                readback_lang="python",
+            )
+        except ExecError as exc:
+            pytest.skip(
+                f"Could not download the Shiny manifest from {manifest_url} in the "
+                f"Workbench session (network/firewall constraint): {exc}"
+            )
+
+        # Patch the manifest platform to the server's newest R, matching what the
+        # Connect deploy test does, so both suites deploy an identical bundle.
+        platform = shiny_bundle_spec["platform"]
+        terminal_run(
+            page,
+            (
+                f"{python_bin} -c "
+                f""""import json; p='{manifest_path}'; """
+                f"m=json.load(open(p)); m['platform']='{platform}'; "
+                f'''json.dump(m,open(p,'w'))"'''
+            ),
             timeout=_VENV_QUICK_TIMEOUT_MS,
             readback_lang="python",
         )
@@ -269,7 +310,7 @@ def deploy_python_shiny_via_terminal(
         output = terminal_run(
             page,
             (
-                f"{rsconnect_bin} deploy manifest {bundle_dir}/manifest.json "
+                f"{rsconnect_bin} deploy manifest {manifest_path} "
                 f"--server {connect_url} "
                 f"--api-key {vip_config.connect.api_key} "
                 f"--title {title}"

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -13,6 +13,7 @@ excludes the tests when either product is absent.
 from __future__ import annotations
 
 import re
+import shlex
 import uuid
 import warnings
 from pathlib import Path
@@ -311,13 +312,17 @@ def deploy_python_shiny_via_terminal(
             readback_lang="python",
         )
 
+        # shlex.quote every interpolated value: the title contains spaces
+        # (unique_session_name → "VIP <file> - <worker>-<ns>"), which the shell
+        # would otherwise split into extra args ("Got unexpected extra
+        # arguments"); the api-key and URL are quoted defensively too.
         output = terminal_run(
             page,
             (
-                f"{rsconnect_bin} deploy manifest {manifest_path} "
-                f"--server {connect_url} "
-                f"--api-key {vip_config.connect.api_key} "
-                f"--title {title}"
+                f"{rsconnect_bin} deploy manifest {shlex.quote(manifest_path)} "
+                f"--server {shlex.quote(connect_url)} "
+                f"--api-key {shlex.quote(vip_config.connect.api_key)} "
+                f"--title {shlex.quote(title)}"
             ),
             timeout=_DEPLOY_TIMEOUT_MS,
             readback_lang="python",

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -372,16 +372,20 @@ def deploy_python_shiny_via_terminal(
                     stacklevel=2,
                 )
 
-    # Primary: stable API title lookup (version-independent).
-    content = connect_client._find_content_by_name(title)
-    if content:
-        guid = content["guid"]
-        content_url = content.get("content_url", "")
+    # Primary: parse the GUID from rsconnect's success output. rsconnect sets
+    # the Connect content *name* to a slug derived from the bundle, not our
+    # --title, so a name lookup does not find it; the deploy output is the
+    # authoritative source. It prints both a dashboard URL (/connect/#/apps/GUID)
+    # and a direct URL (/content/GUID/), so match either path form.
+    m = re.search(r"/(?:apps|content)/([0-9a-f-]{36})", output)
+    if m:
+        guid = m.group(1)
+        content_url = f"{connect_url.rstrip('/')}/content/{guid}/"
     else:
-        # Fallback: parse the rsconnect output URL.
-        m = re.search(r"/apps/([0-9a-f-]{36})", output)
-        guid = m.group(1) if m else None
-        content_url = ""
+        # Fallback: title lookup (older Connect set name == title on some paths).
+        content = connect_client._find_content_by_name(title)
+        guid = content["guid"] if content else None
+        content_url = content.get("content_url", "") if content else ""
 
     if guid:
         _log(f"deployed content guid={guid}")

--- a/src/vip_tests/workbench/test_publish_to_connect.py
+++ b/src/vip_tests/workbench/test_publish_to_connect.py
@@ -201,7 +201,9 @@ def deploy_python_shiny_via_terminal(
 
     # Preflight: a Python interpreter must be on PATH to build the venv.
     # Prefer ``python3`` but accept ``python`` so sessions without the
-    # ``python3`` symlink still qualify.
+    # ``python3`` symlink still qualify. Absence of Python is an environment
+    # precondition, not a publishing defect, so skip rather than fail here --
+    # only a genuine deploy failure below should FAIL the check.
     try:
         python_bin = terminal_run(
             page,
@@ -209,11 +211,22 @@ def deploy_python_shiny_via_terminal(
             timeout=_VENV_QUICK_TIMEOUT_MS,
             readback_lang="python",
         ).strip()
-    except ExecError as exc:
-        raise AssertionError(
+    except ExecError:
+        pytest.skip(
             "Neither python3 nor python is on PATH in the Workbench session; "
             "cannot create a venv to install rsconnect-python for deployment."
-        ) from exc
+        )
+
+    # A blank result means the readback captured no interpreter path (e.g. the
+    # command's stdout escaped the redirect). Skip rather than build an empty
+    # ``python_bin`` that would run as ``'' -m venv`` (exit 127, "-m: command
+    # not found").
+    if not python_bin:
+        pytest.skip(
+            "Could not resolve a python3/python interpreter path in the Workbench "
+            "session; the preflight returned no output, so a venv for "
+            "rsconnect-python cannot be created."
+        )
 
     title = f"vip_test_shiny_{unique_session_name(_FILENAME)}"
     venv_dir = f"/tmp/vip_rsconnect_venv_{uuid.uuid4().hex}"


### PR DESCRIPTION
## Summary

Makes the Workbench→Connect terminal publish test (`test_publish_to_connect.py`) reliable end-to-end and, in the final commit, hardens its skip/diagnostic behavior so environment constraints surface as actionable skips instead of opaque failures.

The bulk of the branch fixes the terminal-deploy mechanics (single-command `uv` deploy to end the multi-terminal race, server-side bundle materialization, manifest download instead of terminal-typing, one-line sentinel-file readback, GUID parsing from rsconnect output). The last commit is an adversarial hardening pass.

## Hardening (final commit)

Environment problems on the **session→Connect** and **session→PyPI** axes previously surfaced as opaque hard failures with raw command output. They now map to skips with messages naming the actual constraint:

- **Connect preflight from inside the session** — `curl`s the Connect URL and tags DNS / unreachable / untrusted-TLS failures (`VIP_CONNECT_DNS` / `_UNREACHABLE` / `_UNTRUSTED`). The URL the pytest host uses is not necessarily reachable from the Workbench server (split-horizon DNS, egress firewall, internal CA).
- **`VIP_NO_RSCONNECT`** — a failed `rsconnect-python` install (air-gapped / no PyPI or internal mirror) now skips rather than hard-failing.
- **Manifest fallback to `main`** — the reference manifest is fetched from the pinned release tag, falling back to `main`, so a dev/unreleased checkout whose tag 404s still resolves; skip only if both fail.
- **Deploy timeout / build wait** — raised to 15 min and corrected the docstring: `--no-verify` skips only rsconnect's client-side app-boot probe, **not** the server-side build wait (confirmed against `rsconnect-python` source — `emit_task_log()`/`wait_for_task()` runs unconditionally), so a cold-cache package restore legitimately runs many minutes.
- **Reachability check** — no longer silently passes when the content URL is unknown (it is always derived), and classifies Connect status codes (confirmed against `posit-dev/connect` serving source): `200`+marker = success, `502`/`503` = worker still booting, `500` StartupError = runtime defect (fail), `401`/`403`/`404` = auth/permission environment constraint (skip).

## Testing

- `ruff check` + `ruff format --check` clean.
- Selftests: 1155 passed.
- Generated deploy shell script `bash -n` syntax-checked; `set -e` skip-tag branches (DNS failure, manifest fallback, install failure) simulated and verified to emit their tags correctly.
- Product test collects (2 scenarios; deselected without configured products, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)