### PR TITLE
ci(connect): run the cross-product suite in a nightly tier

### DIFF
--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -14,6 +14,12 @@ on:
   schedule:
     - cron: "30 3 * * *" # daily at 03:30 UTC (staggered from the other smoke workflows)
   workflow_dispatch:
+    inputs:
+      suite:
+        description: 'gate = hermetic, no external network; full = adds the cross-product suite (what the nightly runs)'
+        type: choice
+        default: gate
+        options: [gate, full]
 
 permissions:
   contents: read
@@ -212,29 +218,63 @@ jobs:
           username = "__bootstrap_admin__"
           EOF
 
-      # Run the full Connect API test suite against Docker Connect (excluding the UI login scenario)
+          # cross_product/test_integration asserts that Connect's deploy log names
+          # the Package Manager URL as its package source. The Connect images
+          # default their R repository at public PPM, so pointing the config there
+          # makes the assertion real with no PM container. It is confined to the
+          # full tier on purpose: declaring package_manager also pulls PPM into the
+          # prerequisites and cross_product health checks, and the PR gate must not
+          # depend on a service outside this repo's control.
+          if [ "${SUITE}" = "full" ]; then
+            cat >> vip.toml << EOF
+
+          [package_manager]
+          enabled = true
+          url = "https://packagemanager.posit.co"
+          EOF
+          fi
+        env:
+          SUITE: ${{ inputs.suite || (github.event_name == 'schedule' && 'full' || 'gate') }}
+
+      # Run the full Connect API test suite against Docker Connect (excluding the
+      # UI login scenario). Two tiers, matching workbench-smoke.yml:
+      #   gate — PR/push. Hermetic: everything runs against the local container.
+      #   full — schedule/dispatch. Adds the cross-product suite, which needs the
+      #          [package_manager] URL written by the config step above and so
+      #          reaches out to public PPM. Kept off the gate deliberately; a PPM
+      #          outage should page the nightly, not block every merge.
       - name: Run Connect smoke tests
         run: |
-          uv run pytest \
-            src/vip_tests/prerequisites/test_components.py \
-            src/vip_tests/connect/test_auth.py \
-            src/vip_tests/connect/test_users.py \
-            src/vip_tests/connect/test_runtime_versions.py \
-            src/vip_tests/connect/test_system_checks.py \
-            src/vip_tests/connect/test_content_deploy.py \
-            src/vip_tests/connect/test_packages.py \
-            src/vip_tests/connect/test_email.py \
-            src/vip_tests/connect/test_data_sources.py \
-            src/vip_tests/connect/test_chronicle.py \
-            src/vip_tests/security/test_error_handling.py \
-            src/vip_tests/security/test_auth_policy.py \
-            src/vip_tests/cross_product/test_resources.py \
-            src/vip_tests/config_hygiene/test_secrets.py \
+          files="
+            src/vip_tests/prerequisites/test_components.py
+            src/vip_tests/connect/test_auth.py
+            src/vip_tests/connect/test_users.py
+            src/vip_tests/connect/test_runtime_versions.py
+            src/vip_tests/connect/test_system_checks.py
+            src/vip_tests/connect/test_content_deploy.py
+            src/vip_tests/connect/test_packages.py
+            src/vip_tests/connect/test_email.py
+            src/vip_tests/connect/test_data_sources.py
+            src/vip_tests/connect/test_chronicle.py
+            src/vip_tests/security/test_error_handling.py
+            src/vip_tests/security/test_auth_policy.py
+            src/vip_tests/cross_product/test_resources.py
+            src/vip_tests/config_hygiene/test_secrets.py
+          "
+          if [ "${SUITE}" = "full" ]; then
+            echo "::notice::Including the cross-product suite; this tier depends on public PPM."
+            files="${files}
+              src/vip_tests/cross_product/test_integration.py
+            "
+          fi
+          # shellcheck disable=SC2086 # word splitting is how the file list is passed
+          uv run pytest $files \
             -v \
             -k "not connect_login_ui" \
             --vip-config=vip.toml \
             --junitxml=smoke-results.xml
         env:
+          SUITE: ${{ inputs.suite || (github.event_name == 'schedule' && 'full' || 'gate') }}
           VIP_CONNECT_API_KEY: ${{ steps.connect.outputs.CONNECT_API_KEY }}
 
       # Upload test results for debugging failures

--- a/.github/workflows/connect-smoke.yml
+++ b/.github/workflows/connect-smoke.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       suite:
-        description: 'gate = hermetic, no external network; full = adds the cross-product suite (what the nightly runs)'
+        description: 'gate = PR/push suite subset; full = adds the cross-product suite (what the nightly runs)'
         type: choice
         default: gate
         options: [gate, full]


### PR DESCRIPTION
Closes #540.

## What this covers

`cross_product/test_integration` was the last suite in #540 without CI coverage — the one that needs Connect and Package Manager both reachable.

## It did not need what I expected

I assumed a Package Manager container, Connect reconfigured to use it as its R repository, cross-container networking, and a CRAN snapshot synced before packages resolved. A measurement run showed all of that to be unnecessary: Connect's images already default their R repository at public PPM, so `test_connect_uses_package_manager` passes with nothing but the URL declared in config.

Measured PASSED on Connect `release`, `2026.06.0` and `2026.05.1`.

## Why it is nightly, not gated

Declaring `[package_manager]` has a side effect: `prerequisites/test_components.py` and `cross_product/test_resources.py` both health-check every configured product, so the gate would gain an explicit liveness check against `packagemanager.posit.co`. Measured, not theorised — the first run showed `test_product_server_is_reachable[Package Manager] PASSED` on what would have been a required check.

To be precise about the reasoning: the gate is **already** not hermetic. Connect's R deploys (`test_deploy_plumber`, `test_deploy_shiny`, `test_deploy_rmarkdown`) pull binaries from `packagemanager.posit.co`, `p3m.dev` and `rspm-sync.rstudio.com` on every single run. So this change is not preserving some pristine offline gate. What it avoids is *widening* that surface and, more importantly, adding a check whose only job is to assert an external service is up — an outage there would redden every PR while telling us nothing about this repo.

| Tier | Trigger | Contents |
|---|---|---|
| `gate` | PR, push | Local container plus the package downloads Connect already performs |
| `full` | schedule, dispatch | Adds `cross_product/test_integration` and the `[package_manager]` config block |

Same shape as the `workbench-smoke.yml` split from #549, so there is one pattern to learn rather than two.

## Verification

- `full` tier dispatched: `test_connect_uses_package_manager PASSED`, 27 passed / 5 skipped in 74s.
- `gate` tier dispatched separately: neither `test_integration` nor the Package Manager health check appears, and the count returns to the 24-passed baseline.
- The config step's generated `vip.toml` was executed locally for both tiers and produces valid TOML, since a heredoc nested in an `if` is easy to get subtly wrong.
- `zizmor` reports 0 findings for the two enforced audits.

## Unrelated flake seen during verification

The `gate` verification run failed on its `2026.06.0` leg, and it is worth recording because it is not caused by this change. `test_deploy_plumber` and `test_deploy_shiny` failed when packrat could not fetch binaries:

```
curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to rspm-sync.rstudio.com:443
Error in getSourceForPkgRecord(...) : Failed to download current version of fontawesome(0.5.3)
```

Both tests passed on the `release` and `2026.05.1` legs of the same run, so this is transient upstream CDN behaviour rather than a version-specific problem. It does mean the Connect gate can go red for reasons entirely outside this repository. Worth its own issue.
