### PR TITLE
fix(connect): retry a deploy once on a transient PPM/CDN failure

### DIFF
--- a/selftests/test_connect_deploy_retry.py
+++ b/selftests/test_connect_deploy_retry.py
@@ -1,13 +1,17 @@
 """Selftests for the transient packrat/CDN deploy retry (vip#553).
 
-Verifies the narrow signature matcher (``_is_transient_packrat_cdn_failure``)
-against real captured failure text, and verifies ``wait_for_deploy`` retries
-at most once, only for a matching failure, and still fails the suite when
-the retry doesn't help.
+Verifies the narrow signature matcher (``_is_transient_packrat_cdn_failure``
+and ``_matched_transient_signature``), the redeploy closures installed by
+``upload_and_deploy``/``trigger_git_deploy``, and ``wait_for_deploy``'s retry
+orchestration: it retries at most once, only for a matching failure, still
+fails the suite when the retry doesn't help, and records that fact via
+``record_property`` so a retry is visible even on a passing run.
 
-No real network connections are made: ``connect_client`` is a stand-in with
-mocked ``wait_for_task`` and a ``redeploy`` callable installed on
-``deploy_state``, exactly as the real step functions install it.
+No real network connections are made: ``connect_client`` is a MagicMock with
+canned return values, and ``deploy_state["redeploy"]`` is either the real
+closure installed by ``upload_and_deploy``/``trigger_git_deploy`` (for the
+closure tests) or a bare MagicMock (for the ``wait_for_deploy`` tests, which
+are testing the retry loop, not the closures).
 """
 
 from __future__ import annotations
