### PR TITLE
fix(ssl): make the SSL steps assert what their names promise

### DIFF
--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -287,6 +287,14 @@ class TestVIPConfigTLS:
         cfg = VIPConfig(ca_bundle=bundle)
         assert cfg.ca_bundle == bundle
 
+    def test_cert_expiry_warning_days_default(self):
+        cfg = VIPConfig()
+        assert cfg.cert_expiry_warning_days == 30
+
+    def test_cert_expiry_warning_days_explicit(self):
+        cfg = VIPConfig(cert_expiry_warning_days=7)
+        assert cfg.cert_expiry_warning_days == 7
+
 
 class TestVIPConfig:
     def test_product_config_lookup(self):
@@ -539,6 +547,12 @@ class TestLoadConfigTLS:
         cfg = load_config(path)
         assert cfg.insecure is False
         assert cfg.ca_bundle is None
+        assert cfg.cert_expiry_warning_days == 30
+
+    def test_cert_expiry_warning_days_from_toml(self, tmp_toml):
+        path = tmp_toml("[tls]\ncert_expiry_warning_days = 7\n")
+        cfg = load_config(path)
+        assert cfg.cert_expiry_warning_days == 7
 
     def test_insecure_from_toml(self, tmp_toml):
         path = tmp_toml("[tls]\ninsecure = true\n")

--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -554,6 +554,18 @@ class TestLoadConfigTLS:
         cfg = load_config(path)
         assert cfg.cert_expiry_warning_days == 7
 
+    def test_cert_expiry_warning_days_zero_disables_check(self, tmp_toml):
+        path = tmp_toml("[tls]\ncert_expiry_warning_days = 0\n")
+        cfg = load_config(path)
+        assert cfg.cert_expiry_warning_days == 0
+
+    def test_cert_expiry_warning_days_negative_raises_valueerror(self, tmp_toml):
+        """A negative threshold would silently pass for a cert already
+        inside any expiry window -- fail fast on the config typo instead."""
+        path = tmp_toml("[tls]\ncert_expiry_warning_days = -1\n")
+        with pytest.raises(ValueError, match="cert_expiry_warning_days must be >= 0"):
+            load_config(path)
+
     def test_insecure_from_toml(self, tmp_toml):
         path = tmp_toml("[tls]\ninsecure = true\n")
         cfg = load_config(path)

--- a/selftests/test_https_helper.py
+++ b/selftests/test_https_helper.py
@@ -1,0 +1,70 @@
+"""Selftests for ``make_http_request`` in
+``src/vip_tests/security/test_https.py``.
+
+Mirrors ``selftests/test_ssl_helper.py``'s coverage of the sibling
+``request_http`` -- both classify "no usable plain-HTTP endpoint" the same
+narrow way (``httpx.HTTPError`` only), so an unrelated exception (a
+malformed URL, a code bug) still propagates instead of being reported as an
+acceptable "port closed" outcome. See #457, #555.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vip.config import VIPConfig
+from vip_tests.security.test_https import make_http_request
+
+
+def test_make_http_request_classifies_connect_error_as_refused(monkeypatch):
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.ConnectError("Connection refused")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    result = make_http_request("https://connect.example.com", VIPConfig())
+
+    assert result["refused"] is True
+
+
+def test_make_http_request_classifies_protocol_error_as_refused(monkeypatch):
+    """A plaintext request landing on a TLS-only port raises a protocol
+    error, not ``httpx.ConnectError`` -- it must still classify as
+    "refused" so ``https_enforced`` treats a missing plain-HTTP listener as
+    acceptable. #457."""
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    result = make_http_request("https://connect.example.com", VIPConfig())
+
+    assert result["refused"] is True
+
+
+def test_make_http_request_does_not_swallow_unrelated_exceptions(monkeypatch):
+    """Regression guard: classifying every exception as "refused" would let
+    ``https_enforced`` pass silently on a malformed URL or a code bug, not
+    just on a genuinely closed port. ``httpx.InvalidURL`` derives directly
+    from ``Exception`` (not ``httpx.HTTPError``), so it must propagate. #457.
+    """
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.InvalidURL("Invalid URL component 'host'")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    with pytest.raises(httpx.InvalidURL):
+        make_http_request("https://connect.example.com", VIPConfig())
+
+
+def test_make_http_request_does_not_swallow_programming_errors(monkeypatch):
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        make_http_request("https://connect.example.com", VIPConfig())

--- a/selftests/test_https_helper.py
+++ b/selftests/test_https_helper.py
@@ -3,7 +3,8 @@
 
 Mirrors ``selftests/test_ssl_helper.py``'s coverage of the sibling
 ``request_http`` -- both classify "no usable plain-HTTP endpoint" the same
