### PR TITLE
fix(workbench): clarify password-login skip on SSO deployments

### DIFF
--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -585,9 +585,10 @@ def workbench_login(
         # is unavailable there, so skip rather than fail the retry loop.
         if sso_only:
             pytest.skip(
-                "Workbench is configured for SSO/OIDC (no password login form); "
-                "the password-login scenario does not apply. Pass --interactive-auth "
-                "or --headless-auth to exercise authenticated Workbench tests."
+                "This scenario requires a Workbench password-login form, but the "
+                "deployment presents an SSO/OIDC sign-in page instead (no username/"
+                "password fields). Password login cannot be exercised on an SSO "
+                "deployment, so this scenario is skipped."
             )
         # Password auth - proceed with form login below
     else:


### PR DESCRIPTION
## Summary

The skip message for the Workbench password-login scenario on an SSO/OIDC deployment advised passing `--interactive-auth`/`--headless-auth`. That advice is misleading for this specific scenario.

`test_workbench_login`'s `page` fixture deliberately strips the pre-loaded `storage_state` (`test_auth.py:49`) so it exercises a genuine logged-out password form, and its step calls `workbench_login(...)` without threading `interactive_auth`/`auth_mode` (`test_auth.py:82`). So those flags cannot make this scenario run — a user who has *already* passed `--interactive-auth` still hits this skip and gets told to pass a flag they just passed.

## Change

Reword the skip at `conftest.py:587` to:
- lead with what the test needs (a password-login form),
- name the tell (no username/password fields),
- drop the inapplicable `--interactive-auth`/`--headless-auth` advice.

**Before:**
> Workbench is configured for SSO/OIDC (no password login form); the password-login scenario does not apply. Pass --interactive-auth or --headless-auth to exercise authenticated Workbench tests.

**After:**
> This scenario requires a Workbench password-login form, but the deployment presents an SSO/OIDC sign-in page instead (no username/password fields). Password login cannot be exercised on an SSO deployment, so this scenario is skipped.

The other two skips in this path still route through `_workbench_session_skip_message(...)`, which correctly names those flags for the paths that honor a pre-loaded session — those are left unchanged.

## Testing

- `ruff check` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)