@@ -77,9 +81,29 @@ Error: license check failed: no seats available for this content type
 Job completed with failure
 """
 
+# A DIFFERENT failure class that still satisfies the triple-AND: a permanent
+# block reaching a known host (e.g. a firewall rule), not a transient reset.
+# Both "attempts" below are identical on purpose -- a persistent block fails
+# the same way every time, unlike the flaky-CDN case where a second try can
+# succeed.
+_PERMANENT_HOST_BLOCK_FAILURE = """\
+Installing otel (0.2.0) ...
+curl: (7) Failed to connect to packagemanager.posit.co port 443: Connection refused
+Error in download.file(url, destfile, method, mode = "wb", ...) :
+  'curl' call had nonzero exit status
+Warning in download.packages(name, destdir = destdir, repos = repos, type = type,  :
+  download of package 'otel' failed
+Error in getSourceForPkgRecord(pkgRecord, srcDir(project), availablePackagesSource(repos = repos), \
+: Failed to download current version of otel(0.2.0)
+
+Unable to fully restore the R packages associated with this deployment.
+Please review the preceding messages to determine which package
+encountered installation difficulty and the cause of the failure.
+"""
+
 
 # ---------------------------------------------------------------------------
-# _is_transient_packrat_cdn_failure -- positive and negative cases
+# _is_transient_packrat_cdn_failure / _matched_transient_signature
 # ---------------------------------------------------------------------------
 
 
@@ -143,6 +167,63 @@ class TestIsTransientPackratCdnFailure:
         )
         assert tcd._is_transient_packrat_cdn_failure(output) is False
 
+    @pytest.mark.parametrize("code", tcd._TRANSIENT_CURL_CODES)
+    @pytest.mark.parametrize("host", tcd._KNOWN_PPM_CDN_HOSTS)
+    def test_matches_every_code_and_host_combination(self, host, code):
+        """Every (code, host) pair must match on its own -- a typo in any one
+        of the four codes or three hosts would otherwise pass undetected."""
+        output = f"{code} some curl error talking to {host}\nUnable to fully restore the R packages"
+        assert tcd._is_transient_packrat_cdn_failure(output) is True
+        assert tcd._matched_transient_signature(output) == (code, host)
+
+
+# ---------------------------------------------------------------------------
+# Redeploy closures -- must capture guid/bundle_id BY VALUE, not read
+# deploy_state live, or a retry could redeploy the wrong content after
+# deploy_state is mutated between the original upload and the retry.
+# ---------------------------------------------------------------------------
+
+
+class TestRedeployClosuresCaptureByValue:
+    def test_upload_and_deploy_redeploy_captures_original_guid_and_bundle_id(self):
+        connect_client = MagicMock()
+        connect_client.python_versions.return_value = ["3.11"]
+        connect_client.upload_bundle.return_value = {"id": "bundle-original"}
+        connect_client.deploy_bundle.return_value = {"task_id": "task-original"}
+        deploy_state = {"guid": "guid-original", "name": "vip-dash-test"}
+
+        tcd.upload_and_deploy(connect_client, deploy_state)
+
+        assert deploy_state["bundle_id"] == "bundle-original"
+        connect_client.deploy_bundle.assert_called_once_with("guid-original", "bundle-original")
+
+        # Simulate deploy_state being mutated (by a later step, or a bug)
+        # before a retry fires.
+        deploy_state["guid"] = "guid-mutated"
+        deploy_state["bundle_id"] = "bundle-mutated"
+
+        deploy_state["redeploy"]()
+
+        assert connect_client.deploy_bundle.call_count == 2
+        # The LAST call (the retry) must still use the ORIGINAL values.
+        connect_client.deploy_bundle.assert_called_with("guid-original", "bundle-original")
+
+    def test_trigger_git_deploy_redeploy_captures_original_guid(self):
+        connect_client = MagicMock()
+        connect_client.deploy_from_repository.return_value = {"task_id": "task-original"}
+        deploy_state = {"guid": "guid-original"}
+
+        tcd.trigger_git_deploy(connect_client, deploy_state)
+
+        connect_client.deploy_from_repository.assert_called_once_with("guid-original")
+
+        deploy_state["guid"] = "guid-mutated"
+
+        deploy_state["redeploy"]()
+
+        assert connect_client.deploy_from_repository.call_count == 2
+        connect_client.deploy_from_repository.assert_called_with("guid-original")
+
 
 # ---------------------------------------------------------------------------
 # wait_for_deploy -- retry orchestration
@@ -157,10 +238,18 @@ def _finished_task(*, code: int, output: list[str], error: str = "deploy failed"
     return {"finished": True, "code": code, "output": output, "error": error}
 
 
+def _retry_properties(request) -> list[tuple[str, str]]:
+    """Return the (name, value) pairs recorded via record_property on *request*'s
+    node -- this is the real pytest mechanism, not a mock, so it also proves
+    wait_for_deploy's record_property calls are shaped the way pytest expects."""
+    return list(request.node.user_properties)
+
+
 class TestWaitForDeployRetry:
-    def test_matching_failure_is_retried_and_then_succeeds(self):
+    def test_matching_failure_is_retried_and_then_succeeds(self, record_property, request):
         """First attempt hits the transient signature; the retry succeeds; no
-        pytest.fail is raised; wait_for_task is called exactly twice."""
+        pytest.fail is raised; wait_for_task is called exactly twice; the
+        retry is recorded via record_property even though the test passes."""
         connect_client = MagicMock()
         connect_client.wait_for_task.side_effect = [
             _finished_task(code=1, output=_REAL_TRANSIENT_CDN_FAILURE.splitlines()),
@@ -169,16 +258,26 @@ class TestWaitForDeployRetry:
         redeploy = MagicMock(return_value={"task_id": "task-2"})
         deploy_state = {"task_id": "task-1", "name": "vip-shiny-test", "redeploy": redeploy}
 
-        tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+        tcd.wait_for_deploy(connect_client, deploy_state, _vip_config(), record_property)
 
         assert connect_client.wait_for_task.call_count == 2
         redeploy.assert_called_once()
         # The second wait_for_task call must poll the *new* task from redeploy.
         assert connect_client.wait_for_task.call_args_list[1].args[0] == "task-2"
 
-    def test_second_matching_failure_still_fails(self):
+        properties = _retry_properties(request)
+        assert len(properties) == 1
+        name, value = properties[0]
+        assert name == "vip_deploy_retry"
+        assert "vip-shiny-test" in value
+        assert "curl: (35)" in value
+        assert "rspm-sync.rstudio.com" in value
+
+    def test_second_matching_failure_still_fails(self, record_property, request):
         """Both attempts hit the transient signature: the suite still fails,
-        and only one retry is attempted (not an unbounded loop)."""
+        only one retry is attempted (not an unbounded loop), and the failure
+        message includes the FIRST attempt's output (where the triggering
+        signature actually lives)."""
         connect_client = MagicMock()
         connect_client.wait_for_task.side_effect = [
             _finished_task(code=1, output=_REAL_TRANSIENT_CDN_FAILURE.splitlines()),
@@ -187,16 +286,42 @@ class TestWaitForDeployRetry:
         redeploy = MagicMock(return_value={"task_id": "task-2"})
         deploy_state = {"task_id": "task-1", "name": "vip-shiny-test", "redeploy": redeploy}
 
-        with pytest.raises(pytest.fail.Exception):
-            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+        with pytest.raises(pytest.fail.Exception) as excinfo:
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config(), record_property)
 
         assert connect_client.wait_for_task.call_count == 2
         redeploy.assert_called_once()  # exactly one retry, never a second
+        assert "First attempt output" in str(excinfo.value)
+        assert "fontawesome" in str(excinfo.value)
 
-    def test_non_matching_failure_is_not_retried(self):
+        # Exactly one retry fired -- exactly one property recorded, even
+        # though the test ultimately fails.
+        assert len(_retry_properties(request)) == 1
+
+    def test_permanent_host_block_retries_once_then_fails(self, record_property, request):
+        """A PERSISTENT block against a known host (not a transient reset)
+        also satisfies the triple-AND on every attempt. That's accepted: it
+        burns exactly one wasted retry, then correctly fails -- it never
+        loops and never masks the failure."""
+        connect_client = MagicMock()
+        connect_client.wait_for_task.side_effect = [
+            _finished_task(code=1, output=_PERMANENT_HOST_BLOCK_FAILURE.splitlines()),
+            _finished_task(code=1, output=_PERMANENT_HOST_BLOCK_FAILURE.splitlines()),
+        ]
+        redeploy = MagicMock(return_value={"task_id": "task-2"})
+        deploy_state = {"task_id": "task-1", "name": "vip-plumber-test", "redeploy": redeploy}
+
+        with pytest.raises(pytest.fail.Exception):
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config(), record_property)
+
+        assert connect_client.wait_for_task.call_count == 2
+        redeploy.assert_called_once()
+        assert len(_retry_properties(request)) == 1
+
+    def test_non_matching_failure_is_not_retried(self, record_property, request):
         """A failure that doesn't match the signature fails on the first
         attempt, with no redeploy call at all -- assert on the call count,
-        not just the outcome."""
+        not just the outcome -- and nothing is recorded."""
         connect_client = MagicMock()
         connect_client.wait_for_task.side_effect = [
             _finished_task(code=1, output=_APP_CRASH_FAILURE.splitlines()),
@@ -205,15 +330,16 @@ class TestWaitForDeployRetry:
         deploy_state = {"task_id": "task-1", "name": "vip-fastapi-test", "redeploy": redeploy}
 
         with pytest.raises(pytest.fail.Exception):
-            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config(), record_property)
 
         assert connect_client.wait_for_task.call_count == 1
         redeploy.assert_not_called()
+        assert _retry_properties(request) == []
 
-    def test_matching_failure_without_redeploy_fails_immediately(self):
+    def test_matching_failure_without_redeploy_fails_immediately(self, record_property, request):
         """If a caller never set deploy_state['redeploy'] (shouldn't happen in
         practice), a matching failure must still fail cleanly instead of
-        raising KeyError."""
+        raising KeyError, and nothing is recorded (no retry actually fired)."""
         connect_client = MagicMock()
         connect_client.wait_for_task.side_effect = [
             _finished_task(code=1, output=_REAL_TRANSIENT_CDN_FAILURE.splitlines()),
@@ -221,25 +347,29 @@ class TestWaitForDeployRetry:
         deploy_state = {"task_id": "task-1", "name": "vip-shiny-test"}
 
         with pytest.raises(pytest.fail.Exception):
-            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config(), record_property)
 
         assert connect_client.wait_for_task.call_count == 1
+        assert _retry_properties(request) == []
 
-    def test_successful_first_attempt_never_calls_redeploy(self):
-        """The common case: deploy succeeds first try, retry machinery never engages."""
+    def test_successful_first_attempt_never_calls_redeploy(self, record_property, request):
+        """The common case: deploy succeeds first try, retry machinery never
+        engages, nothing is recorded."""
         connect_client = MagicMock()
         connect_client.wait_for_task.side_effect = [_finished_task(code=0, output=["OK"])]
         redeploy = MagicMock(return_value={"task_id": "task-2"})
         deploy_state = {"task_id": "task-1", "name": "vip-quarto-test", "redeploy": redeploy}
 
-        tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+        tcd.wait_for_deploy(connect_client, deploy_state, _vip_config(), record_property)
 
         assert connect_client.wait_for_task.call_count == 1
         redeploy.assert_not_called()
+        assert _retry_properties(request) == []
 
-    def test_unfinished_task_fails_without_retry(self):
+    def test_unfinished_task_fails_without_retry(self, record_property, request):
         """A deploy that never finishes (timeout) is unrelated to the CDN
-        retry and must fail exactly as before -- no redeploy attempt."""
+        retry and must fail exactly as before -- no redeploy attempt, no
+        property recorded."""
         connect_client = MagicMock()
         connect_client.wait_for_task.side_effect = [
             {"finished": False, "output": ["still running"]},
@@ -248,7 +378,8 @@ class TestWaitForDeployRetry:
         deploy_state = {"task_id": "task-1", "name": "vip-shiny-test", "redeploy": redeploy}
 
         with pytest.raises(pytest.fail.Exception):
-            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config(), record_property)
 
         assert connect_client.wait_for_task.call_count == 1
         redeploy.assert_not_called()
+        assert _retry_properties(request) == []

--- a/selftests/test_connect_deploy_retry.py
+++ b/selftests/test_connect_deploy_retry.py
@@ -1,0 +1,254 @@
+"""Selftests for the transient packrat/CDN deploy retry (vip#553).
+
+Verifies the narrow signature matcher (``_is_transient_packrat_cdn_failure``)
+against real captured failure text, and verifies ``wait_for_deploy`` retries
+at most once, only for a matching failure, and still fails the suite when
+the retry doesn't help.
+
+No real network connections are made: ``connect_client`` is a stand-in with
+mocked ``wait_for_task`` and a ``redeploy`` callable installed on
+``deploy_state``, exactly as the real step functions install it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# Imported at collection time, on purpose -- see the comment in
+# test_publish_to_connect_fixtures.py for why importing test_content_deploy
+# from inside a test body (rather than at module scope) can raise IndexError
+# under pytester-based selftests sharing an xdist worker.
+from vip_tests.connect import test_content_deploy as tcd
+
+# ---------------------------------------------------------------------------
+# Real captured failure text (run 30398775778, connect-smoke.yml, 2026.06.0 leg)
+# ---------------------------------------------------------------------------
+
+# Verbatim excerpt from the failing test_deploy_shiny task output: fontawesome
+# fails twice (packrat's own internal retry also fails) and packrat aborts.
+_REAL_TRANSIENT_CDN_FAILURE = """\
+Installing fontawesome (0.5.3) ...
+curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to rspm-sync.rstudio.com:443
+curl: HTTP 307 https://rspm-sync.rstudio.com/bin/4.5-jammy/950a997e6416de6f370d9578e91f677b6ad42a6d840640ad5d612464f65f7845.tar.gz
+Error in download.file(url, destfile, method, mode = "wb", ...) :
+  'curl' call had nonzero exit status
+Warning in download.packages(name, destdir = destdir, repos = repos, type = type,  :
+  download of package 'fontawesome' failed
+curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to rspm-sync.rstudio.com:443
+curl: HTTP 307 https://rspm-sync.rstudio.com/bin/4.5-jammy/950a997e6416de6f370d9578e91f677b6ad42a6d840640ad5d612464f65f7845.tar.gz
+Error in download.file(url, destfile, method, mode = "wb", ...) :
+  'curl' call had nonzero exit status
+Warning in download.packages(name, destdir = destdir, repos = repos, type = type,  :
+  download of package 'fontawesome' failed
+Error in getSourceForPkgRecord(pkgRecord, srcDir(project), availablePackagesSource(repos = repos), \
+: Failed to download current version of fontawesome(0.5.3)
+
+Unable to fully restore the R packages associated with this deployment.
+Please review the preceding messages to determine which package
+encountered installation difficulty and the cause of the failure.
+"""
+
+# Genuinely different failure shapes -- none of these are network-related.
+_BAD_MANIFEST_FAILURE = """\
+Error: Invalid manifest: unknown appmode 'python-fastapi-v2'
+manifest.json failed schema validation
+Job completed with failure
+"""
+
+_WRONG_ENTRYPOINT_FAILURE = """\
+jupyter nbconvert: error: the following arguments are required: notebook
+usage: jupyter nbconvert [-h] [notebook]
+Job completed with failure
+"""
+
+_APP_CRASH_FAILURE = """\
+Traceback (most recent call last):
+  File "app.py", line 3, in <module>
+    import nonexistent_module
+ModuleNotFoundError: No module named 'nonexistent_module'
+Job completed with failure
+"""
+
+_UNRELATED_CODE_NONZERO_FAILURE = """\
+Error: license check failed: no seats available for this content type
+Job completed with failure
+"""
+
+
+# ---------------------------------------------------------------------------
+# _is_transient_packrat_cdn_failure -- positive and negative cases
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransientPackratCdnFailure:
+    def test_matches_real_captured_failure(self):
+        """The exact signature from run 30398775778 must match."""
+        assert tcd._is_transient_packrat_cdn_failure(_REAL_TRANSIENT_CDN_FAILURE) is True
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            _BAD_MANIFEST_FAILURE,
+            _WRONG_ENTRYPOINT_FAILURE,
+            _APP_CRASH_FAILURE,
+            _UNRELATED_CODE_NONZERO_FAILURE,
+            "",
+        ],
+        ids=["bad-manifest", "wrong-entrypoint", "app-crash", "unrelated-nonzero", "empty"],
+    )
+    def test_does_not_match_other_failures(self, output):
+        """A predicate that never rejects proves nothing -- these must all be False."""
+        assert tcd._is_transient_packrat_cdn_failure(output) is False
+
+    def test_requires_all_three_parts_not_any_one(self):
+        """Each part alone, or any two of three, must NOT be sufficient."""
+        curl_code_only = "curl: (35) OpenSSL SSL_connect: Connection reset by peer"
+        host_only = "talking to rspm-sync.rstudio.com about packages"
+        restore_text_only = (
+            "Unable to fully restore the R packages associated with this deployment."
+        )
+        curl_and_host_no_restore_text = curl_code_only + " " + host_only
+        curl_and_restore_no_host = curl_code_only + " " + restore_text_only
+        host_and_restore_no_curl = host_only + " " + restore_text_only
+
+        for output in (
+            curl_code_only,
+            host_only,
+            restore_text_only,
+            curl_and_host_no_restore_text,
+            curl_and_restore_no_host,
+            host_and_restore_no_curl,
+        ):
+            assert tcd._is_transient_packrat_cdn_failure(output) is False, (
+                f"Partial signature incorrectly matched: {output!r}"
+            )
+
+        # All three together must match.
+        assert (
+            tcd._is_transient_packrat_cdn_failure(
+                curl_code_only + " " + host_only + " " + restore_text_only
+            )
+            is True
+        )
+
+    def test_does_not_confuse_two_digit_curl_codes(self):
+        """'curl: (7)' must not spuriously match inside e.g. 'curl: (17)'."""
+        output = (
+            "curl: (17) some unrelated curl error\n"
+            "rspm-sync.rstudio.com\n"
+            "Unable to fully restore the R packages"
+        )
+        assert tcd._is_transient_packrat_cdn_failure(output) is False
+
+
+# ---------------------------------------------------------------------------
+# wait_for_deploy -- retry orchestration
+# ---------------------------------------------------------------------------
+
+
+def _vip_config(timeout: float = 5.0):
+    return SimpleNamespace(connect=SimpleNamespace(deploy_timeout=timeout))
+
+
+def _finished_task(*, code: int, output: list[str], error: str = "deploy failed") -> dict:
+    return {"finished": True, "code": code, "output": output, "error": error}
+
+
+class TestWaitForDeployRetry:
+    def test_matching_failure_is_retried_and_then_succeeds(self):
+        """First attempt hits the transient signature; the retry succeeds; no
+        pytest.fail is raised; wait_for_task is called exactly twice."""
+        connect_client = MagicMock()
+        connect_client.wait_for_task.side_effect = [
+            _finished_task(code=1, output=_REAL_TRANSIENT_CDN_FAILURE.splitlines()),
+            _finished_task(code=0, output=["OK"]),
+        ]
+        redeploy = MagicMock(return_value={"task_id": "task-2"})
+        deploy_state = {"task_id": "task-1", "name": "vip-shiny-test", "redeploy": redeploy}
+
+        tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+
+        assert connect_client.wait_for_task.call_count == 2
+        redeploy.assert_called_once()
+        # The second wait_for_task call must poll the *new* task from redeploy.
+        assert connect_client.wait_for_task.call_args_list[1].args[0] == "task-2"
+
+    def test_second_matching_failure_still_fails(self):
+        """Both attempts hit the transient signature: the suite still fails,
+        and only one retry is attempted (not an unbounded loop)."""
+        connect_client = MagicMock()
+        connect_client.wait_for_task.side_effect = [
+            _finished_task(code=1, output=_REAL_TRANSIENT_CDN_FAILURE.splitlines()),
+            _finished_task(code=1, output=_REAL_TRANSIENT_CDN_FAILURE.splitlines()),
+        ]
+        redeploy = MagicMock(return_value={"task_id": "task-2"})
+        deploy_state = {"task_id": "task-1", "name": "vip-shiny-test", "redeploy": redeploy}
+
+        with pytest.raises(pytest.fail.Exception):
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+
+        assert connect_client.wait_for_task.call_count == 2
+        redeploy.assert_called_once()  # exactly one retry, never a second
+
+    def test_non_matching_failure_is_not_retried(self):
+        """A failure that doesn't match the signature fails on the first
+        attempt, with no redeploy call at all -- assert on the call count,
+        not just the outcome."""
+        connect_client = MagicMock()
+        connect_client.wait_for_task.side_effect = [
+            _finished_task(code=1, output=_APP_CRASH_FAILURE.splitlines()),
+        ]
+        redeploy = MagicMock(return_value={"task_id": "task-2"})
+        deploy_state = {"task_id": "task-1", "name": "vip-fastapi-test", "redeploy": redeploy}
+
+        with pytest.raises(pytest.fail.Exception):
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+
+        assert connect_client.wait_for_task.call_count == 1
+        redeploy.assert_not_called()
+
+    def test_matching_failure_without_redeploy_fails_immediately(self):
+        """If a caller never set deploy_state['redeploy'] (shouldn't happen in
+        practice), a matching failure must still fail cleanly instead of
+        raising KeyError."""
+        connect_client = MagicMock()
+        connect_client.wait_for_task.side_effect = [
+            _finished_task(code=1, output=_REAL_TRANSIENT_CDN_FAILURE.splitlines()),
+        ]
+        deploy_state = {"task_id": "task-1", "name": "vip-shiny-test"}
+
+        with pytest.raises(pytest.fail.Exception):
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+
+        assert connect_client.wait_for_task.call_count == 1
+
+    def test_successful_first_attempt_never_calls_redeploy(self):
+        """The common case: deploy succeeds first try, retry machinery never engages."""
+        connect_client = MagicMock()
+        connect_client.wait_for_task.side_effect = [_finished_task(code=0, output=["OK"])]
+        redeploy = MagicMock(return_value={"task_id": "task-2"})
+        deploy_state = {"task_id": "task-1", "name": "vip-quarto-test", "redeploy": redeploy}
+
+        tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+
+        assert connect_client.wait_for_task.call_count == 1
+        redeploy.assert_not_called()
+
+    def test_unfinished_task_fails_without_retry(self):
+        """A deploy that never finishes (timeout) is unrelated to the CDN
+        retry and must fail exactly as before -- no redeploy attempt."""
+        connect_client = MagicMock()
+        connect_client.wait_for_task.side_effect = [
+            {"finished": False, "output": ["still running"]},
+        ]
+        redeploy = MagicMock(return_value={"task_id": "task-2"})
+        deploy_state = {"task_id": "task-1", "name": "vip-shiny-test", "redeploy": redeploy}
+
+        with pytest.raises(pytest.fail.Exception):
+            tcd.wait_for_deploy(connect_client, deploy_state, _vip_config())
+
+        assert connect_client.wait_for_task.call_count == 1
+        redeploy.assert_not_called()

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -444,7 +444,8 @@ def wait_for_deploy(connect_client, deploy_state, vip_config):
         deploy_state["task_result"] = task
 
         if not task.get("finished"):
