### PR TITLE
ci(smoke): run cross-cutting suites and stop writing secrets to disk

### DIFF
--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -192,7 +192,10 @@ jobs:
       - name: Install Playwright browsers
         run: uv run vip install --skip-system
 
-      # Generate vip.toml from with-connect outputs
+      # Generate vip.toml from with-connect outputs. The API key is deliberately
+      # NOT written here — it is passed to pytest as VIP_CONNECT_API_KEY, which
+      # config.py:89 reads as the fallback. Writing it into the file would put a
+      # live credential on the runner disk and fail config_hygiene/test_secrets.
       - name: Configure VIP for CI Connect
         run: |
           cat > vip.toml << EOF
@@ -202,7 +205,6 @@ jobs:
           [connect]
           enabled = true
           url = "${{ steps.connect.outputs.CONNECT_SERVER }}"
-          api_key = "${{ steps.connect.outputs.CONNECT_API_KEY }}"
           version = "${{ steps.version.outputs.resolved }}"
 
           [auth]
@@ -225,6 +227,9 @@ jobs:
             src/vip_tests/connect/test_data_sources.py \
             src/vip_tests/connect/test_chronicle.py \
             src/vip_tests/security/test_error_handling.py \
+            src/vip_tests/security/test_auth_policy.py \
+            src/vip_tests/cross_product/test_resources.py \
+            src/vip_tests/config_hygiene/test_secrets.py \
             -v \
             -k "not connect_login_ui" \
             --vip-config=vip.toml \

--- a/.github/workflows/packagemanager-smoke.yml
+++ b/.github/workflows/packagemanager-smoke.yml
@@ -271,6 +271,8 @@ jobs:
             src/vip_tests/package_manager/test_authenticated_repos.py \
             src/vip_tests/package_manager/test_private_repos.py \
             src/vip_tests/package_manager/test_ui.py \
+            src/vip_tests/cross_product/test_resources.py \
+            src/vip_tests/config_hygiene/test_secrets.py \
             -v \
             --vip-config=vip.toml \
             --junitxml=smoke-results.xml

--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -210,6 +210,10 @@ jobs:
         run: uv run vip install --skip-system
 
       # Generate vip.toml from with-workbench outputs
+      # The password is deliberately NOT written here — it is passed to pytest as
+      # VIP_TEST_PASSWORD, which config.py:354 reads as the fallback. Writing it
+      # into the file would put a live credential on the runner disk and fail
+      # config_hygiene/test_secrets.
       - name: Configure VIP for CI Workbench
         run: |
           cat > vip.toml << EOF
@@ -230,7 +234,6 @@ jobs:
           [auth]
           provider = "password"
           username = "${{ steps.workbench.outputs.WORKBENCH_USER }}"
-          password = "${{ steps.workbench.outputs.WORKBENCH_PASSWORD }}"
           EOF
 
       # Run the subset of tests that work against Docker Workbench
@@ -238,6 +241,11 @@ jobs:
         # -n 0 disables xdist (overriding -n auto from pyproject.toml) because
         # the Docker Workbench returns "Temporary server error" when multiple
         # workers attempt concurrent logins.
+        #
+        # No `-k` filter: the plugin already deselects scenarios for products
+        # that are not enabled in vip.toml, so the previous `-k "workbench"`
+        # collected exactly the same tests while silently deselecting any
+        # cross-cutting suite whose name lacks the word "workbench".
         run: |
           uv run pytest \
             src/vip_tests/prerequisites/test_components.py \
@@ -245,9 +253,14 @@ jobs:
             src/vip_tests/workbench/test_ide_launch.py \
             src/vip_tests/workbench/test_packages.py \
             src/vip_tests/workbench/test_data_sources.py \
-            -v -k "workbench" -n 0 \
+            src/vip_tests/security/test_auth_policy.py \
+            src/vip_tests/cross_product/test_resources.py \
+            src/vip_tests/config_hygiene/test_secrets.py \
+            -v -n 0 \
             --vip-config=vip.toml \
             --junitxml=smoke-results.xml
+        env:
+          VIP_TEST_PASSWORD: ${{ steps.workbench.outputs.WORKBENCH_PASSWORD }}
 
       # Upload test results for debugging failures
       - name: Upload test results


### PR DESCRIPTION
Part of #540. First increment; the remaining pieces are noted at the bottom.

## Coverage added

| Suite | Connect | Workbench | Package Manager |
|---|---|---|---|
| `cross_product/test_resources` | yes | yes | yes |
| `security/test_auth_policy` | yes (both scenarios) | provider check only | — |
| `config_hygiene/test_secrets` | yes (both scenarios) | no-plaintext check | no-plaintext check |

Connect gains 5 tests, Workbench 3, Package Manager 2. The Connect-dependent scenarios are deselected automatically where Connect is not enabled, so nothing skips silently on a technicality.

## The security fix this surfaced

Adding `config_hygiene/test_secrets` failed immediately, for a good reason: every smoke workflow was writing a live credential into `vip.toml` on the runner.

- `connect-smoke.yml` wrote `api_key = "<with-connect bootstrap key>"`
- `workbench-smoke.yml` wrote `password = "<container password>"`

`config.py` already supports env-var fallbacks (`VIP_CONNECT_API_KEY` at line 89, `VIP_TEST_PASSWORD` at line 354), so the fix needed no product-code change — pass them as step `env` and stop writing them to the file.

Verified in both directions locally, since `test_secrets` only reads the config file:

```
OLD Connect config:    test_no_plaintext_secrets FAILED — Plaintext secrets found: ['api_key']
OLD Workbench config:  test_no_plaintext_secrets FAILED — Plaintext secrets found: ['password']
NEW Connect config:    2 passed
NEW Workbench config:  1 passed, 1 deselected
```

That is the point of the test, and it was catching something real on its first run.

## Removing `-k "workbench"`

`workbench-smoke.yml` filtered with `-k "workbench"`. Collection is byte-identical without it — the plugin already deselects scenarios for products that are not enabled in `vip.toml`, which is what that filter was standing in for. Left in place, it would have silently deselected all three new suites, since none of their test names contain "workbench".

## Verification

All three workflows are change-gated on their own path, so opening this PR runs all three against real containers — that is the actual verification and I will report the result. Locally: `zizmor` reports 0 findings for the two enforced audits, all three workflows parse, and collection was checked against the exact configs each workflow now generates.

## Still open on #540

- `cross_product/test_integration` needs Connect and Package Manager in the same job — a new workflow, next increment.
- `security/test_https` and `cross_product/test_ssl` skip unless the URL is HTTPS, so they need a TLS front-end. Being split into its own issue rather than deferred silently.
- `cross_product/test_monitoring` is gone — removed by #543, so the issue body needs correcting.
