### PR TITLE
test: fix flaky IndexError in the shared shiny-bundle selftest

### DIFF
--- a/selftests/test_publish_to_connect_fixtures.py
+++ b/selftests/test_publish_to_connect_fixtures.py
@@ -14,6 +14,17 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+# Imported at collection time, on purpose. ``test_content_deploy`` is a
+# pytest-bdd module whose module-level ``@scenario`` decorators read
+# ``pytest_bdd.utils.CONFIG_STACK[-1]``. pytest-bdd pushes the session config in
+# a ``trylast`` ``pytest_configure`` but pops it unconditionally in
+# ``pytest_unconfigure``, so an in-process ``pytester`` run (see
+# ``selftests/test_plugin.py``) can pop the outer session's entry and leave the
+# stack empty. Importing this module from inside a test body then raises
+# ``IndexError: list index out of range`` whenever a pytester test happens to
+# run earlier on the same xdist worker. Collection runs before any of that.
+from vip_tests.connect import bundles, test_content_deploy
+
 # Paths to the conftest files under test
 _ROOT_CONFTEST = Path(__file__).parent.parent / "src" / "vip_tests" / "conftest.py"
 _CONNECT_CONFTEST = Path(__file__).parent.parent / "src" / "vip_tests" / "connect" / "conftest.py"
@@ -165,7 +176,6 @@ class TestSharedShinyBundle:
     def test_connect_and_workbench_use_identical_bundle(self):
         """The Connect deploy test and Workbench publish test must ship the
         byte-identical bundle -- both route through build_shiny_bundle_files."""
-        from vip_tests.connect import bundles, test_content_deploy
 
         # Connect's _get_bundle for the shiny item delegates to the shared builder.
         class _FakeConnect:


### PR DESCRIPTION
`main` is currently red: `Selftests` fails on `f64886e4` in three of four matrix jobs, and on PR #541 it took out `macos-latest / 3.12`. Introduced by #538, which added the test.

## Root cause

`test_connect_and_workbench_use_identical_bundle` imports `vip_tests.connect.test_content_deploy` from inside the test body. That module is a pytest-bdd module, so importing it executes its top-level `@scenario(...)` decorators, which call `get_from_ini()` → `pytest_bdd.utils.CONFIG_STACK[-1]`.

`CONFIG_STACK` is a module global. pytest-bdd appends the session config in a `trylast` `pytest_configure` and pops it in `pytest_unconfigure` guarded only by `if CONFIG_STACK:`. The in-process `pytester` runs in `selftests/test_plugin.py` can therefore pop the *outer* session's entry, leaving the stack empty for the rest of that worker's tests. The import then raises `IndexError: list index out of range`.

That is why it is a flake and not a clean break: it only fires when a pytester test is scheduled ahead of this one on the same xdist worker.

## Fix

Hoist the import to module scope, so it runs during collection, before any pytester test can touch the stack. The behavioural assertion is unchanged.

## Verification

Reproduced locally with `uv run pytest selftests/ -n 3` (fails on roughly half of runs at `-n 3`; never at `-n auto` on a many-core machine, which is why it looked CI-only). After the fix, 8 consecutive runs at `-n 3` are clean. `ruff check` and `ruff format --check` pass.

Any pytest-bdd module imported from inside a test body in `selftests/` carries the same trap; this is the only such import today.