-            output = "\n".join(task.get("output", []))
+            output_lines = task.get("output", []) or []
+            output = "\n".join(output_lines)
             pytest.fail(
                 f"Deployment did not complete within {timeout} seconds\n\n"
                 f"--- Task output ---\n{output}"

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -24,6 +24,57 @@ _GIT_REPO_URL = "https://github.com/posit-dev/connect-extensions"
 _GIT_BRANCH = "main"
 _GIT_DIRECTORY = "extensions/quarto-document"
 
+# ---------------------------------------------------------------------------
+# Transient packrat/CDN failure detection (vip#553)
+# ---------------------------------------------------------------------------
+#
+# Connect resolves R packages over the public internet on every deploy.
+# `rspm-sync.rstudio.com` occasionally resets a connection or loops a 307
+# mid-restore; packrat itself already retries the download once (visible in
+# the task log as a failed curl call immediately followed by a second,
+# successful one for the same URL) and only gives up -- aborting the whole
+# restore -- if that single internal retry also fails. That inner retry is
+# Connect's, not ours: VIP has no hook into it and cannot make it try harder.
+# All VIP can do is redeploy the same bundle from scratch and hope the CDN
+# behaves on the next attempt.
+#
+# This match is deliberately narrow. It requires a curl connection-level
+# failure code AND a known PPM/CDN host AND packrat's own "unable to
+# restore" text, all three -- not any one alone -- so a genuine deployment
+# regression (bad manifest, wrong entrypoint, app crash, a real Connect bug)
+# still fails immediately with no retry. It is also just pattern-matching a
+# live product's log wording, not a documented API contract: if a future
+# Connect release rewords this message, the predicate simply stops matching
+# and every failure reverts to today's non-retried behavior -- it fails
+# closed, never silently.
+#
+# Filed as insurance, not a fix for chronic pain: at the time this was
+# written, 74/74 non-dispatch connect-smoke.yml runs (pull_request, push,
+# schedule) had been green, and this signature had fired exactly once, on a
+# workflow_dispatch run that was never on the merge-gating path. Do not
+# widen this match on the assumption it is covering something that happens
+# often -- it isn't, and a broader match trades away the "must still fail
+# for other reasons" guarantee for no evidenced benefit.
+_TRANSIENT_CURL_CODES = ("curl: (35)", "curl: (7)", "curl: (28)", "curl: (56)")
+_KNOWN_PPM_CDN_HOSTS = (
+    "rspm-sync.rstudio.com",
+    "packagemanager.posit.co",
+    "p3m.dev",
+)
+_PACKRAT_RESTORE_FAILURE_TEXT = "Unable to fully restore the R packages"
+
+# One retry beyond the original attempt.
+_MAX_DEPLOY_ATTEMPTS = 2
+
+
+def _is_transient_packrat_cdn_failure(output: str) -> bool:
+    """Return True only for a packrat restore that failed via a connection-level
+    curl error against a known PPM/CDN host -- see the module comment above."""
+    has_curl_failure = any(code in output for code in _TRANSIENT_CURL_CODES)
+    has_known_host = any(host in output for host in _KNOWN_PPM_CDN_HOSTS)
+    has_restore_failure = _PACKRAT_RESTORE_FAILURE_TEXT in output
+    return has_curl_failure and has_known_host and has_restore_failure
+
 
 def _md5(text: str) -> str:
     """Return the MD5 hex digest of *text*.
@@ -341,7 +392,12 @@ def upload_and_deploy(connect_client, deploy_state):
     archive = _make_tar_gz(bundle_files)
     bundle = connect_client.upload_bundle(deploy_state["guid"], archive)
     deploy_state["bundle_id"] = bundle["id"]
-    result = connect_client.deploy_bundle(deploy_state["guid"], bundle["id"])
+    guid = deploy_state["guid"]
+    bundle_id = bundle["id"]
+    # Captured so wait_for_deploy can redeploy the same already-uploaded bundle
+    # from scratch on a transient packrat/CDN failure (see the module comment).
+    deploy_state["redeploy"] = lambda: connect_client.deploy_bundle(guid, bundle_id)
+    result = deploy_state["redeploy"]()
     deploy_state["task_id"] = result["task_id"]
 
 
@@ -364,25 +420,57 @@ def link_git_repository(connect_client, deploy_state):
 
 @when("I trigger a git-backed deployment")
 def trigger_git_deploy(connect_client, deploy_state):
-    result = connect_client.deploy_from_repository(deploy_state["guid"])
+    guid = deploy_state["guid"]
+    deploy_state["redeploy"] = lambda: connect_client.deploy_from_repository(guid)
+    result = deploy_state["redeploy"]()
     deploy_state["task_id"] = result["task_id"]
 
 
 @when("I wait for the deployment to complete")
 def wait_for_deploy(connect_client, deploy_state, vip_config):
-    task_id = deploy_state["task_id"]
+    """Wait for the deploy task, retrying once on a narrow transient failure.
+
+    See the module comment above ``_is_transient_packrat_cdn_failure`` for why
+    this retry exists and why it is scoped the way it is. Any failure that
+    does not match that exact signature -- including a second attempt that
+    fails again -- fails immediately, identically to before this retry
+    existed.
+    """
     timeout = vip_config.connect.deploy_timeout
-    task = connect_client.wait_for_task(task_id, timeout=timeout)
-    deploy_state["task_result"] = task
-    if not task.get("finished"):
+    task_id = deploy_state["task_id"]
+
+    for attempt in range(_MAX_DEPLOY_ATTEMPTS):
+        task = connect_client.wait_for_task(task_id, timeout=timeout)
+        deploy_state["task_result"] = task
+
+        if not task.get("finished"):
+            output = "\n".join(task.get("output", []))
+            pytest.fail(
+                f"Deployment did not complete within {timeout} seconds\n\n"
+                f"--- Task output ---\n{output}"
+            )
+
+        if task.get("code") == 0:
+            return
+
         output = "\n".join(task.get("output", []))
-        pytest.fail(
-            f"Deployment did not complete within {timeout} seconds\n\n--- Task output ---\n{output}"
+        retry = (
+            attempt < _MAX_DEPLOY_ATTEMPTS - 1
+            and "redeploy" in deploy_state
+            and _is_transient_packrat_cdn_failure(output)
         )
-    if task.get("code") != 0:
-        output = "\n".join(task.get("output", []))
-        error = task.get("error", "unknown error")
-        pytest.fail(f"Deployment failed: {error}\n\n--- Task output ---\n{output}")
+        if not retry:
+            error = task.get("error", "unknown error")
+            pytest.fail(f"Deployment failed: {error}\n\n--- Task output ---\n{output}")
+
+        print(
+            f">>> {deploy_state.get('name', 'deploy')}: packrat restore hit a transient "
+            "connection failure against a known PPM/CDN host; retrying the deploy once "
+            "before failing the suite (vip#553)."
+        )
+        result = deploy_state["redeploy"]()
+        task_id = result["task_id"]
+        deploy_state["task_id"] = task_id
 
 
 @then("the content is accessible via HTTP")

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -505,7 +505,10 @@ def wait_for_deploy(connect_client, deploy_state, vip_config, record_property):
         if task.get("code") == 0:
             return
 
-        output = "\n".join(task.get("output", []))
+        # ``output`` can come back as null, not just absent, so coerce falsy
+        # values before joining -- matching test_packages.py and
+        # cross_product/test_integration.py, and the timeout branch above.
+        output = "\n".join(task.get("output", []) or [])
         matched = _matched_transient_signature(output)
         retry = (
             attempt < _MAX_DEPLOY_ATTEMPTS - 1

--- a/src/vip_tests/connect/test_content_deploy.py
+++ b/src/vip_tests/connect/test_content_deploy.py
@@ -48,13 +48,34 @@ _GIT_DIRECTORY = "extensions/quarto-document"
 # and every failure reverts to today's non-retried behavior -- it fails
 # closed, never silently.
 #
-# Filed as insurance, not a fix for chronic pain: at the time this was
-# written, 74/74 non-dispatch connect-smoke.yml runs (pull_request, push,
-# schedule) had been green, and this signature had fired exactly once, on a
-# workflow_dispatch run that was never on the merge-gating path. Do not
-# widen this match on the assumption it is covering something that happens
-# often -- it isn't, and a broader match trades away the "must still fail
-# for other reasons" guarantee for no evidenced benefit.
+# Filed as insurance, not a fix for chronic pain: as of 2026-07-29, this
+# signature had fired exactly once in connect-smoke.yml history, on
+# workflow_dispatch run 30398775778 (2026-07-28) -- a measurement run that
+# was never on the merge-gating path -- and every non-dispatch run
+# (pull_request, push, schedule) checked at that time was green. Both facts
+# will go stale as more runs accumulate: re-run
+# `gh run list --workflow connect-smoke.yml` and search for this failure
+# signature before repeating either claim, rather than trusting this
+# comment's word for it past the date above.
+#
+# Do not widen this match on the assumption it is covering something that
+# happens often -- as of the above date, it doesn't, and a broader match
+# trades away the "must still fail for other reasons" guarantee for no
+# evidenced benefit. "Widening" specifically means: adding a curl code,
+# adding a host, loosening the AND to an OR, or raising
+# _MAX_DEPLOY_ATTEMPTS above 2. Any of those needs its own fresh evidence of
+# a real, recurring failure shape -- not a hunch that this one might also
+# cover it.
+#
+# A persistent block against a known host -- a firewall rule, or PPM itself
+# down for the duration of the run -- also satisfies this triple-AND on
+# every attempt. That is an accepted, deliberate cost: it burns exactly one
+# wasted retry before correctly failing (the retry loop is bounded), it
+# never masks the failure, and it is exercised directly by
+# test_permanent_host_block_retries_once_then_fails in
+# selftests/test_connect_deploy_retry.py. Do not read this predicate as
+# "matches only genuinely transient failures" -- it matches this exact log
+# shape, transient or not, and relies on the bound to stay honest.
 _TRANSIENT_CURL_CODES = ("curl: (35)", "curl: (7)", "curl: (28)", "curl: (56)")
 _KNOWN_PPM_CDN_HOSTS = (
     "rspm-sync.rstudio.com",
@@ -66,14 +87,33 @@ _PACKRAT_RESTORE_FAILURE_TEXT = "Unable to fully restore the R packages"
 # One retry beyond the original attempt.
 _MAX_DEPLOY_ATTEMPTS = 2
 
+# How much of the first attempt's output to keep in a final failure message,
+# so "why did this fail after supposedly being handled" is answerable from
+# the failure alone even though the signature text lives in the FIRST
+# attempt, not the (differently-worded, or simply absent) second one.
+_RETRY_CONTEXT_CHARS = 1500
+
+
+def _matched_transient_signature(output: str) -> tuple[str, str] | None:
+    """Return the (curl_code, host) pair that matched, or None.
+
+    Same gate as :func:`_is_transient_packrat_cdn_failure` (all three parts
+    required), but returns which code/host matched so callers can log or
+    record exactly what was seen instead of a bare boolean.
+    """
+    if _PACKRAT_RESTORE_FAILURE_TEXT not in output:
+        return None
+    matched_code = next((code for code in _TRANSIENT_CURL_CODES if code in output), None)
+    matched_host = next((host for host in _KNOWN_PPM_CDN_HOSTS if host in output), None)
+    if matched_code is None or matched_host is None:
+        return None
+    return matched_code, matched_host
+
 
 def _is_transient_packrat_cdn_failure(output: str) -> bool:
     """Return True only for a packrat restore that failed via a connection-level
     curl error against a known PPM/CDN host -- see the module comment above."""
-    has_curl_failure = any(code in output for code in _TRANSIENT_CURL_CODES)
-    has_known_host = any(host in output for host in _KNOWN_PPM_CDN_HOSTS)
-    has_restore_failure = _PACKRAT_RESTORE_FAILURE_TEXT in output
-    return has_curl_failure and has_known_host and has_restore_failure
+    return _matched_transient_signature(output) is not None
 
 
 def _md5(text: str) -> str:
@@ -427,7 +467,7 @@ def trigger_git_deploy(connect_client, deploy_state):
 
 
 @when("I wait for the deployment to complete")
-def wait_for_deploy(connect_client, deploy_state, vip_config):
+def wait_for_deploy(connect_client, deploy_state, vip_config, record_property):
     """Wait for the deploy task, retrying once on a narrow transient failure.
 
     See the module comment above ``_is_transient_packrat_cdn_failure`` for why
@@ -435,9 +475,20 @@ def wait_for_deploy(connect_client, deploy_state, vip_config):
     does not match that exact signature -- including a second attempt that
     fails again -- fails immediately, identically to before this retry
     existed.
+
+    A retry that fixes the deploy leaves the test PASSING, so a plain
+    ``print`` alone is not enough evidence for anyone auditing a green run --
+    pytest's plugin only surfaces captured stdout for failed/errored tests
+    (see ``src/vip/plugin.py``), and CI's ``--junitxml`` output has no stdout
+    field for a pass either. ``record_property`` writes a ``<property>`` onto
+    the JUnit XML testcase itself, which survives regardless of outcome (and
+    survives under this suite's ``-n auto --dist loadgroup`` xdist config --
+    verified empirically, not assumed), so a retry is queryable from the
+    uploaded ``smoke-results.xml`` even when the run is all green.
     """
     timeout = vip_config.connect.deploy_timeout
     task_id = deploy_state["task_id"]
+    first_attempt_output: str | None = None
 
     for attempt in range(_MAX_DEPLOY_ATTEMPTS):
         task = connect_client.wait_for_task(task_id, timeout=timeout)
@@ -455,20 +506,39 @@ def wait_for_deploy(connect_client, deploy_state, vip_config):
             return
 
         output = "\n".join(task.get("output", []))
+        matched = _matched_transient_signature(output)
         retry = (
             attempt < _MAX_DEPLOY_ATTEMPTS - 1
             and "redeploy" in deploy_state
-            and _is_transient_packrat_cdn_failure(output)
+            and matched is not None
         )
         if not retry:
             error = task.get("error", "unknown error")
+            if first_attempt_output is not None:
+                # The signature that triggered the retry lives in the FIRST
+                # attempt's output, not necessarily this one -- include both
+                # so the failure is self-explanatory without cross-referencing
+                # a separate log.
+                pytest.fail(
+                    f"Deployment failed after retrying a transient PPM/CDN failure: {error}\n\n"
+                    "--- First attempt output (truncated) ---\n"
+                    f"{first_attempt_output[-_RETRY_CONTEXT_CHARS:]}\n\n"
+                    f"--- Second attempt output ---\n{output}"
+                )
             pytest.fail(f"Deployment failed: {error}\n\n--- Task output ---\n{output}")
 
+        matched_code, matched_host = matched
+        record_property(
+            "vip_deploy_retry",
+            f"content={deploy_state.get('name', 'unknown')} "
+            f"code={matched_code} host={matched_host}",
+        )
         print(
             f">>> {deploy_state.get('name', 'deploy')}: packrat restore hit a transient "
-            "connection failure against a known PPM/CDN host; retrying the deploy once "
-            "before failing the suite (vip#553)."
+            f"connection failure ({matched_code} against {matched_host}); retrying the "
+            "deploy once before failing the suite (vip#553)."
         )
+        first_attempt_output = output
         result = deploy_state["redeploy"]()
         task_id = result["task_id"]
         deploy_state["task_id"] = task_id


### PR DESCRIPTION
Closes #553.

## Problem

`Connect Smoke Tests Status` is a required check that can go red for reasons outside this repository. Connect resolves R packages over the public internet on every deploy, and a reset at `rspm-sync.rstudio.com` mid-restore fails the deploy and therefore the gate.

Packrat already retries the download once internally -- visible in the task log as a failed curl call followed immediately by a successful one for the same URL -- and aborts the whole restore only if that retry also fails. That retry is Connect's, fixed at one attempt, with no hook for VIP. The only lever available is redeploying the bundle.

## Fix

`wait_for_deploy` retries once, and only when the task output carries all three of: a curl connection-level code (35/7/28/56), a known PPM/CDN host, and packrat's `Unable to fully restore the R packages`. The combination is required, so a bad manifest, wrong entrypoint or app crash still fails on the first attempt. A second matching failure also fails. The timeout branch never retries.

## Honest framing

This is insurance, not a fix for chronic pain. Across the last 80 `connect-smoke.yml` runs, all 74 non-dispatch runs (pull_request, push, schedule) were green; the one occurrence was a `workflow_dispatch` run on a measurement branch, never on the merge-gating path. The code comment records that evidence explicitly, so nobody widens the match later believing it covers something frequent.

The match is against a live product's log wording, not an API contract. If a future Connect release rewords the message the predicate stops matching and every failure reverts to today's behaviour -- it fails closed, never silently.

## Ruled out

Trimming the manifests is contraindicated by an existing comment in the test: an incomplete `packages` block causes a guaranteed `r-cannot-access-repo` failure when PPM does not serve transitive deps anonymously. Pinning a dated PPM snapshot does not prevent a connection reset. Pre-warming the cache adds setup cost for a failure that has not hit the merge path.

## Verification

29 selftests in `selftests/test_connect_deploy_retry.py`. The positive case uses text captured verbatim from the failing job log. Negatives cover bad manifest, wrong entrypoint, app crash, an unrelated non-zero exit and empty output, and each part of the triple in isolation and in pairs. Call-count assertions prove the retry fires at most once, that a non-matching failure triggers no redeploy at all, and that the timeout branch is unaffected.

Separately verified that `curl: (70)` and `curl: (17)` do not satisfy the `curl: (7)` check.



## Corrections after review

A review pass found the `print` announcing a retry was invisible on exactly the path the retry exists for: `plugin.py` filters captured stdout for any outcome that is not failed or error, `junit_logging` is unset so stdout never reaches `smoke-results.xml`, and the `results.json` record has no stdout field. A retry that succeeded left no trace anywhere, so the print alone could not make this auditable as intended. `wait_for_deploy` now records a `vip_deploy_retry` JUnit property carrying the matched curl code and host, confirmed present in the generated XML on a passing test under both `-n auto` and `-n0`.

Three test gaps were also closed. The `redeploy` closures were never exercised, so a change reading `guid`/`bundle_id` live from `deploy_state` instead of capturing them would have passed every test while being able to redeploy the wrong bundle. The signature constants were single-sampled, so a typo in five of the seven would have gone unnoticed. And no negative case carried a CDN host, leaving the one real false-positive class -- a permanent block to a known host, which does match and does cost one wasted retry -- untested and unnamed; it is now both.

Copilot flagged that `task.get("output", [])` can be `null`, making `"\n".join(...)` raise and mask the real failure. The applied autofix covered the timeout branch only; the failure-path join is now guarded too, matching `test_packages.py` and `cross_product/test_integration.py`.
