### PR TITLE
ci(publish): attest release artifacts with build provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,11 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Attest the artifacts here, in the job that produced them.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -31,6 +36,15 @@ jobs:
       - name: Build wheel and sdist
         run: uv build
 
+      # The PyPI upload carries its own PEP 740 attestations, but those only
+      # cover the PyPI download path. This attests the same wheel and sdist to
+      # GitHub so any copy of them can be verified with
+      # `gh attestation verify <file> --repo posit-dev/vip`.
+      - name: Attest wheel and sdist
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: 'dist/*'
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
@@ -44,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -64,6 +80,13 @@ jobs:
         run: |
           uv export --frozen --no-emit-project --no-hashes --format requirements.txt \
             -o "constraints-${VERSION}.txt"
+
+      # Attested before it is attached, so the asset a consumer downloads from
+      # the release is the exact file this job exported from the locked uv.lock.
+      - name: Attest locked constraints
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: constraints-${{ env.VERSION }}.txt
 
       # Reproduces the body semantic-release attached via --vcs-release: the
       # CHANGELOG.md section for this version (including its "## vX.Y.Z (date)"


### PR DESCRIPTION
Closes #422.

The last open item on #422 after scope was narrowed in the Track C plan: container-image cosign/provenance stays out of scope, and the 1.0 cutover stays a documented manual act (`docs/development.md`, "Versioning and the 1.0 cutover"). Everything else on the issue — tag/version guard, PEP 740 attestations on PyPI, draft-then-publish constraints, published-package smoke test, image smoke test — is already on main.

## What changes

- `build`: attests `dist/*` right after `uv build`, and gains an explicit `permissions` block (`contents: read`, `id-token: write`, `attestations: write`) where it previously inherited the repo default.
- `release`: attests `constraints-<version>.txt` immediately after exporting it from the frozen `uv.lock`, before it is attached to the draft release.

## Verification

- `zizmor` clean on `publish.yml`.
- End-to-end attestation can only be proven on a real tag push; the first release after merge is the check. `gh attestation verify posit_vip-<version>-py3-none-any.whl --repo posit-dev/vip` should succeed.

Pinned `actions/attest-build-provenance` to v4.1.1 (`0f67c3f`), consistent with the repo's SHA-pinning convention.