-narrow way (``httpx.HTTPError`` only), so an unrelated exception (a
+narrow way (``httpx.NetworkError``/``httpx.ProtocolError`` only, NOT the
+wider ``httpx.HTTPError``), so a timeout or an unrelated exception (a
 malformed URL, a code bug) still propagates instead of being reported as an
 acceptable "port closed" outcome. See #457, #555.
 """
@@ -44,6 +45,25 @@ def test_make_http_request_classifies_protocol_error_as_refused(monkeypatch):
     assert result["refused"] is True
 
 
+def test_make_http_request_classifies_read_error_as_refused(monkeypatch):
+    """Confirmed against a live self-signed server (not assumed): hitting a
+    TLS-only port with plaintext HTTP can also surface as
+    ``httpx.ReadError``/"Connection reset by peer" rather than
+    ``RemoteProtocolError``, depending on the server and OS. ``ReadError``
+    is an ``httpx.NetworkError``, NOT an ``httpx.ConnectError`` or
+    ``httpx.ProtocolError``, which is why the except clause must catch
+    ``NetworkError`` rather than just ``ConnectError``. #457."""
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.ReadError("[Errno 54] Connection reset by peer")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    result = make_http_request("https://connect.example.com", VIPConfig())
+
+    assert result["refused"] is True
+
+
 def test_make_http_request_does_not_swallow_unrelated_exceptions(monkeypatch):
     """Regression guard: classifying every exception as "refused" would let
     ``https_enforced`` pass silently on a malformed URL or a code bug, not
@@ -67,4 +87,32 @@ def test_make_http_request_does_not_swallow_programming_errors(monkeypatch):
     monkeypatch.setattr(httpx, "get", fake_get)
 
     with pytest.raises(RuntimeError, match="boom"):
+        make_http_request("https://connect.example.com", VIPConfig())
+
+
+def test_make_http_request_does_not_classify_connect_timeout_as_refused(monkeypatch):
+    """A timeout means the host is filtered or hung, not "no plain-HTTP
+    listener" -- ``httpx.ConnectTimeout`` is a ``TimeoutException``, NOT an
+    ``httpx.NetworkError``/``ProtocolError``, so it must propagate. #457.
+    """
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.ConnectTimeout("timed out")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    with pytest.raises(httpx.ConnectTimeout):
+        make_http_request("https://connect.example.com", VIPConfig())
+
+
+def test_make_http_request_does_not_classify_read_timeout_as_refused(monkeypatch):
+    """A ``ReadTimeout`` means the port accepted the connection and never
+    answered -- a hung listener, a real bug, not "port closed". #457."""
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    with pytest.raises(httpx.ReadTimeout):
         make_http_request("https://connect.example.com", VIPConfig())

--- a/selftests/test_ssl_helper.py
+++ b/selftests/test_ssl_helper.py
@@ -8,6 +8,7 @@ actually fail.
 
 from __future__ import annotations
 
+import locale
 import socket
 import ssl
 from datetime import datetime, timedelta, timezone
@@ -20,6 +21,7 @@ from vip_tests.cross_product.test_ssl import (
     _attempt_tls,
     _cert_expires_at,
     cert_valid,
+    check_ssl_cert,
     http_port_no_content,
     request_http,
 )
@@ -325,6 +327,34 @@ def test_modern_tls_succeeds_insecure_cert_failure_does_not_suggest_ssl_cert_fil
 
 
 # ---------------------------------------------------------------------------
+# check_ssl_cert connect-vs-handshake exception narrowing #555
+# ---------------------------------------------------------------------------
+
+
+def test_check_ssl_cert_skips_on_connect_failure(monkeypatch):
+    """A TCP connect failure (refused/timeout/DNS) means the host is
+    unreachable -- not a certificate finding -- so it must still skip."""
+    _patch_connect(monkeypatch, OSError("connection refused"))
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    with pytest.raises(pytest.skip.Exception):
+        check_ssl_cert("Connect", vip_config)
+
+
+def test_check_ssl_cert_propagates_non_cert_handshake_errors(monkeypatch):
+    """A handshake failure for a reason other than certificate verification
+    (e.g. a protocol mismatch) must fail loudly, not be silently skipped --
+    a broad skip here would gate the expiry-margin assertion behind "not
+    applicable" instead of "unknown"."""
+    _patch_connect(monkeypatch)
+    _patch_handshake(monkeypatch, ssl.SSLError("unsupported protocol"))
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    with pytest.raises(ssl.SSLError, match="unsupported protocol"):
+        check_ssl_cert("Connect", vip_config)
+
+
+# ---------------------------------------------------------------------------
 # Certificate-expiry margin ("the certificate is valid and not expired") #555
 # ---------------------------------------------------------------------------
 
@@ -339,6 +369,60 @@ def _cert_with_days_remaining(days: float) -> dict:
 def test_cert_expires_at_parses_notafter():
     expires_at = _cert_expires_at({"notAfter": "Jun 15 12:00:00 2030 GMT"})
     assert expires_at == datetime(2030, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_cert_expires_at_handles_single_digit_day_double_space():
+    """OpenSSL pads a single-digit day with an extra space instead of
+    zero-padding it (e.g. "Jun  1 ..."), not "Jun 01 ...". #560."""
+    expires_at = _cert_expires_at({"notAfter": "Jun  1 12:00:00 2030 GMT"})
+    assert expires_at == datetime(2030, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "month_abbr,month_num",
+    [
+        ("Jan", 1),
+        ("Feb", 2),
+        ("Mar", 3),
+        ("Apr", 4),
+        ("May", 5),
+        ("Jun", 6),
+        ("Jul", 7),
+        ("Aug", 8),
+        ("Sep", 9),
+        ("Oct", 10),
+        ("Nov", 11),
+        ("Dec", 12),
+    ],
+)
+def test_cert_expires_at_all_month_abbreviations(month_abbr, month_num):
+    not_after = f"{month_abbr} 15 12:00:00 2030 GMT"
+    expires_at = _cert_expires_at({"notAfter": not_after})
+    assert expires_at == datetime(2030, month_num, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_cert_expires_at_locale_independent():
+    """``_cert_expires_at`` must not depend on ``LC_TIME``. OpenSSL's
+    ``notAfter`` month abbreviation is always English regardless of locale,
+    but a ``%b``-based ``strptime`` reads the process's LC_TIME month table
+    -- so on a non-English runner (VIP is customer-run software; we don't
+    control this) the old implementation raised on this exact, unchanging
+    string. #560. Skips (rather than silently passing) if the runner lacks
+    the de_DE locale data, since that would prove nothing either way.
+    """
+    original = locale.setlocale(locale.LC_TIME)
+    try:
+        try:
+            locale.setlocale(locale.LC_TIME, "de_DE.UTF-8")
+        except locale.Error:
+            pytest.skip("de_DE.UTF-8 locale not available on this runner")
+
+        expires_at = _cert_expires_at({"notAfter": "Jun 15 12:00:00 2030 GMT"})
+        assert expires_at == datetime(2030, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    finally:
+        # Reset unconditionally so a locale change here can't leak into
+        # other tests sharing this worker process.
+        locale.setlocale(locale.LC_TIME, original)
 
 
 def test_cert_valid_passes_when_expiry_beyond_threshold():
@@ -422,6 +506,26 @@ def test_request_http_classifies_protocol_error_as_port_closed(monkeypatch):
     assert result["error"] == "port_closed"
 
 
+def test_request_http_classifies_read_error_as_port_closed(monkeypatch):
+    """Confirmed against a live self-signed server (not assumed): hitting a
+    TLS-only port with plaintext HTTP can also surface as
+    ``httpx.ReadError``/"Connection reset by peer" rather than
+    ``RemoteProtocolError``, depending on the server and OS. ``ReadError``
+    is an ``httpx.NetworkError``, NOT an ``httpx.ConnectError`` or
+    ``httpx.ProtocolError``, which is why the except clause must catch
+    ``NetworkError`` rather than just ``ConnectError``. #457."""
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.ReadError("[Errno 54] Connection reset by peer")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    result = request_http("Connect", vip_config)
+
+    assert result["error"] == "port_closed"
+
+
 def test_request_http_does_not_swallow_unrelated_exceptions(monkeypatch):
     """A regression guard for the failure mode this whole file exists to
     prevent: classifying every exception as "port_closed" would make
@@ -453,4 +557,38 @@ def test_request_http_does_not_swallow_programming_errors(monkeypatch):
     vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
 
     with pytest.raises(RuntimeError, match="boom"):
+        request_http("Connect", vip_config)
+
+
+def test_request_http_does_not_classify_connect_timeout_as_port_closed(monkeypatch):
+    """A timeout is not "no plain-HTTP listener" -- it means the host is
+    filtered (SYN dropped) or hung, a materially different, reportable
+    state from a genuinely closed port. ``httpx.ConnectTimeout`` is a
+    ``TimeoutException``, NOT an ``httpx.NetworkError``/``ProtocolError``,
+    so the narrow except must let it propagate rather than silently passing
+    the redirect/no-content checks. #457.
+    """
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.ConnectTimeout("timed out")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    with pytest.raises(httpx.ConnectTimeout):
+        request_http("Connect", vip_config)
+
+
+def test_request_http_does_not_classify_read_timeout_as_port_closed(monkeypatch):
+    """A ``ReadTimeout`` means the port accepted the connection and then
+    never answered -- a hung listener, a real bug worth surfacing loudly,
+    not "port closed". #457."""
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    with pytest.raises(httpx.ReadTimeout):
         request_http("Connect", vip_config)

--- a/selftests/test_ssl_helper.py
+++ b/selftests/test_ssl_helper.py
@@ -1,18 +1,28 @@
-"""Selftests for the TLS-version classification helper.
+"""Selftests for the step definitions in
+``src/vip_tests/cross_product/test_ssl.py``.
 
-Covers ``_attempt_tls`` in ``src/vip_tests/cross_product/test_ssl.py``.
-No real sockets: the handshake is monkeypatched to raise each exception
-type in turn so we can assert how the helper classifies the result.
+No real sockets: handshakes, connects, and HTTP requests are monkeypatched
+so we can assert how each step classifies results and where its assertions
+actually fail.
 """
 
 from __future__ import annotations
 
 import socket
 import ssl
+from datetime import datetime, timedelta, timezone
 
+import httpx
 import pytest
 
-from vip_tests.cross_product.test_ssl import _attempt_tls
+from vip.config import ConnectConfig, VIPConfig
+from vip_tests.cross_product.test_ssl import (
+    _attempt_tls,
+    _cert_expires_at,
+    cert_valid,
+    http_port_no_content,
+    request_http,
+)
 
 
 def _patch_handshake(monkeypatch, exc: BaseException | None):
@@ -107,6 +117,61 @@ def test_attempt_tls_raises_connect_error_when_host_unreachable(monkeypatch):
         _attempt_tls("example.com", 443, min_version=ssl.TLSVersion.TLSv1_2)
 
     assert "connection refused" in str(info.value)
+
+
+def _recording_context_factory(seen: dict):
+    """Build a fake ``create_default_context()`` replacement that records
+    every attribute assignment into *seen* and answers ``wrap_socket`` with
+    a stub context manager (no real handshake)."""
+
+    class _StubSSLSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    class _RecordingContext:
+        minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+        maximum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
+
+        def __setattr__(self, name, value):
+            seen[name] = value
+            object.__setattr__(self, name, value)
+
+        def wrap_socket(self, sock, server_hostname=None, **kwargs):
+            return _StubSSLSocket()
+
+    return _RecordingContext
+
+
+def test_attempt_tls_defaults_to_full_verification(monkeypatch):
+    """Without ``insecure``, the context must require and check certs."""
+    _patch_connect(monkeypatch)
+
+    seen: dict = {}
+    monkeypatch.setattr(ssl, "create_default_context", lambda: _recording_context_factory(seen)())
+
+    _attempt_tls("example.com", 443, min_version=ssl.TLSVersion.TLSv1_2)
+
+    assert seen["check_hostname"] is True
+    assert seen["verify_mode"] == ssl.CERT_REQUIRED
+
+
+def test_attempt_tls_insecure_disables_verification(monkeypatch):
+    """``insecure=True`` (mirrors ``tls.insecure``) must relax verification
+    so a self-signed cert doesn't masquerade as a TLS-version failure. #457.
+    """
+    _patch_connect(monkeypatch)
+
+    seen: dict = {}
+    monkeypatch.setattr(ssl, "create_default_context", lambda: _recording_context_factory(seen)())
+
+    result = _attempt_tls("example.com", 443, insecure=True, min_version=ssl.TLSVersion.TLSv1_2)
+
+    assert seen["check_hostname"] is False
+    assert seen["verify_mode"] == ssl.CERT_NONE
+    assert result == {"status": "connected", "detail": ""}
 
 
 def test_attempt_tls_classifies_context_config_failure_as_client_unsupported(
@@ -237,3 +302,155 @@ def test_modern_tls_succeeds_reports_plain_rejection_clearly():
     msg = str(info.value)
     assert "TLS 1.2 connection failed" in msg
     assert "unsupported protocol" in msg
+
+
+def test_modern_tls_succeeds_insecure_cert_failure_does_not_suggest_ssl_cert_file():
+    """Under ``tls.insecure=true`` a cert-verify failure should not blame the
+    user for skipping a step they explicitly opted out of. #457."""
+    results = _results(
+        {"status": "rejected", "detail": ""},
+        {"status": "rejected", "detail": ""},
+        {
+            "status": "cert_verify_failed",
+            "detail": "self-signed certificate",
+        },
+    )
+    results["insecure"] = True
+    with pytest.raises(AssertionError) as info:
+        modern_tls_succeeds(results)
+    msg = str(info.value)
+    assert "SSL_CERT_FILE" not in msg
+    assert "tls.insecure=true" in msg
+    assert "self-signed certificate" in msg
+
+
+# ---------------------------------------------------------------------------
+# Certificate-expiry margin ("the certificate is valid and not expired") #555
+# ---------------------------------------------------------------------------
+
+
+def _cert_with_days_remaining(days: float) -> dict:
+    expires = datetime.now(timezone.utc) + timedelta(days=days)
+    # OpenSSL's notAfter format, e.g. "Jun 15 12:00:00 2030 GMT". A two-digit
+    # day sidesteps the single-digit-day double-space quirk (" 1" vs "01").
+    return {"notAfter": expires.strftime("%b %d %H:%M:%S %Y GMT")}
+
+
+def test_cert_expires_at_parses_notafter():
+    expires_at = _cert_expires_at({"notAfter": "Jun 15 12:00:00 2030 GMT"})
+    assert expires_at == datetime(2030, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_cert_valid_passes_when_expiry_beyond_threshold():
+    cert_info = {
+        "error": None,
+        "cert": _cert_with_days_remaining(400),
+        "hostname": "example.com",
+    }
+    cert_valid(cert_info, VIPConfig())  # no assertion error
+
+
+def test_cert_valid_fails_when_expiry_within_threshold():
+    """A soon-to-expire certificate must trip the margin check -- proof the
+    assertion isn't vacuous. #555."""
+    cert_info = {
+        "error": None,
+        "cert": _cert_with_days_remaining(5),
+        "hostname": "example.com",
+    }
+    with pytest.raises(AssertionError) as info:
+        cert_valid(cert_info, VIPConfig())
+    msg = str(info.value)
+    assert "example.com" in msg
+    assert "expires in" in msg
+    assert "30-day" in msg
+
+
+def test_cert_valid_respects_configured_threshold():
+    cert_info = {
+        "error": None,
+        "cert": _cert_with_days_remaining(10),
+        "hostname": "example.com",
+    }
+    # 10 days remaining clears a 5-day threshold...
+    cert_valid(cert_info, VIPConfig(cert_expiry_warning_days=5))
+    # ...but not the 30-day default.
+    with pytest.raises(AssertionError):
+        cert_valid(cert_info, VIPConfig())
+
+
+# ---------------------------------------------------------------------------
+# "the HTTP port is closed or serves no content directly" #555
+# ---------------------------------------------------------------------------
+
+
+def test_http_port_no_content_passes_when_port_closed():
+    http_port_no_content({"error": "port_closed", "status": None})  # no assertion error
+
+
+def test_http_port_no_content_passes_on_redirect():
+    http_port_no_content({"error": None, "status": 301})  # no assertion error
+
+
+def test_http_port_no_content_fails_on_real_content():
+    """A plain-HTTP server answering with real content (not a redirect) must
+    trip this step -- proof it isn't a vacuous ``pass`` anymore. #555."""
+    with pytest.raises(AssertionError) as info:
+        http_port_no_content({"error": None, "status": 200})
+    assert "served content directly" in str(info.value)
+
+
+# ---------------------------------------------------------------------------
+# request_http transport-error classification #457
+# ---------------------------------------------------------------------------
+
+
+def test_request_http_classifies_protocol_error_as_port_closed(monkeypatch):
+    """A plaintext request landing on a TLS-only port raises a protocol
+    error, not ``httpx.ConnectError`` -- it must still classify as
+    "port_closed" so the redirect / no-content checks treat a missing
+    plain-HTTP listener as acceptable rather than failing. #457."""
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    result = request_http("Connect", vip_config)
+
+    assert result["error"] == "port_closed"
+
+
+def test_request_http_does_not_swallow_unrelated_exceptions(monkeypatch):
+    """A regression guard for the failure mode this whole file exists to
+    prevent: classifying every exception as "port_closed" would make
+    ``redirects_to_https`` and ``http_port_no_content`` both pass silently
+    on a malformed URL or a code bug, not just on a genuinely closed port.
+    ``httpx.InvalidURL`` derives directly from ``Exception`` (not
+    ``httpx.HTTPError``), so it must still propagate rather than being
+    classified as "port_closed". #457.
+    """
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise httpx.InvalidURL("Invalid URL component 'host'")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    with pytest.raises(httpx.InvalidURL):
+        request_http("Connect", vip_config)
+
+
+def test_request_http_does_not_swallow_programming_errors(monkeypatch):
+    """A plain bug (e.g. a typo introduced in a future edit) must not be
+    reported as an acceptable "port closed" outcome either. #457."""
+
+    def fake_get(url, follow_redirects=False, timeout=10, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        request_http("Connect", vip_config)

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -501,6 +501,25 @@ def _resolve_ca_bundle(raw: str | None) -> Path | None:
     return p
 
 
+def _validate_cert_expiry_warning_days(value: int) -> int:
+    """Reject a negative threshold.
+
+    ``0`` disables the expiry-margin check (documented behavior). A negative
+    value would silently pass for a certificate already inside any expiry
+    window, defeating the check -- fail fast on a config typo instead.
+
+    Deliberate exception to this file's dominant convention: other plain
+    numeric fields (``job_timeout``, ``deploy_timeout``, etc.) are
+    unvalidated, and only ``ca_bundle``/``git_test.auth_method`` validate
+    today. This one gets a validator anyway because, unlike a bad timeout,
+    a negative threshold doesn't fail loudly on first use -- it silently
+    turns off a security check the field exists to enforce.
+    """
+    if value < 0:
+        raise ValueError(f"[tls] cert_expiry_warning_days must be >= 0, got {value}")
+    return value
+
+
 def load_config(path: str | Path | None = None) -> VIPConfig:
     """Load VIP configuration from a TOML file.
 
@@ -566,5 +585,7 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
         security_policy_checks_enabled=security_raw.get("policy_checks_enabled", False),
         insecure=tls_raw.get("insecure", False),
         ca_bundle=_resolve_ca_bundle(tls_raw.get("ca_bundle")),
-        cert_expiry_warning_days=tls_raw.get("cert_expiry_warning_days", 30),
+        cert_expiry_warning_days=_validate_cert_expiry_warning_days(
+            tls_raw.get("cert_expiry_warning_days", 30)
+        ),
     )

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -458,6 +458,7 @@ class VIPConfig:
 
     insecure: bool = False
     ca_bundle: Path | None = None
+    cert_expiry_warning_days: int = 30
 
     @property
     def verify(self) -> bool | str:
@@ -565,4 +566,5 @@ def load_config(path: str | Path | None = None) -> VIPConfig:
         security_policy_checks_enabled=security_raw.get("policy_checks_enabled", False),
         insecure=tls_raw.get("insecure", False),
         ca_bundle=_resolve_ca_bundle(tls_raw.get("ca_bundle")),
+        cert_expiry_warning_days=tls_raw.get("cert_expiry_warning_days", 30),
     )

--- a/src/vip_tests/cross_product/test_ssl.feature
+++ b/src/vip_tests/cross_product/test_ssl.feature
@@ -20,7 +20,7 @@ Feature: SSL certificates and HTTPS
     Given <product> is configured in vip.toml
     When I request the HTTP URL for <product>
     Then the response redirects to HTTPS
-    And the HTTP port is not open
+    And the HTTP port is closed or serves no content directly
 
     Examples:
       | product         |

--- a/src/vip_tests/cross_product/test_ssl.py
+++ b/src/vip_tests/cross_product/test_ssl.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import socket
 import ssl
+from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import httpx
@@ -52,17 +53,44 @@ def check_ssl_cert(product, vip_config):
         with socket.create_connection((hostname, port), timeout=10) as sock:
             with ctx.wrap_socket(sock, server_hostname=hostname) as ssock:
                 cert = ssock.getpeercert()
-                return {"cert": cert, "error": None}
+                return {"cert": cert, "error": None, "hostname": hostname}
     except ssl.SSLCertVerificationError as exc:
-        return {"cert": None, "error": str(exc)}
+        return {"cert": None, "error": str(exc), "hostname": hostname}
     except Exception as exc:
         pytest.skip(f"Could not connect to {hostname}:{port}: {exc}")
 
 
+def _cert_expires_at(cert: dict) -> datetime:
+    """Parse the ``notAfter`` field from ``ssl.SSLSocket.getpeercert()``.
+
+    The format is fixed by OpenSSL (e.g. ``"Jun  1 12:00:00 2030 GMT"``) and
+    is always UTC, so the ``GMT`` token is matched literally rather than
+    interpreted as a real timezone abbreviation.
+    """
+    not_after = cert.get("notAfter")
+    if not not_after:
+        raise ValueError("Certificate has no notAfter field")
+    return datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z").replace(tzinfo=timezone.utc)
+
+
 @then("the certificate is valid and not expired")
-def cert_valid(cert_info):
+def cert_valid(cert_info, vip_config):
     assert cert_info["error"] is None, f"SSL certificate error: {cert_info['error']}"
     assert cert_info["cert"] is not None, "No certificate returned"
+
+    # A handshake succeeding only proves the cert isn't expired *yet* -- an
+    # already-expired cert would have failed verification above. The useful
+    # check is the margin: warn early enough to renew before the cert lapses
+    # and causes an outage. See #555.
+    expires_at = _cert_expires_at(cert_info["cert"])
+    days_remaining = (expires_at - datetime.now(timezone.utc)).total_seconds() / 86400
+    threshold = vip_config.cert_expiry_warning_days
+    assert days_remaining >= threshold, (
+        f"Certificate for {cert_info['hostname']} expires in "
+        f"{days_remaining:.1f} day(s) (on {cert_info['cert']['notAfter']}), "
+        f"under the configured {threshold}-day warning threshold "
+        f"([tls] cert_expiry_warning_days). Renew it before it expires."
+    )
 
 
 @then("the certificate chain is complete")
@@ -95,10 +123,26 @@ def request_http(product, vip_config):
         http_url = f"http://{parsed.hostname}"
     try:
         resp_no_follow = httpx.get(http_url, follow_redirects=False, timeout=10)
-    except httpx.ConnectError:
-        return {"status": None, "location": "", "final_url_scheme": None, "error": "port_closed"}
-    except Exception as exc:
-        return {"status": None, "location": "", "final_url_scheme": None, "error": str(exc)}
+    except httpx.HTTPError as exc:
+        # httpx.HTTPError's subtree covers what "no usable plain-HTTP
+        # endpoint" actually means: connection refused (ConnectError), a
+        # timeout, or a protocol violation from sending plaintext HTTP at a
+        # TLS-only port (ProtocolError/RemoteProtocolError). Deliberately
+        # NOT a bare ``except Exception``: an unrelated bug (a malformed
+        # configured URL raising httpx.InvalidURL, or a future edit
+        # introducing a NameError/AttributeError here) must keep propagating
+        # as a real failure, not get reported as "port closed, that's fine"
+        # -- that would silently recreate the exact vacuous-check problem
+        # this file's steps were just fixed for. See #457, #555.
+        # src/vip_tests/security/test_https.py::make_http_request classifies
+        # its sibling check the same narrow way -- keep the two in sync.
+        return {
+            "status": None,
+            "location": "",
+            "final_url_scheme": None,
+            "error": "port_closed",
+            "detail": str(exc),
+        }
 
     # Also follow redirects to detect ALB / load-balancer patterns where the
     # HTTP→HTTPS upgrade happens transparently (no client-visible 3xx).  This is
@@ -144,10 +188,19 @@ def redirects_to_https(http_response):
     )
 
 
-@then("the HTTP port is not open")
-def http_port_closed(http_response):
-    # This step is an alternative - if HTTP redirected, that's fine too.
-    pass
+@then("the HTTP port is closed or serves no content directly")
+def http_port_no_content(http_response):
+    # This step is the narrower companion to "the response redirects to
+    # HTTPS": a closed port is fine, and so is a redirect (already verified
+    # above), but a 2xx response means the server served real content over
+    # plaintext HTTP, which is never acceptable. See #555.
+    if http_response["error"] == "port_closed":
+        return
+    status = http_response["status"]
+    assert status is None or not (200 <= status < 300), (
+        f"Plain HTTP served content directly (status {status}) instead of "
+        "redirecting to HTTPS or refusing the connection."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +220,7 @@ def _attempt_tls(
     hostname: str,
     port: int,
     *,
+    insecure: bool = False,
     min_version: ssl.TLSVersion | None = None,
     max_version: ssl.TLSVersion | None = None,
     timeout: float = 10.0,
@@ -174,7 +228,13 @@ def _attempt_tls(
     """Attempt one TLS handshake and classify the result.
 
     Uses ``ssl.create_default_context()`` so the system CA bundle is
-    loaded (and ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` are honored).
+    loaded (and ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` are honored) --
+    unless *insecure* is set, in which case certificate verification is
+    disabled entirely. This scenario is about which TLS *versions* a server
+    accepts, not certificate trust, so a user running with
+    ``tls.insecure=true`` (e.g. against a self-signed cert) should still get
+    a meaningful version-enforcement result instead of a cert-trust failure
+    they already opted out of. See #457.
 
     Returns a dict with:
       - ``status``: ``"connected"``, ``"rejected"``,
@@ -195,8 +255,15 @@ def _attempt_tls(
     try:
         try:
             ctx = ssl.create_default_context()
-            ctx.check_hostname = True
-            ctx.verify_mode = ssl.CERT_REQUIRED
+            if insecure:
+                # check_hostname must be cleared before verify_mode, or
+                # ssl raises ValueError("Cannot set verify_mode to
+                # CERT_NONE when check_hostname is enabled").
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+            else:
+                ctx.check_hostname = True
+                ctx.verify_mode = ssl.CERT_REQUIRED
             # ``create_default_context`` sets minimum_version = TLS 1.2 on
             # Python 3.10+.  Reset to the library minimum first so the
             # caller-specified window is applied cleanly — otherwise
@@ -255,16 +322,20 @@ def attempt_tls_connection(product, vip_config):
             "tls1_0": _attempt_tls(
                 hostname,
                 port,
+                insecure=vip_config.insecure,
                 min_version=ssl.TLSVersion.TLSv1,
                 max_version=ssl.TLSVersion.TLSv1,
             ),
             "tls1_1": _attempt_tls(
                 hostname,
                 port,
+                insecure=vip_config.insecure,
                 min_version=ssl.TLSVersion.TLSv1_1,
                 max_version=ssl.TLSVersion.TLSv1_1,
             ),
-            "tls1_2": _attempt_tls(hostname, port, min_version=ssl.TLSVersion.TLSv1_2),
+            "tls1_2": _attempt_tls(
+                hostname, port, insecure=vip_config.insecure, min_version=ssl.TLSVersion.TLSv1_2
+            ),
         }
     except _ConnectError as exc:
         pytest.skip(f"Could not reach {hostname}:{port}: {exc}")
@@ -280,6 +351,10 @@ def attempt_tls_connection(product, vip_config):
             f"assess server TLS enforcement on this client."
         )
 
+    # Carried alongside the per-version results (not iterated by the "TLS
+    # 1.0/1.1" loop below, which only looks up the tls1_* keys) so
+    # ``modern_tls_succeeds`` can give insecure-mode-aware guidance. #457.
+    results["insecure"] = vip_config.insecure
     return results
 
 
@@ -314,6 +389,19 @@ def modern_tls_succeeds(tls_results):
         return
 
     if status == "cert_verify_failed":
+        if tls_results.get("insecure"):
+            # With tls.insecure=true, _attempt_tls disables verification
+            # entirely, so this branch should be unreachable in practice --
+            # but if it ever fires, the SSL_CERT_FILE guidance below would be
+            # actively wrong: the user didn't misconfigure trust, they opted
+            # out of it. #457.
+            raise AssertionError(
+                "TLS 1.2 handshake reached the server, but certificate "
+                "verification failed even though tls.insecure=true disables "
+                "it. This points to a TLS-stack problem, not a "
+                "certificate-trust gap to configure around. "
+                f"Detail: {detail}"
+            )
         raise AssertionError(
             "TLS 1.2 handshake reached the server, but the test runner "
             "could not verify the server's certificate. This is a "

--- a/src/vip_tests/cross_product/test_ssl.py
+++ b/src/vip_tests/cross_product/test_ssl.py
@@ -48,29 +48,67 @@ def check_ssl_cert(product, vip_config):
     hostname = parsed.hostname
     port = parsed.port or 443
 
+    try:
+        sock = socket.create_connection((hostname, port), timeout=10)
+    except OSError as exc:
+        # DNS failure, connection refused, or a timed-out connect -- the
+        # host is unreachable, which is not a certificate finding. Same
+        # connect-vs-handshake split as ``_attempt_tls``/``_ConnectError``
+        # below: only the TCP connect stage is skip-worthy. #555.
+        pytest.skip(f"Could not connect to {hostname}:{port}: {exc}")
+
     ctx = ssl.create_default_context()
     try:
-        with socket.create_connection((hostname, port), timeout=10) as sock:
+        with sock:
             with ctx.wrap_socket(sock, server_hostname=hostname) as ssock:
                 cert = ssock.getpeercert()
                 return {"cert": cert, "error": None, "hostname": hostname}
     except ssl.SSLCertVerificationError as exc:
         return {"cert": None, "error": str(exc), "hostname": hostname}
-    except Exception as exc:
-        pytest.skip(f"Could not connect to {hostname}:{port}: {exc}")
+    # Deliberately no broader ``except Exception`` here: a handshake failure
+    # for any other reason (a non-cert ssl.SSLError, a mid-handshake drop)
+    # must propagate and fail loudly, not get silently reported as "not
+    # applicable" -- that would gate this file's main new value, the
+    # expiry-margin assertion in ``cert_valid``, behind a broad catch-all.
+
+
+_MONTH_ABBREVIATIONS = {
+    "Jan": 1,
+    "Feb": 2,
+    "Mar": 3,
+    "Apr": 4,
+    "May": 5,
+    "Jun": 6,
+    "Jul": 7,
+    "Aug": 8,
+    "Sep": 9,
+    "Oct": 10,
+    "Nov": 11,
+    "Dec": 12,
+}
 
 
 def _cert_expires_at(cert: dict) -> datetime:
     """Parse the ``notAfter`` field from ``ssl.SSLSocket.getpeercert()``.
 
-    The format is fixed by OpenSSL (e.g. ``"Jun  1 12:00:00 2030 GMT"``) and
-    is always UTC, so the ``GMT`` token is matched literally rather than
-    interpreted as a real timezone abbreviation.
+    The format is fixed by OpenSSL (e.g. ``"Jun  1 12:00:00 2030 GMT"``,
+    always UTC) but is parsed with an explicit month-abbreviation lookup
+    rather than ``strptime``: ``%b`` reads from the process's ``LC_TIME``
+    month table, so on a non-English runner (e.g. ``LC_TIME=de_DE``)
+    ``strptime`` would raise on this exact, unchanging string. VIP is
+    customer-run software and does not control the runner's locale. #560.
     """
     not_after = cert.get("notAfter")
     if not not_after:
         raise ValueError("Certificate has no notAfter field")
-    return datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z").replace(tzinfo=timezone.utc)
+
+    # split() collapses the extra space OpenSSL uses to pad a single-digit
+    # day instead of zero-padding it (e.g. "Jun  1 ..."), so this handles
+    # both single- and double-digit days without special-casing either.
+    month_abbr, day, time_str, year, _tz = not_after.split()
+    month = _MONTH_ABBREVIATIONS[month_abbr]
+    hour, minute, second = (int(part) for part in time_str.split(":"))
+    return datetime(int(year), month, int(day), hour, minute, second, tzinfo=timezone.utc)
 
 
 @then("the certificate is valid and not expired")
@@ -123,17 +161,29 @@ def request_http(product, vip_config):
         http_url = f"http://{parsed.hostname}"
     try:
         resp_no_follow = httpx.get(http_url, follow_redirects=False, timeout=10)
-    except httpx.HTTPError as exc:
-        # httpx.HTTPError's subtree covers what "no usable plain-HTTP
-        # endpoint" actually means: connection refused (ConnectError), a
-        # timeout, or a protocol violation from sending plaintext HTTP at a
-        # TLS-only port (ProtocolError/RemoteProtocolError). Deliberately
-        # NOT a bare ``except Exception``: an unrelated bug (a malformed
-        # configured URL raising httpx.InvalidURL, or a future edit
-        # introducing a NameError/AttributeError here) must keep propagating
-        # as a real failure, not get reported as "port closed, that's fine"
-        # -- that would silently recreate the exact vacuous-check problem
-        # this file's steps were just fixed for. See #457, #555.
+    except (httpx.NetworkError, httpx.ProtocolError) as exc:
+        # NetworkError (ConnectError/ReadError/WriteError/CloseError) is a
+        # refused, reset, or closed TCP connection; ProtocolError (its
+        # subclass RemoteProtocolError in particular) is what a plaintext
+        # HTTP request gets back from a TLS-only port. Both mean "no usable
+        # plain-HTTP endpoint" for the checks below. In practice, hitting a
+        # TLS-only port with plaintext HTTP has been observed to raise
+        # EITHER RemoteProtocolError (server replies with a garbled TLS
+        # byte httpx tries to parse as HTTP) OR ReadError/"Connection reset
+        # by peer" (server just resets on non-TLS bytes) depending on the
+        # server and OS -- confirmed against a live self-signed server,
+        # not assumed -- so NetworkError, not just ConnectError, is needed.
+        #
+        # Deliberately NOT ``httpx.HTTPError`` (too wide) or a bare
+        # ``except Exception`` (wider still): a timeout means the host is
+        # filtered or hung, which is a materially different, reportable
+        # state -- not "closed" -- so it must fall through and fail loudly.
+        # An unrelated bug (httpx.InvalidURL from a malformed configured
+        # URL, or a future edit introducing a NameError/AttributeError
+        # here) must propagate as a real failure too, not get reported as
+        # "port closed, that's fine" -- that would silently recreate the
+        # exact vacuous-check problem this file's steps were just fixed
+        # for. See #457, #555.
         # src/vip_tests/security/test_https.py::make_http_request classifies
         # its sibling check the same narrow way -- keep the two in sync.
         return {
@@ -197,7 +247,15 @@ def http_port_no_content(http_response):
     if http_response["error"] == "port_closed":
         return
     status = http_response["status"]
-    assert status is None or not (200 <= status < 300), (
+    # Nothing legitimate reaches here with status=None: the only producer of
+    # None is the port_closed branch above, which already returned. Assert
+    # that explicitly rather than writing `status is None or ...`, which
+    # would silently treat a future None-producing bug as "fine, no content".
+    assert status is not None, (
+        f"Expected an HTTP status since the port answered, got None "
+        f"(error={http_response['error']!r})."
+    )
+    assert not (200 <= status < 300), (
         f"Plain HTTP served content directly (status {status}) instead of "
         "redirecting to HTTPS or refusing the connection."
     )

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -62,9 +62,20 @@ def make_http_request(product_url, vip_config):
             "location": resp.headers.get("location", ""),
             "refused": False,
         }
-    except httpx.ConnectError:
-        return {"status": None, "location": "", "refused": True}
-    except Exception:
+    except httpx.HTTPError:
+        # httpx.HTTPError's subtree covers what "no usable plain-HTTP
+        # endpoint" actually means: connection refused (ConnectError), a
+        # timeout, or a protocol violation from a plaintext request hitting
+        # a TLS-only port (ProtocolError/RemoteProtocolError). Deliberately
+        # NOT a bare ``except Exception`` (which this used to be, pre-#457):
+        # an unrelated bug -- a malformed configured URL raising
+        # httpx.InvalidURL, or a future edit introducing a NameError/
+        # AttributeError here -- must keep propagating as a real failure,
+        # not get reported as "port closed, that's fine". A silent "refused"
+        # on any exception is exactly the vacuous-check failure mode #555
+        # exists to remove.
+        # src/vip_tests/cross_product/test_ssl.py::request_http classifies
+        # its sibling check the same narrow way -- keep the two in sync.
         return {"status": None, "location": "", "refused": True}
 
 

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -62,18 +62,28 @@ def make_http_request(product_url, vip_config):
             "location": resp.headers.get("location", ""),
             "refused": False,
         }
-    except httpx.HTTPError:
-        # httpx.HTTPError's subtree covers what "no usable plain-HTTP
-        # endpoint" actually means: connection refused (ConnectError), a
-        # timeout, or a protocol violation from a plaintext request hitting
-        # a TLS-only port (ProtocolError/RemoteProtocolError). Deliberately
-        # NOT a bare ``except Exception`` (which this used to be, pre-#457):
-        # an unrelated bug -- a malformed configured URL raising
-        # httpx.InvalidURL, or a future edit introducing a NameError/
-        # AttributeError here -- must keep propagating as a real failure,
-        # not get reported as "port closed, that's fine". A silent "refused"
-        # on any exception is exactly the vacuous-check failure mode #555
-        # exists to remove.
+    except (httpx.NetworkError, httpx.ProtocolError):
+        # NetworkError (ConnectError/ReadError/WriteError/CloseError) is a
+        # refused, reset, or closed TCP connection; ProtocolError (its
+        # subclass RemoteProtocolError in particular) is what a plaintext
+        # HTTP request gets back from a TLS-only port. Both mean "no usable
+        # plain-HTTP endpoint" for the check below. In practice, hitting a
+        # TLS-only port with plaintext HTTP has been observed to raise
+        # EITHER RemoteProtocolError OR ReadError/"Connection reset by
+        # peer" depending on the server and OS -- confirmed against a live
+        # self-signed server, not assumed -- so NetworkError, not just
+        # ConnectError, is needed.
+        #
+        # Deliberately NOT ``httpx.HTTPError`` (too wide) or a bare
+        # ``except Exception`` (which this used to be, pre-#457, and is
+        # wider still): a timeout means the host is filtered or hung, a
+        # materially different, reportable state -- not "closed" -- so it
+        # must fall through and fail loudly. An unrelated bug -- a
+        # malformed configured URL raising httpx.InvalidURL, or a future
+        # edit introducing a NameError/AttributeError here -- must
+        # propagate as a real failure too, not get reported as "port
+        # closed, that's fine". A silent "refused" on any exception is
+        # exactly the vacuous-check failure mode #555 exists to remove.
         # src/vip_tests/cross_product/test_ssl.py::request_http classifies
         # its sibling check the same narrow way -- keep the two in sync.
         return {"status": None, "location": "", "refused": True}

--- a/vip.toml.example
+++ b/vip.toml.example
@@ -230,6 +230,12 @@ enabled = false
 # launching Chromium (Chromium-level trust only).
 # Overridable on the command line with: vip verify --ca-bundle /path/to/ca.pem
 # ca_bundle = "/etc/ssl/corp-ca.pem"
+#
+# Fail the certificate-validity scenario if a certificate expires within this
+# many days, even though the handshake itself still succeeds.  Catches
+# renewals that were missed before they cause an outage.  Not checked when
+# insecure = true (see above -- that scenario is skipped entirely).
+# cert_expiry_warning_days = 30
 
 [security]
 # Set enabled = true to run security-policy compliance tests.


### PR DESCRIPTION
Closes #555. Closes #457.

## Why these are together

Both are `cross_product/test_ssl.py`, and #457's change to `request_http`'s error classification overlaps #555's question of what the HTTP-port step should assert. Split across two PRs they would conflict, and one would rename a step the other was rewriting.

## #555 -- two steps that verified nothing

`the HTTP port is not open` was a bare `pass`. A reader of the feature file would reasonably conclude VIP checks the plain-HTTP port is closed; it did not. Renamed to `the HTTP port is closed or serves no content directly` in both the feature file and the step, now asserting the narrower true thing: a closed port passes, a redirect passes, a 2xx over plaintext fails.

`the certificate is valid and not expired` computed no expiry. An already-expired certificate did fail, because the handshake rejects it, so the scenario was not wrong -- but the name promised a date check that did not exist, and the useful version (warn before an outage) was absent. Now parses `notAfter` and asserts the margin against a new `[tls] cert_expiry_warning_days`, default 30.

**Behaviour change worth calling out:** a deployment whose certificate expires within 30 days now fails this scenario where it previously passed. That is the point of the check, and it is what the issue asked for, but it will surprise anyone upgrading mid-renewal-window. Set `cert_expiry_warning_days` lower, or to 0 to disable.

The expiry breach fails rather than warns because this codebase has no warn outcome for a `then` step -- everything is assert, skip or fail -- and a silently-passing warning would recreate the exact vacuity this PR removes.

## #457 -- two quirks under insecure/self-signed

`_attempt_tls` always built `ssl.create_default_context()` with verification on, so a self-signed certificate made the TLS-*version* scenario fail on certificate trust, advising the user to set `SSL_CERT_FILE` -- when they had explicitly set `tls.insecure = true` to opt out of trust. Verification is now disabled when insecure is set, so the version check stays meaningful, and the guidance is insecure-aware if a verify failure ever surfaces there anyway.

`request_http` classified only `httpx.ConnectError` as `port_closed`, so a plaintext request hitting a TLS-only port raised a protocol error, fell through to a generic error string, and failed the redirect assertion instead of treating "no plain-HTTP listener" as acceptable.

Both it and `security/test_https.py::make_http_request` now catch `httpx.HTTPError`. That subtree covers `ConnectError`, timeouts and `RemoteProtocolError`; `httpx.InvalidURL` is not in it (it derives from `Exception` directly), so a malformed URL still fails loudly, as do ordinary programming errors. This deliberately tightens `make_http_request`, whose bare `except Exception` predates this PR: `redirects_to_https` returns early and passes on `port_closed`, so mapping every exception there would make the scenario pass vacuously -- the failure mode this PR exists to remove.

## Verification

The live repro from #457, self-signed HTTPS on `127.0.0.1:8443` with `[tls] insecure = true`. Before: `test_http_redirects_to_https_for_product` and `test_tls_12_or_higher_is_enforced_for_product` both FAILED. After: both PASSED, with the certificate-validity scenario still correctly SKIPPED.

Each new assertion was watched failing, not just passing. A 1-day-validity certificate (trusted via `SSL_CERT_FILE` so the handshake itself succeeds) passed before the change and now fails with the margin message. A plain-HTTP server returning 200 content fails the HTTP-port step, isolated by calling the step directly since the sibling redirect step fails first in a full scenario run.

New selftests cover the expiry margin, the HTTP-port assertion, the protocol-error reclassification, and two regression guards proving `httpx.InvalidURL` and a plain `RuntimeError` propagate rather than being swallowed as `port_closed`. Widening the except back to `except Exception` makes both guards fail, which is what makes them worth having. `selftests/test_https_helper.py` is new -- `make_http_request` had no coverage at all.

Full suite, ruff and mypy clean; the only failures are the two known macOS-sandbox timing flakes in `test_load_engine.py`, reproduced on an unmodified tree.
