### PR TITLE
fix(auth): infer https for scheme-less URLs, never downgrade silently

### DIFF
--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from vip.auth import (
@@ -534,16 +535,26 @@ class TestStartInteractiveAuthSchemeResolutionWiring:
             connect_url_scheme_inferred=True,
         )
 
-        resolve.assert_called_once_with(
-            "https://connect.example.com", insecure=False, ca_bundle=None
-        )
+        resolve.assert_called_once()
+        called_pc = resolve.call_args.args[0]
+        assert called_pc.url == "https://connect.example.com"
+        assert called_pc.url_scheme_inferred is True
+        assert resolve.call_args.kwargs == {"insecure": False, "ca_bundle": None}
         assert session._connect_url == "http://connect.example.com"
         # The mint client must have been called with the resolved URL, not
         # the original https:// one.
         assert mint.call_args.args[1] == "http://connect.example.com"
 
-    def test_explicit_scheme_never_calls_resolve(self, monkeypatch):
-        """A user-supplied scheme is authoritative -- no probe, ever."""
+    def test_explicit_scheme_never_probes(self, monkeypatch):
+        """A user-supplied scheme is authoritative -- no probe, ever.
+
+        resolve_url_scheme is *not* mocked here: it is always called (that's
+        the point of taking the whole ProductConfig -- see its docstring),
+        but for an explicit scheme its own internal check must make that a
+        no-op. Mocking httpx.get directly (the actual network boundary)
+        proves that no-op is real, not an artifact of also mocking the
+        function meant to enforce it.
+        """
         from vip.auth import start_interactive_auth
 
         monkeypatch.setattr(
@@ -552,15 +563,14 @@ class TestStartInteractiveAuthSchemeResolutionWiring:
         )
         monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
         monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
-        resolve = MagicMock()
-        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
 
-        session = start_interactive_auth(
-            connect_url="https://connect.example.com",
-            connect_url_scheme_inferred=False,
-        )
+        with patch("httpx.get") as mock_get:
+            session = start_interactive_auth(
+                connect_url="https://connect.example.com",
+                connect_url_scheme_inferred=False,
+            )
 
-        resolve.assert_not_called()
+        mock_get.assert_not_called()
         assert session._connect_url == "https://connect.example.com"
 
     def test_default_is_not_inferred(self, monkeypatch):
@@ -575,12 +585,11 @@ class TestStartInteractiveAuthSchemeResolutionWiring:
         )
         monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
         monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
-        resolve = MagicMock()
-        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
 
-        start_interactive_auth(connect_url="https://connect.example.com")
+        with patch("httpx.get") as mock_get:
+            start_interactive_auth(connect_url="https://connect.example.com")
 
-        resolve.assert_not_called()
+        mock_get.assert_not_called()
 
 
 class TestStartHeadlessAuthSchemeResolutionWiring:
@@ -615,30 +624,121 @@ class TestStartHeadlessAuthSchemeResolutionWiring:
             connect_url_scheme_inferred=True,
         )
 
-        resolve.assert_called_once_with(
-            "https://connect.example.com", insecure=False, ca_bundle=None
-        )
+        resolve.assert_called_once()
+        called_pc = resolve.call_args.args[0]
+        assert called_pc.url == "https://connect.example.com"
+        assert called_pc.url_scheme_inferred is True
+        assert resolve.call_args.kwargs == {"insecure": False, "ca_bundle": None}
         assert session._connect_url == "http://connect.example.com"
         assert mint.call_args.args[1] == "http://connect.example.com"
 
-    def test_explicit_scheme_never_calls_resolve(self, monkeypatch):
+    def test_explicit_scheme_never_probes(self, monkeypatch):
+        """See the interactive-auth counterpart's docstring: resolve_url_scheme
+        is always called, but must no-op on its own for an explicit scheme --
+        proved here by mocking httpx.get (the real network boundary) rather
+        than resolve_url_scheme itself."""
         from vip.auth import start_headless_auth
 
         self._stub_headless_playwright(monkeypatch)
         monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
         monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
-        resolve = MagicMock()
-        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
 
-        session = start_headless_auth(
-            connect_url="https://connect.example.com",
-            username="user",
-            password="pass",
-            connect_url_scheme_inferred=False,
-        )
+        with patch("httpx.get") as mock_get:
+            session = start_headless_auth(
+                connect_url="https://connect.example.com",
+                username="user",
+                password="pass",
+                connect_url_scheme_inferred=False,
+            )
 
-        resolve.assert_not_called()
+        mock_get.assert_not_called()
         assert session._connect_url == "https://connect.example.com"
+
+
+class TestSchemeResolutionRealCodePath:
+    """Regression coverage proving the explicit-scheme invariant through the
+    actual production path -- ``vip.config.load_config`` all the way to
+    ``start_interactive_auth`` -- rather than a hand-typed
+    ``url_scheme_inferred`` in an isolated unit test.
+
+    A type-design review on #562 called out that a test which sets
+    ``url_scheme_inferred=False`` (or constructs a mock with it) by hand only
+    proves the function behaves given that input; it says nothing about
+    whether a real caller ever produces that input correctly. These tests
+    load a real ``vip.toml`` through ``load_config`` -- the same code every
+    ``vip verify`` invocation runs -- and mock only ``httpx.get`` (the actual
+    network boundary) plus Playwright (no real browser in a selftest), so a
+    regression in how provenance is computed or threaded through would fail
+    here even if every unit test above still passed.
+    """
+
+    @staticmethod
+    def _playwright_stub(logged_in_url: str) -> MagicMock:
+        class _PageStub:
+            url = logged_in_url
+
+            def goto(self, *_a, **_kw) -> None:
+                return None
+
+            def wait_for_timeout(self, *_a, **_kw) -> None:
+                return None
+
+        pw = MagicMock()
+        browser = pw.start.return_value.chromium.launch.return_value
+        browser.new_context.return_value.new_page.return_value = _PageStub()
+        return pw
+
+    def test_explicit_scheme_from_real_config_never_probes(self, tmp_toml, monkeypatch):
+        from vip.auth import start_interactive_auth
+        from vip.config import load_config
+
+        path = tmp_toml('[connect]\nurl = "https://connect.example.com"\n')
+        cfg = load_config(path)
+        assert cfg.connect.url_scheme_inferred is False  # real provenance, not hand-set
+
+        monkeypatch.setattr(
+            "vip.auth.sync_playwright",
+            lambda: self._playwright_stub("https://connect.example.com/"),
+        )
+        monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
+        monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
+
+        with patch("httpx.get") as mock_get:
+            session = start_interactive_auth(
+                connect_url=cfg.connect.url,
+                connect_url_scheme_inferred=cfg.connect.url_scheme_inferred,
+            )
+
+        mock_get.assert_not_called()
+        assert session._connect_url == "https://connect.example.com"
+
+    def test_inferred_scheme_from_real_config_falls_back_when_unreachable(
+        self, tmp_toml, monkeypatch
+    ):
+        """Same real load_config path, but scheme-less -- proves the other
+        half of the invariant end-to-end too: an inferred scheme really does
+        get probed and can fall back, driven by the real provenance value."""
+        from vip.auth import start_interactive_auth
+        from vip.config import load_config
+
+        path = tmp_toml('[connect]\nurl = "connect.example.com"\n')
+        cfg = load_config(path)
+        assert cfg.connect.url_scheme_inferred is True
+
+        monkeypatch.setattr(
+            "vip.auth.sync_playwright",
+            lambda: self._playwright_stub("http://connect.example.com/"),
+        )
+        monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
+        monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            session = start_interactive_auth(
+                connect_url=cfg.connect.url,
+                connect_url_scheme_inferred=cfg.connect.url_scheme_inferred,
+            )
+
+        assert session._connect_url == "http://connect.example.com"
 
 
 class TestAuthenticateWorkbench:
@@ -1058,9 +1158,26 @@ class TestResolveUrlScheme:
     """resolve_url_scheme falls an inferred https:// URL back to http:// only
     when https genuinely doesn't answer (issue #537).
 
+    Every test builds a real ``ConnectConfig``/``ProductConfig`` (never a
+    hand-set ``url_scheme_inferred``) so the "explicit scheme" cases run
+    through the actual provenance computation in ``vip.config._normalize_url``,
+    not a value a test author typed by hand. A type-design review on #562
+    flagged that ``resolve_url_scheme`` used to take a bare ``url: str`` and
+    trust the caller to have checked ``url_scheme_inferred`` first -- a
+    forgotten check was invisible. It now takes the ``ProductConfig`` itself
+    and consults provenance internally, so there is no bare-string entry
+    point left for a caller (or a test) to accidentally skip that check.
+
     Every test clears the module-level cache first so results from one test
     don't leak into the next -- the whole point of the cache is to survive
     across calls *within* a run, not across independent test cases.
+
+    ``_tls_listener_present`` is patched to ``False`` by default for every
+    test in this class (a real TCP connect to a fake ``connect.example.com``
+    would otherwise depend on DNS/network behavior in whatever environment
+    runs the suite -- see ``test_auth_tls_e2e.py`` for the real-socket
+    version of this proof against an actual listener). Tests for the
+    "TLS present but untrusted" branch override it locally to ``True``.
     """
 
     @pytest.fixture(autouse=True)
@@ -1071,23 +1188,57 @@ class TestResolveUrlScheme:
         yield
         vip.auth._scheme_resolution_cache.clear()
 
-    def test_non_https_url_returned_unchanged_without_probing(self):
-        """An explicit (or already-resolved) http:// URL is never probed --
-        this function trusts its caller to have checked url_scheme_inferred."""
+    @pytest.fixture(autouse=True)
+    def _no_real_tls_listener(self):
+        with patch("vip.auth._tls_listener_present", return_value=False):
+            yield
+
+    @staticmethod
+    def _pc(url: str):
+        from vip.config import ConnectConfig
+
+        return ConnectConfig(url=url)
+
+    def test_explicit_http_never_probed(self):
+        """An explicit http:// is authoritative -- never probed, never
+        upgraded."""
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("http://connect.example.com")
+        assert pc.url_scheme_inferred is False
+
         with patch("httpx.get") as mock_get:
-            result = resolve_url_scheme("http://connect.example.com")
+            result = resolve_url_scheme(pc)
 
         assert result == "http://connect.example.com"
+        mock_get.assert_not_called()
+
+    def test_explicit_https_never_probed(self):
+        """An explicit https:// is authoritative -- never probed, even if it
+        would otherwise be unreachable. This is the case the type-design
+        review specifically flagged: swap the mock below for a ConnectError
+        and the assertion must still hold, because provenance (not the
+        prefix or a mock's success) is what gates the probe."""
+        from vip.auth import resolve_url_scheme
+
+        pc = self._pc("https://connect.example.com")
+        assert pc.url_scheme_inferred is False
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
+            result = resolve_url_scheme(pc)
+
+        assert result == "https://connect.example.com"
         mock_get.assert_not_called()
 
     def test_https_that_answers_is_kept(self):
         """https:// responds (any status) -- kept as-is, nothing downgraded."""
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("connect.example.com")
+        assert pc.url_scheme_inferred is True
+
         with patch("httpx.get", return_value=MagicMock(status_code=200)):
-            result = resolve_url_scheme("https://connect.example.com")
+            result = resolve_url_scheme(pc)
 
         assert result == "https://connect.example.com"
 
@@ -1095,42 +1246,44 @@ class TestResolveUrlScheme:
         """A 500 means the server answered -- do not fall back to http://."""
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("connect.example.com")
+
         with patch("httpx.get", return_value=MagicMock(status_code=500)):
-            result = resolve_url_scheme("https://connect.example.com")
+            result = resolve_url_scheme(pc)
 
         assert result == "https://connect.example.com"
 
     def test_connection_failure_falls_back_to_http(self):
         """A connection-level failure (refused, DNS, TLS, timeout) -- the
         server genuinely doesn't answer -- triggers the http:// fallback."""
-        import httpx
-
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("connect.example.com")
+
         with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
-            result = resolve_url_scheme("https://connect.example.com")
+            result = resolve_url_scheme(pc)
 
         assert result == "http://connect.example.com"
 
     def test_timeout_falls_back_to_http(self):
         """ConnectTimeout is also a TransportError -- same fallback."""
-        import httpx
-
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("connect.example.com")
+
         with patch("httpx.get", side_effect=httpx.ConnectTimeout("timed out")):
-            result = resolve_url_scheme("https://connect.example.com")
+            result = resolve_url_scheme(pc)
 
         assert result == "http://connect.example.com"
 
     def test_fallback_is_logged_loudly(self, capsys):
         """A user who meant https must see that they got plaintext instead."""
-        import httpx
-
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("connect.example.com")
+
         with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
-            resolve_url_scheme("https://connect.example.com")
+            resolve_url_scheme(pc)
 
         out = capsys.readouterr().out
         assert "connect.example.com" in out
@@ -1140,22 +1293,54 @@ class TestResolveUrlScheme:
         """Keeping https (the common case) must not print a warning."""
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("connect.example.com")
+
         with patch("httpx.get", return_value=MagicMock(status_code=200)):
-            resolve_url_scheme("https://connect.example.com")
+            resolve_url_scheme(pc)
 
         assert capsys.readouterr().out == ""
 
-    def test_result_is_cached_across_calls(self):
-        """A second call for the same URL must not probe the network again --
-        the auth flow and a client fixture can both ask for the same URL in
-        one run."""
-        import httpx
-
+    def test_mutates_pc_in_place_and_resets_inferred_flag(self):
+        """After resolving, pc.url holds the final value and
+        pc.url_scheme_inferred is reset to False -- resolution is a one-time
+        transition, not a repeatable state a second call re-enters."""
         from vip.auth import resolve_url_scheme
 
+        pc = self._pc("connect.example.com")
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            resolve_url_scheme(pc)
+
+        assert pc.url == "http://connect.example.com"
+        assert pc.url_scheme_inferred is False
+
+    def test_second_call_on_same_pc_is_a_pure_read_no_probe(self):
+        """Once url_scheme_inferred is reset, a second call on the *same*
+        ProductConfig must not touch the network at all -- not even a cache
+        lookup is needed, since the flag itself now says "nothing to do"."""
+        from vip.auth import resolve_url_scheme
+
+        pc = self._pc("connect.example.com")
+
         with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
-            first = resolve_url_scheme("https://connect.example.com")
-            second = resolve_url_scheme("https://connect.example.com")
+            first = resolve_url_scheme(pc)
+            second = resolve_url_scheme(pc)
+
+        assert first == second == "http://connect.example.com"
+        mock_get.assert_called_once()
+
+    def test_result_is_cached_across_different_pc_instances(self):
+        """A *different* ProductConfig for the same URL (e.g. a fresh
+        instance built from the same --connect-url at another call site)
+        still only probes once, via the module-level cache."""
+        from vip.auth import resolve_url_scheme
+
+        pc1 = self._pc("connect.example.com")
+        pc2 = self._pc("connect.example.com")
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
+            first = resolve_url_scheme(pc1)
+            second = resolve_url_scheme(pc2)
 
         assert first == second == "http://connect.example.com"
         mock_get.assert_called_once()
@@ -1166,11 +1351,87 @@ class TestResolveUrlScheme:
         from vip.auth import resolve_url_scheme
 
         ca = tmp_path / "ca.pem"
+        pc = self._pc("connect.example.com")
         with patch("httpx.get", return_value=MagicMock(status_code=200)) as mock_get:
-            resolve_url_scheme("https://connect.example.com", ca_bundle=ca)
+            resolve_url_scheme(pc, ca_bundle=ca)
 
         assert mock_get.call_args.kwargs["follow_redirects"] is True
         assert mock_get.call_args.kwargs["verify"] == str(ca)
+
+    def test_tls_present_but_untrusted_does_not_downgrade(self):
+        """When a real listener is present (a TLS-level failure, not a
+        transport-level one) but the connection still failed with a
+        TransportError -- e.g. a self-signed cert -- resolve_url_scheme
+        must NOT downgrade to http://. Downgrading here would send
+        credentials to a real TLS-terminating server in the clear. See
+        test_auth_tls_e2e.py for the same proof against a real self-signed
+        listener rather than this mock."""
+        from vip.auth import resolve_url_scheme
+
+        pc = self._pc("connect.example.com")
+
+        with patch("vip.auth._tls_listener_present", return_value=True):
+            with patch(
+                "httpx.get",
+                side_effect=httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED]"),
+            ):
+                result = resolve_url_scheme(pc)
+
+        assert result == "https://connect.example.com"
+        assert pc.url == "https://connect.example.com"
+        assert pc.url_scheme_inferred is False  # settled as https, not left ambiguous
+
+    def test_tls_present_but_untrusted_names_the_remedy(self, capsys):
+        """The warning for this case must be distinguishable from the
+        "nothing answered" warning and must name the actual fix -- silently
+        printing the same generic message as the network-unreachable case
+        would leave a user with an untrusted cert no better off."""
+        from vip.auth import resolve_url_scheme
+
+        pc = self._pc("connect.example.com")
+
+        with patch("vip.auth._tls_listener_present", return_value=True):
+            with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+                resolve_url_scheme(pc)
+
+        out = capsys.readouterr().out
+        assert "NOT falling back to plaintext" in out
+        assert "insecure" in out
+        assert "ca_bundle" in out
+        # Must not also claim the server "did not answer" -- it did, just not
+        # with a certificate this client trusts.
+        assert "did not answer" not in out
+
+    def test_result_is_cached_per_url_and_tls_settings(self):
+        """Two calls with the same URL but different insecure/ca_bundle must
+        each probe -- a cached verify=True failure must not authorise a
+        downgrade decision for a caller that actually passed a different
+        TLS configuration and might get a different, correct answer."""
+        from vip.auth import resolve_url_scheme
+
+        pc1 = self._pc("connect.example.com")
+        pc2 = self._pc("connect.example.com")
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
+            resolve_url_scheme(pc1, insecure=False)
+            resolve_url_scheme(pc2, insecure=True)
+
+        assert mock_get.call_count == 2
+
+    def test_same_url_and_tls_settings_still_share_the_cache(self):
+        """The cache-keying fix must not regress the existing dedup: two
+        different ProductConfig instances with the same URL *and* the same
+        insecure/ca_bundle still cost only one probe."""
+        from vip.auth import resolve_url_scheme
+
+        pc1 = self._pc("connect.example.com")
+        pc2 = self._pc("connect.example.com")
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
+            resolve_url_scheme(pc1, insecure=False)
+            resolve_url_scheme(pc2, insecure=False)
+
+        mock_get.assert_called_once()
 
 
 class TestResolveConnectApiBase:

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -490,6 +490,157 @@ class TestStartInteractiveAuthPollLoop:
             auth_mod.start_interactive_auth(workbench_url="https://wb.example.com")
 
 
+class TestStartInteractiveAuthSchemeResolutionWiring:
+    """*_scheme_inferred flags gate calls to resolve_url_scheme (issue #537):
+    an explicit scheme must never be second-guessed, and an inferred one
+    must be resolved before Playwright or the mint client touch the URL."""
+
+    @staticmethod
+    def _playwright_stub(logged_in_url: str) -> MagicMock:
+        """Stub sync_playwright() whose page is immediately "logged in" at
+        *logged_in_url* (must match the resolved primary_url + no /__login__)."""
+
+        class _PageStub:
+            url = logged_in_url
+
+            def goto(self, *_a, **_kw) -> None:
+                return None
+
+            def wait_for_timeout(self, *_a, **_kw) -> None:
+                return None
+
+        pw = MagicMock()
+        browser = pw.start.return_value.chromium.launch.return_value
+        browser.new_context.return_value.new_page.return_value = _PageStub()
+        return pw
+
+    def test_inferred_scheme_is_resolved_before_use(self, monkeypatch):
+        """A downgrade must reach both the browser (page.goto) and the mint
+        client -- not just one of the two."""
+        from vip.auth import start_interactive_auth
+
+        monkeypatch.setattr(
+            "vip.auth.sync_playwright",
+            lambda: self._playwright_stub("http://connect.example.com/"),
+        )
+        monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
+        mint = MagicMock(return_value="FAKE_KEY")
+        monkeypatch.setattr("vip.auth._create_api_key_via_session", mint)
+        resolve = MagicMock(return_value="http://connect.example.com")
+        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
+
+        session = start_interactive_auth(
+            connect_url="https://connect.example.com",
+            connect_url_scheme_inferred=True,
+        )
+
+        resolve.assert_called_once_with(
+            "https://connect.example.com", insecure=False, ca_bundle=None
+        )
+        assert session._connect_url == "http://connect.example.com"
+        # The mint client must have been called with the resolved URL, not
+        # the original https:// one.
+        assert mint.call_args.args[1] == "http://connect.example.com"
+
+    def test_explicit_scheme_never_calls_resolve(self, monkeypatch):
+        """A user-supplied scheme is authoritative -- no probe, ever."""
+        from vip.auth import start_interactive_auth
+
+        monkeypatch.setattr(
+            "vip.auth.sync_playwright",
+            lambda: self._playwright_stub("https://connect.example.com/"),
+        )
+        monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
+        monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
+        resolve = MagicMock()
+        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
+
+        session = start_interactive_auth(
+            connect_url="https://connect.example.com",
+            connect_url_scheme_inferred=False,
+        )
+
+        resolve.assert_not_called()
+        assert session._connect_url == "https://connect.example.com"
+
+    def test_default_is_not_inferred(self, monkeypatch):
+        """The *_scheme_inferred parameters default to False so a caller that
+        doesn't pass them (e.g. an older test or script) keeps today's
+        behaviour: no probing."""
+        from vip.auth import start_interactive_auth
+
+        monkeypatch.setattr(
+            "vip.auth.sync_playwright",
+            lambda: self._playwright_stub("https://connect.example.com/"),
+        )
+        monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
+        monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
+        resolve = MagicMock()
+        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
+
+        start_interactive_auth(connect_url="https://connect.example.com")
+
+        resolve.assert_not_called()
+
+
+class TestStartHeadlessAuthSchemeResolutionWiring:
+    """Headless counterpart to TestStartInteractiveAuthSchemeResolutionWiring."""
+
+    def _stub_headless_playwright(self, monkeypatch) -> None:
+        pw = MagicMock()
+        browser = pw.start.return_value.chromium.launch.return_value
+        page = browser.new_context.return_value.new_page.return_value
+        # ``_sanitize_url(page.url)`` is called unconditionally (its result
+        # is only *printed* conditionally) and expects a real string.
+        page.url = "https://connect.example.com/"
+        monkeypatch.setattr("vip.auth.sync_playwright", lambda: pw)
+        monkeypatch.setattr("vip.auth._fill_product_login", lambda *a, **kw: None)
+        monkeypatch.setattr("vip.auth._wait_for_product_redirect", lambda *a, **kw: None)
+        return page
+
+    def test_inferred_scheme_is_resolved_before_use(self, monkeypatch):
+        from vip.auth import start_headless_auth
+
+        self._stub_headless_playwright(monkeypatch)
+        monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
+        mint = MagicMock(return_value="FAKE_KEY")
+        monkeypatch.setattr("vip.auth._create_api_key_via_session", mint)
+        resolve = MagicMock(return_value="http://connect.example.com")
+        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
+
+        session = start_headless_auth(
+            connect_url="https://connect.example.com",
+            username="user",
+            password="pass",
+            connect_url_scheme_inferred=True,
+        )
+
+        resolve.assert_called_once_with(
+            "https://connect.example.com", insecure=False, ca_bundle=None
+        )
+        assert session._connect_url == "http://connect.example.com"
+        assert mint.call_args.args[1] == "http://connect.example.com"
+
+    def test_explicit_scheme_never_calls_resolve(self, monkeypatch):
+        from vip.auth import start_headless_auth
+
+        self._stub_headless_playwright(monkeypatch)
+        monkeypatch.setattr("vip.auth._resolve_connect_api_base", lambda *a, **kw: a[0])
+        monkeypatch.setattr("vip.auth._create_api_key_via_session", lambda *a, **kw: "FAKE_KEY")
+        resolve = MagicMock()
+        monkeypatch.setattr("vip.auth.resolve_url_scheme", resolve)
+
+        session = start_headless_auth(
+            connect_url="https://connect.example.com",
+            username="user",
+            password="pass",
+            connect_url_scheme_inferred=False,
+        )
+
+        resolve.assert_not_called()
+        assert session._connect_url == "https://connect.example.com"
+
+
 class TestAuthenticateWorkbench:
     """_authenticate_workbench establishes the Workbench SSO session after
     Connect auth has already succeeded.  Network failures here must NOT
@@ -903,6 +1054,125 @@ class TestHttpxVerify:
         assert _httpx_verify(True, ca) is False
 
 
+class TestResolveUrlScheme:
+    """resolve_url_scheme falls an inferred https:// URL back to http:// only
+    when https genuinely doesn't answer (issue #537).
+
+    Every test clears the module-level cache first so results from one test
+    don't leak into the next -- the whole point of the cache is to survive
+    across calls *within* a run, not across independent test cases.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        import vip.auth
+
+        vip.auth._scheme_resolution_cache.clear()
+        yield
+        vip.auth._scheme_resolution_cache.clear()
+
+    def test_non_https_url_returned_unchanged_without_probing(self):
+        """An explicit (or already-resolved) http:// URL is never probed --
+        this function trusts its caller to have checked url_scheme_inferred."""
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get") as mock_get:
+            result = resolve_url_scheme("http://connect.example.com")
+
+        assert result == "http://connect.example.com"
+        mock_get.assert_not_called()
+
+    def test_https_that_answers_is_kept(self):
+        """https:// responds (any status) -- kept as-is, nothing downgraded."""
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get", return_value=MagicMock(status_code=200)):
+            result = resolve_url_scheme("https://connect.example.com")
+
+        assert result == "https://connect.example.com"
+
+    def test_https_5xx_is_not_a_fallback_trigger(self):
+        """A 500 means the server answered -- do not fall back to http://."""
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get", return_value=MagicMock(status_code=500)):
+            result = resolve_url_scheme("https://connect.example.com")
+
+        assert result == "https://connect.example.com"
+
+    def test_connection_failure_falls_back_to_http(self):
+        """A connection-level failure (refused, DNS, TLS, timeout) -- the
+        server genuinely doesn't answer -- triggers the http:// fallback."""
+        import httpx
+
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            result = resolve_url_scheme("https://connect.example.com")
+
+        assert result == "http://connect.example.com"
+
+    def test_timeout_falls_back_to_http(self):
+        """ConnectTimeout is also a TransportError -- same fallback."""
+        import httpx
+
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get", side_effect=httpx.ConnectTimeout("timed out")):
+            result = resolve_url_scheme("https://connect.example.com")
+
+        assert result == "http://connect.example.com"
+
+    def test_fallback_is_logged_loudly(self, capsys):
+        """A user who meant https must see that they got plaintext instead."""
+        import httpx
+
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            resolve_url_scheme("https://connect.example.com")
+
+        out = capsys.readouterr().out
+        assert "connect.example.com" in out
+        assert "http://connect.example.com" in out
+
+    def test_success_is_not_logged(self, capsys):
+        """Keeping https (the common case) must not print a warning."""
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get", return_value=MagicMock(status_code=200)):
+            resolve_url_scheme("https://connect.example.com")
+
+        assert capsys.readouterr().out == ""
+
+    def test_result_is_cached_across_calls(self):
+        """A second call for the same URL must not probe the network again --
+        the auth flow and a client fixture can both ask for the same URL in
+        one run."""
+        import httpx
+
+        from vip.auth import resolve_url_scheme
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
+            first = resolve_url_scheme("https://connect.example.com")
+            second = resolve_url_scheme("https://connect.example.com")
+
+        assert first == second == "http://connect.example.com"
+        mock_get.assert_called_once()
+
+    def test_probe_uses_follow_redirects_and_verify(self, tmp_path):
+        """The probe itself must honour insecure/ca_bundle and follow
+        redirects, matching every other httpx call site in this module."""
+        from vip.auth import resolve_url_scheme
+
+        ca = tmp_path / "ca.pem"
+        with patch("httpx.get", return_value=MagicMock(status_code=200)) as mock_get:
+            resolve_url_scheme("https://connect.example.com", ca_bundle=ca)
+
+        assert mock_get.call_args.kwargs["follow_redirects"] is True
+        assert mock_get.call_args.kwargs["verify"] == str(ca)
+
+
 class TestResolveConnectApiBase:
     """_resolve_connect_api_base handles split layouts where the Connect
     dashboard sits on a sub-path (``/connect/``) but the API stays at the
@@ -1178,6 +1448,29 @@ class TestCreateApiKeyViaSession:
 
         assert result == "K" * 30
         assert client_cls.call_args.kwargs["verify"] is False
+
+    def test_follows_redirects(self):
+        """follow_redirects=True must be set so an http->https (or trailing-
+        slash) redirect isn't treated as a mint failure (issue #537).
+        Matches _resolve_connect_api_base's probes, which already do this."""
+        from vip.auth import _create_api_key_via_session
+
+        page = self._page()
+        me = self._httpx_response(json_data={"guid": "g"})
+        keys_list = self._httpx_response(json_data=[])
+        created = self._httpx_response(json_data={"id": "1", "key": "K" * 30})
+
+        def get_side_effect(path, **_kw):
+            return me if path.endswith("/v1/user") else keys_list
+
+        patcher, client_cls, _client = self._patch_httpx_client(
+            get_side_effect=get_side_effect,
+            post_rv=created,
+        )
+        with patcher:
+            _create_api_key_via_session(page, "https://c.example.com", "k")
+
+        assert client_cls.call_args.kwargs["follow_redirects"] is True
 
     def test_ca_bundle_sets_verify_path(self, tmp_path):
         """When ca_bundle is set, httpx.Client must receive verify=str(ca_bundle)."""

--- a/selftests/test_auth_tls_e2e.py
+++ b/selftests/test_auth_tls_e2e.py
@@ -235,3 +235,58 @@ def test_mint_follows_http_to_https_redirect(connect_http_redirect_server: str):
         insecure=True,  # the https side of the redirect uses a self-signed cert
     )
     assert api_key == _API_KEY
+
+
+# ---------------------------------------------------------------------------
+# resolve_url_scheme: real listener, real closed port (issue #562 security fix)
+# ---------------------------------------------------------------------------
+#
+# _tls_listener_present decides whether a transport failure means "nothing is
+# listening" (safe to downgrade to http://) or "a real TLS listener is here
+# but this client doesn't trust its certificate" (must NOT downgrade -- that
+# would send the caller's credentials to a real server in the clear). The
+# unit tests in test_auth.py mock that decision directly; these two prove it
+# against a real socket in each state, since the whole point of deciding via
+# a raw TCP connect (rather than exception introspection) is that it must
+# work regardless of what real, uncontrived cause makes the TLS handshake
+# fail.
+
+
+def test_resolve_url_scheme_does_not_downgrade_against_untrusted_real_cert(
+    connect_tls_server: str,
+):
+    """A real self-signed listener: httpx.get(verify=True) fails with a
+    genuine CERTIFICATE_VERIFY_FAILED, but a raw TCP connect to the same
+    host:port succeeds -- resolve_url_scheme must keep https://, not
+    downgrade to plaintext http://."""
+    import vip.auth
+    from vip.config import ConnectConfig
+
+    vip.auth._scheme_resolution_cache.clear()
+    host = connect_tls_server.removeprefix("https://")
+    pc = ConnectConfig(url=host)  # scheme-less -> inferred https://<host>
+    assert pc.url == connect_tls_server
+    assert pc.url_scheme_inferred is True
+
+    result = vip.auth.resolve_url_scheme(pc)
+
+    assert result == connect_tls_server
+    assert pc.url == connect_tls_server
+    assert pc.url_scheme_inferred is False  # settled as https, not re-probed again
+
+
+def test_resolve_url_scheme_downgrades_when_nothing_listens():
+    """A real closed port: neither httpx.get nor a raw TCP connect succeeds --
+    resolve_url_scheme must still downgrade to http://, exactly as before
+    this fix. Uses 127.0.0.1:1 (a low port nothing binds to in this sandbox)
+    rather than a mock, so the TCP-level check is exercised for real too."""
+    import vip.auth
+    from vip.config import ConnectConfig
+
+    vip.auth._scheme_resolution_cache.clear()
+    pc = ConnectConfig(url="127.0.0.1:1")
+
+    result = vip.auth.resolve_url_scheme(pc)
+
+    assert result == "http://127.0.0.1:1"
+    assert pc.url == "http://127.0.0.1:1"

--- a/selftests/test_auth_tls_e2e.py
+++ b/selftests/test_auth_tls_e2e.py
@@ -112,6 +112,57 @@ def connect_tls_server(tmp_path_factory):
     server.server_close()
 
 
+def _start_http_redirect_server(https_base: str) -> tuple[ThreadingHTTPServer, str]:
+    """Start a plaintext HTTP server that 307-redirects every request to
+    the same path under *https_base*.
+
+    Mirrors a deployment that terminates TLS at a reverse proxy and redirects
+    plain HTTP to HTTPS -- the scenario from issue #537. Every request (GET
+    and POST) is redirected, not just the first: ``httpx.Client.
+    follow_redirects`` applies per request, and the mint flow issues three
+    calls (GET /v1/user, GET .../keys, POST .../keys) against the same
+    ``base_url``, each of which needs its own redirect to succeed.
+
+    307 (not 301/302) is deliberate: it's the status code that preserves the
+    method and body across the redirect, which is what a proxy has to use to
+    avoid silently turning the mint flow's ``POST .../keys`` into a bodyless
+    ``GET`` -- httpx (like every browser) downgrades POST to GET on 301/302
+    for legacy compatibility. A proxy correctly configured for an API
+    (as opposed to a browser-only redirect) uses 307/308 for exactly this
+    reason.
+    """
+
+    class _RedirectHandler(BaseHTTPRequestHandler):
+        def log_message(self, *args, **kwargs):  # noqa
+            pass
+
+        def _redirect(self) -> None:
+            self.send_response(307)
+            self.send_header("Location", f"{https_base}{self.path}")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._redirect()
+
+        def do_POST(self) -> None:  # noqa: N802
+            self._redirect()
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _RedirectHandler)
+    httpd.daemon_threads = True
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture(scope="module")
+def connect_http_redirect_server(connect_tls_server: str):
+    httpd, url = _start_http_redirect_server(connect_tls_server)
+    yield url
+    httpd.shutdown()
+    httpd.server_close()
+
+
 def _stub_page() -> MagicMock:
     """Return a Playwright Page stub with a usable session cookie jar."""
     page = MagicMock()
@@ -161,3 +212,26 @@ def test_mint_returns_none_against_self_signed_when_strict(connect_tls_server):
         insecure=False,
     )
     assert api_key is None
+
+
+def test_mint_follows_http_to_https_redirect(connect_http_redirect_server: str):
+    """Reproduces issue #537 end-to-end: a Connect URL that resolves to a
+    plaintext-HTTP endpoint which 307-redirects every request to HTTPS must
+    still mint an API key.
+
+    Before the fix, ``_create_api_key_via_session``'s ``httpx.Client`` left
+    ``follow_redirects`` at its default (``False``), so the first
+    ``GET /__api__/v1/user`` hit the redirect and was reported as a mint
+    failure (returns ``None``) even though the server was healthy and
+    reachable at the HTTPS location the redirect pointed to.
+    """
+    from vip.auth import _create_api_key_via_session
+
+    page = _stub_page()
+    api_key = _create_api_key_via_session(
+        page,
+        connect_http_redirect_server,
+        "test_vip_key",
+        insecure=True,  # the https side of the redirect uses a self-signed cert
+    )
+    assert api_key == _API_KEY

--- a/selftests/test_cli_status.py
+++ b/selftests/test_cli_status.py
@@ -34,18 +34,26 @@ def _make_config(
     connect.is_configured = connect_configured
     connect.url = connect_url
     connect.api_key = "test-key"
+    # Every URL passed to _make_config is a hardcoded explicit https:// in
+    # this file, not scheme-less input -- pin the flag rather than leave it
+    # as MagicMock's default (truthy) auto-attribute, which would make
+    # _collect_status's _resolved_url() think the scheme was inferred and
+    # attempt a real network probe against these fake example.com hosts.
+    connect.url_scheme_inferred = False
     config.connect = connect
 
     workbench = MagicMock()
     workbench.is_configured = workbench_configured
     workbench.url = workbench_url
     workbench.api_key = "test-key"
+    workbench.url_scheme_inferred = False
     config.workbench = workbench
 
     pm = MagicMock()
     pm.is_configured = pm_configured
     pm.url = pm_url
     pm.token = "test-token"
+    pm.url_scheme_inferred = False
     config.package_manager = pm
 
     return config

--- a/selftests/test_cli_status.py
+++ b/selftests/test_cli_status.py
@@ -37,8 +37,9 @@ def _make_config(
     # Every URL passed to _make_config is a hardcoded explicit https:// in
     # this file, not scheme-less input -- pin the flag rather than leave it
     # as MagicMock's default (truthy) auto-attribute, which would make
-    # _collect_status's _resolved_url() think the scheme was inferred and
-    # attempt a real network probe against these fake example.com hosts.
+    # _collect_status's resolve_url_scheme() call think the scheme was
+    # inferred and attempt a real network probe against these fake
+    # example.com hosts.
     connect.url_scheme_inferred = False
     config.connect = connect
 

--- a/selftests/test_cli_url_scheme.py
+++ b/selftests/test_cli_url_scheme.py
@@ -1,0 +1,324 @@
+"""Tests for the scheme-inference fallback wiring in vip.cli (issue #537).
+
+``_resolved_url`` and its call sites in ``_collect_status`` (``vip status``),
+``run_cleanup`` (``vip cleanup``), and ``run_uninstall``'s chained-cleanup
+callable all need the same probe-and-fallback treatment as ``vip verify``:
+a scheme-less URL defaults to https:// (``vip.config._normalize_url``) and
+falls back to http:// only when https genuinely doesn't answer
+(``vip.auth.resolve_url_scheme``), never for a URL the caller gave an
+explicit scheme for.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from vip.config import ConnectConfig
+
+
+class TestResolvedUrlCli:
+    """``vip.cli._resolved_url`` mirrors conftest.py's fixture-level helper."""
+
+    def setup_method(self):
+        import vip.auth
+
+        vip.auth._scheme_resolution_cache.clear()
+
+    def test_explicit_scheme_never_probes(self):
+        from vip.cli import _resolved_url
+
+        pc = ConnectConfig(url="https://connect.example.com")
+
+        with patch("httpx.get") as mock_get:
+            url = _resolved_url(pc)
+
+        assert url == "https://connect.example.com"
+        mock_get.assert_not_called()
+
+    def test_inferred_scheme_kept_when_https_answers(self):
+        from vip.cli import _resolved_url
+
+        pc = ConnectConfig(url="connect.example.com")
+        assert pc.url_scheme_inferred is True
+
+        with patch("httpx.get", return_value=MagicMock(status_code=200)):
+            url = _resolved_url(pc)
+
+        assert url == "https://connect.example.com"
+        assert pc.url == "https://connect.example.com"
+
+    def test_inferred_scheme_falls_back_and_mutates_in_place(self):
+        pc = ConnectConfig(url="connect.example.com")
+
+        from vip.cli import _resolved_url
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            url = _resolved_url(pc)
+
+        assert url == "http://connect.example.com"
+        assert pc.url == "http://connect.example.com"
+
+    def test_insecure_and_ca_bundle_forwarded(self, tmp_path):
+        from vip.cli import _resolved_url
+
+        ca = tmp_path / "ca.pem"
+        pc = ConnectConfig(url="connect.example.com")
+
+        with patch("httpx.get", return_value=MagicMock(status_code=200)) as mock_get:
+            _resolved_url(pc, insecure=True, ca_bundle=ca)
+
+        assert mock_get.call_args.kwargs["verify"] is False
+
+
+class TestCollectStatusSchemeResolution:
+    """``vip status`` must not get stuck on a wrong inferred scheme, and must
+    not probe a URL the user gave a scheme for."""
+
+    def setup_method(self):
+        import vip.auth
+
+        vip.auth._scheme_resolution_cache.clear()
+
+    def _config(self, url: str):
+        from vip.config import VIPConfig
+
+        cfg = VIPConfig()
+        cfg.connect = ConnectConfig(url=url, enabled=True)
+        return cfg
+
+    def test_explicit_scheme_no_probe(self):
+        from vip.cli import _collect_status
+
+        config = self._config("https://connect.example.com")
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("httpx.get") as mock_get:
+            with patch("vip.clients.connect.ConnectClient", return_value=mock_client) as ctor:
+                result = _collect_status(config)
+
+        mock_get.assert_not_called()
+        assert ctor.call_args.args[0] == "https://connect.example.com"
+        assert result["products"]["connect"]["state"] == "ok"
+
+    def test_inferred_scheme_falls_back_before_client_construction(self):
+        """A bare hostname that only serves plain HTTP must still report a
+        real status, not 'fail' from ConnectClient choking on an https://
+        URL that doesn't answer."""
+        from vip.cli import _collect_status
+
+        config = self._config("connect.example.com")
+        mock_client = MagicMock()
+        mock_client.health.return_value = 200
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            with patch("vip.clients.connect.ConnectClient", return_value=mock_client) as ctor:
+                result = _collect_status(config)
+
+        assert ctor.call_args.args[0] == "http://connect.example.com"
+        assert result["products"]["connect"]["url"] == "http://connect.example.com"
+        assert result["products"]["connect"]["state"] == "ok"
+
+
+class TestRunCleanupSchemeResolution:
+    """``vip cleanup --connect-url``/``--workbench-url`` route a bare hostname
+    through the same normalization + fallback as every other entry point --
+    previously a scheme-less CLI flag was handed to ConnectClient completely
+    unnormalized (httpx requires an absolute URL) and never got a fallback."""
+
+    def setup_method(self):
+        import vip.auth
+
+        vip.auth._scheme_resolution_cache.clear()
+
+    @staticmethod
+    def _args(**overrides) -> argparse.Namespace:
+        defaults = {"connect_url": None, "api_key": None, "workbench_url": None}
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_bare_hostname_connect_url_is_normalized_and_resolved(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        class _FakeConnectClient:
+            def __init__(self, *a, **k):
+                self.url = a[0]
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 0
+
+        constructed: list[str] = []
+        orig_init = _FakeConnectClient.__init__
+
+        def _record_init(self, *a, **k):
+            constructed.append(a[0])
+            orig_init(self, *a, **k)
+
+        _FakeConnectClient.__init__ = _record_init
+        monkeypatch.setattr("vip.clients.connect.ConnectClient", _FakeConnectClient)
+
+        import vip.cli
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            vip.cli.run_cleanup(self._args(connect_url="connect.example.com"))
+
+        assert constructed == ["http://connect.example.com"]
+        assert "http://connect.example.com" in capsys.readouterr().out
+
+    def test_explicit_scheme_connect_url_never_probes(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        class _FakeConnectClient:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 0
+
+        monkeypatch.setattr("vip.clients.connect.ConnectClient", _FakeConnectClient)
+
+        import vip.cli
+
+        with patch("httpx.get") as mock_get:
+            vip.cli.run_cleanup(self._args(connect_url="https://c.example.com"))
+
+        mock_get.assert_not_called()
+
+
+def _write_manifest(tmp_path) -> None:
+    """Write a minimal .vip-install.json matching the current host, per the
+    established pattern in selftests/install/test_cli_uninstall.py."""
+    import json
+    import socket
+
+    manifest = {
+        "version": 1,
+        "vip_version": "0.0.0",
+        "created_at": "t",
+        "updated_at": "t",
+        "host": socket.gethostname(),
+        "platform": "rhel-family",
+        "platform_id": "rhel",
+        "platform_version": "10",
+        "items": [],
+        "pending_system_packages": [],
+    }
+    (tmp_path / ".vip-install.json").write_text(json.dumps(manifest))
+
+
+class TestRunUninstallSchemeResolution:
+    """The chained-cleanup callable in ``vip uninstall`` resolves an inferred
+    scheme lazily -- only when actually invoked (--yes), never during a
+    dry-run plan preview."""
+
+    def setup_method(self):
+        import vip.auth
+
+        vip.auth._scheme_resolution_cache.clear()
+
+    def test_dry_run_never_probes(self, tmp_path, monkeypatch):
+        """Without --yes, execute_uninstall_plan never calls cleanup_callable
+        at all -- confirm no network call happens building up to that point."""
+        import vip.cli as cli
+
+        _write_manifest(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        args = argparse.Namespace(
+            connect_url="connect.example.com", api_key=None, force_host=False, yes=False
+        )
+        with patch("httpx.get") as mock_get:
+            with pytest.raises(SystemExit) as exc:
+                cli.run_uninstall(args)
+
+        assert exc.value.code == 0
+        mock_get.assert_not_called()
+
+    def test_yes_resolves_inferred_scheme_before_client_construction(self, tmp_path, monkeypatch):
+        import vip.cli as cli
+        import vip.clients.connect as connect_mod
+
+        _write_manifest(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        constructed: list[str] = []
+
+        class _FakeConnectClient:
+            def __init__(self, url, *a, **k):
+                constructed.append(url)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 0
+
+        monkeypatch.setattr(connect_mod, "ConnectClient", _FakeConnectClient)
+
+        args = argparse.Namespace(
+            connect_url="connect.example.com", api_key=None, force_host=False, yes=True
+        )
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            with pytest.raises(SystemExit) as exc:
+                cli.run_uninstall(args)
+
+        assert exc.value.code == 0
+        assert constructed == ["http://connect.example.com"]
+
+    def test_explicit_scheme_never_probes(self, tmp_path, monkeypatch):
+        import vip.cli as cli
+        import vip.clients.connect as connect_mod
+
+        _write_manifest(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        class _FakeConnectClient:
+            def __init__(self, url, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 0
+
+        monkeypatch.setattr(connect_mod, "ConnectClient", _FakeConnectClient)
+
+        args = argparse.Namespace(
+            connect_url="https://connect.example.com", api_key=None, force_host=False, yes=True
+        )
+        with patch("httpx.get") as mock_get:
+            with pytest.raises(SystemExit) as exc:
+                cli.run_uninstall(args)
+
+        assert exc.value.code == 0
+        mock_get.assert_not_called()

--- a/selftests/test_cli_url_scheme.py
+++ b/selftests/test_cli_url_scheme.py
@@ -1,12 +1,20 @@
 """Tests for the scheme-inference fallback wiring in vip.cli (issue #537).
 
-``_resolved_url`` and its call sites in ``_collect_status`` (``vip status``),
-``run_cleanup`` (``vip cleanup``), and ``run_uninstall``'s chained-cleanup
-callable all need the same probe-and-fallback treatment as ``vip verify``:
-a scheme-less URL defaults to https:// (``vip.config._normalize_url``) and
-falls back to http:// only when https genuinely doesn't answer
-(``vip.auth.resolve_url_scheme``), never for a URL the caller gave an
-explicit scheme for.
+``_collect_status`` (``vip status``), ``run_cleanup`` (``vip cleanup``), and
+``run_uninstall``'s chained-cleanup callable all need the same probe-and-
+fallback treatment as ``vip verify``: a scheme-less URL defaults to https://
+(``vip.config._normalize_url``) and falls back to http:// only when https
+genuinely doesn't answer (``vip.auth.resolve_url_scheme``), never for a URL
+the caller gave an explicit scheme for.
+
+``resolve_url_scheme`` itself (the shared function all three call directly --
+cli.py has no wrapper of its own, see #562) is tested exhaustively in
+``TestResolveUrlScheme`` in ``test_auth.py``; the tests below exercise the
+real ``_collect_status``/``run_cleanup``/``run_uninstall`` entry points end to
+end, mocking only ``httpx.get`` (the network boundary) and the product
+clients, so a wiring mistake at these specific call sites -- e.g. passing the
+wrong ProductConfig, or resolving eagerly where laziness is required -- would
+fail here even though the underlying function is already covered.
 """
 
 from __future__ import annotations
@@ -18,60 +26,6 @@ import httpx
 import pytest
 
 from vip.config import ConnectConfig
-
-
-class TestResolvedUrlCli:
-    """``vip.cli._resolved_url`` mirrors conftest.py's fixture-level helper."""
-
-    def setup_method(self):
-        import vip.auth
-
-        vip.auth._scheme_resolution_cache.clear()
-
-    def test_explicit_scheme_never_probes(self):
-        from vip.cli import _resolved_url
-
-        pc = ConnectConfig(url="https://connect.example.com")
-
-        with patch("httpx.get") as mock_get:
-            url = _resolved_url(pc)
-
-        assert url == "https://connect.example.com"
-        mock_get.assert_not_called()
-
-    def test_inferred_scheme_kept_when_https_answers(self):
-        from vip.cli import _resolved_url
-
-        pc = ConnectConfig(url="connect.example.com")
-        assert pc.url_scheme_inferred is True
-
-        with patch("httpx.get", return_value=MagicMock(status_code=200)):
-            url = _resolved_url(pc)
-
-        assert url == "https://connect.example.com"
-        assert pc.url == "https://connect.example.com"
-
-    def test_inferred_scheme_falls_back_and_mutates_in_place(self):
-        pc = ConnectConfig(url="connect.example.com")
-
-        from vip.cli import _resolved_url
-
-        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
-            url = _resolved_url(pc)
-
-        assert url == "http://connect.example.com"
-        assert pc.url == "http://connect.example.com"
-
-    def test_insecure_and_ca_bundle_forwarded(self, tmp_path):
-        from vip.cli import _resolved_url
-
-        ca = tmp_path / "ca.pem"
-        pc = ConnectConfig(url="connect.example.com")
-
-        with patch("httpx.get", return_value=MagicMock(status_code=200)) as mock_get:
-            _resolved_url(pc, insecure=True, ca_bundle=ca)
-
-        assert mock_get.call_args.kwargs["verify"] is False
 
 
 class TestCollectStatusSchemeResolution:
@@ -289,6 +243,76 @@ class TestRunUninstallSchemeResolution:
 
         assert exc.value.code == 0
         assert constructed == ["http://connect.example.com"]
+
+    def test_printed_plan_matches_the_url_actually_used(self, tmp_path, monkeypatch, capsys):
+        """format_uninstall_plan prints ``run vip cleanup against {url}``
+        before execute_uninstall_plan's own --yes gate. Resolving lazily
+        inside cleanup_callable (the previous approach) meant a --yes run
+        could print https:// and then use http:// -- the exact scheme
+        mismatch this feature exists to prevent. The printed URL must match
+        what ConnectClient actually receives."""
+        import vip.cli as cli
+        import vip.clients.connect as connect_mod
+
+        _write_manifest(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        constructed: list[str] = []
+
+        class _FakeConnectClient:
+            def __init__(self, url, *a, **k):
+                constructed.append(url)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def cleanup_vip_content(self):
+                return 0
+
+        monkeypatch.setattr(connect_mod, "ConnectClient", _FakeConnectClient)
+
+        args = argparse.Namespace(
+            connect_url="connect.example.com", api_key=None, force_host=False, yes=True
+        )
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            with pytest.raises(SystemExit) as exc:
+                cli.run_uninstall(args)
+
+        assert exc.value.code == 0
+        printed = capsys.readouterr().out
+        # The resolve_url_scheme downgrade warning legitimately mentions the
+        # original https:// URL as part of explaining what it tried; the
+        # thing under test is specifically the printed *plan* line.
+        assert "run vip cleanup against http://connect.example.com" in printed
+        assert "run vip cleanup against https://connect.example.com" not in printed
+        assert constructed == ["http://connect.example.com"]
+
+    def test_dry_run_prints_unresolved_url_and_never_probes(self, tmp_path, monkeypatch, capsys):
+        """A dry-run preview (no --yes) must not probe the network at all, so
+        it necessarily prints the unresolved (inferred https://) URL --
+        nothing is actually cleaned up in a dry run, so there is no scheme
+        mismatch to create."""
+        import vip.cli as cli
+
+        _write_manifest(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VIP_CONFIG", raising=False)
+
+        args = argparse.Namespace(
+            connect_url="connect.example.com", api_key=None, force_host=False, yes=False
+        )
+        with patch("httpx.get") as mock_get:
+            with pytest.raises(SystemExit) as exc:
+                cli.run_uninstall(args)
+
+        assert exc.value.code == 0
+        mock_get.assert_not_called()
+        printed = capsys.readouterr().out
+        assert "run vip cleanup against https://connect.example.com" in printed
 
     def test_explicit_scheme_never_probes(self, tmp_path, monkeypatch):
         import vip.cli as cli

--- a/selftests/test_config.py
+++ b/selftests/test_config.py
@@ -67,11 +67,24 @@ class TestConnectConfig:
 
     def test_url_normalized_when_scheme_missing(self):
         cc = ConnectConfig(url="connect.example.com")
-        assert cc.url == "http://connect.example.com"
+        assert cc.url == "https://connect.example.com"
+
+    def test_url_scheme_missing_marks_inferred(self):
+        cc = ConnectConfig(url="connect.example.com")
+        assert cc.url_scheme_inferred is True
 
     def test_url_host_only_no_trailing_slash(self):
         cc = ConnectConfig(url="https://connect.example.com")
         assert cc.url == "https://connect.example.com"
+
+    def test_url_explicit_scheme_not_marked_inferred(self):
+        cc = ConnectConfig(url="https://connect.example.com")
+        assert cc.url_scheme_inferred is False
+
+    def test_url_explicit_http_scheme_preserved(self):
+        cc = ConnectConfig(url="http://connect.example.com")
+        assert cc.url == "http://connect.example.com"
+        assert cc.url_scheme_inferred is False
 
     def test_url_host_only_trailing_slash_stripped(self):
         cc = ConnectConfig(url="https://connect.example.com/")

--- a/selftests/test_conftest_client_urls.py
+++ b/selftests/test_conftest_client_urls.py
@@ -1,0 +1,84 @@
+"""Tests for vip_tests.conftest._resolved_url.
+
+``connect_client``/``workbench_client``/``pm_client`` (and their companion
+``connect_url``/``workbench_url``/``pm_url`` fixtures) are the seam that talks
+to the server for the ``--api-auth``/``--no-auth`` paths, where no browser
+auth flow runs to resolve a scheme-less URL first (see ``vip.auth.
+resolve_url_scheme`` and issue #537). ``_resolved_url`` is the shared helper
+those fixtures call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from vip.config import ConnectConfig, VIPConfig
+from vip_tests.conftest import _resolved_url
+
+
+class TestResolvedUrl:
+    def setup_method(self):
+        import vip.auth
+
+        vip.auth._scheme_resolution_cache.clear()
+
+    def test_explicit_scheme_never_probes(self):
+        pc = ConnectConfig(url="https://connect.example.com")
+        vip_config = VIPConfig()
+
+        with patch("httpx.get") as mock_get:
+            url = _resolved_url(pc, vip_config)
+
+        assert url == "https://connect.example.com"
+        mock_get.assert_not_called()
+
+    def test_inferred_scheme_kept_when_https_answers(self):
+        pc = ConnectConfig(url="connect.example.com")
+        assert pc.url_scheme_inferred is True
+        vip_config = VIPConfig()
+
+        with patch("httpx.get", return_value=MagicMock(status_code=200)):
+            url = _resolved_url(pc, vip_config)
+
+        assert url == "https://connect.example.com"
+        assert pc.url == "https://connect.example.com"
+
+    def test_inferred_scheme_falls_back_and_mutates_config_in_place(self):
+        """The fixture's whole point is that pc.url is corrected in place so
+        every other fixture that reads it afterward sees the same value."""
+        import httpx
+
+        pc = ConnectConfig(url="connect.example.com")
+        vip_config = VIPConfig()
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            url = _resolved_url(pc, vip_config)
+
+        assert url == "http://connect.example.com"
+        assert pc.url == "http://connect.example.com"
+
+    def test_second_call_does_not_probe_again(self):
+        """resolve_url_scheme's cache means calling this from more than one
+        fixture (connect_client, then connect_url) for the same product
+        probes the network only once."""
+        import httpx
+
+        pc = ConnectConfig(url="connect.example.com")
+        vip_config = VIPConfig()
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
+            first = _resolved_url(pc, vip_config)
+            second = _resolved_url(pc, vip_config)
+
+        assert first == second == "http://connect.example.com"
+        mock_get.assert_called_once()
+
+    def test_insecure_and_ca_bundle_are_forwarded(self, tmp_path):
+        ca = tmp_path / "ca.pem"
+        pc = ConnectConfig(url="connect.example.com")
+        vip_config = VIPConfig(ca_bundle=ca)
+
+        with patch("httpx.get", return_value=MagicMock(status_code=200)) as mock_get:
+            _resolved_url(pc, vip_config)
+
+        assert mock_get.call_args.kwargs["verify"] == str(ca)

--- a/selftests/test_conftest_client_urls.py
+++ b/selftests/test_conftest_client_urls.py
@@ -1,84 +1,104 @@
-"""Tests for vip_tests.conftest._resolved_url.
+"""Tests for the scheme-resolution wiring in vip_tests/conftest.py.
 
 ``connect_client``/``workbench_client``/``pm_client`` (and their companion
 ``connect_url``/``workbench_url``/``pm_url`` fixtures) are the seam that talks
 to the server for the ``--api-auth``/``--no-auth`` paths, where no browser
 auth flow runs to resolve a scheme-less URL first (see ``vip.auth.
-resolve_url_scheme`` and issue #537). ``_resolved_url`` is the shared helper
-those fixtures call.
+resolve_url_scheme`` and issue #537).
+
+A type-design review on #562 pointed out that ``resolve_url_scheme`` used to
+take a bare ``url: str`` and trust the caller to have checked
+``ProductConfig.url_scheme_inferred`` first. It now takes the whole
+``ProductConfig`` and checks provenance itself (see ``TestResolveUrlScheme``
+in ``test_auth.py`` for the full behavior matrix), which means there is no
+longer a separate conftest.py helper with its own logic to test in
+isolation -- these fixtures are now a single direct call. What is still
+worth pinning down here is that each fixture passes the *right*
+``ProductConfig`` (connect's, not workbench's or package_manager's) and the
+right TLS settings through to ``resolve_url_scheme``.
+
+The ``connect_url``/``workbench_url``/``pm_url`` fixtures are called via
+``.__wrapped__`` to invoke the underlying function directly, bypassing
+pytest's "fixtures cannot be called directly" guard -- they take only
+``vip_config`` as a parameter, so this needs no ``request``/stash setup.
 """
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from vip.config import ConnectConfig, VIPConfig
-from vip_tests.conftest import _resolved_url
+import httpx
+
+from vip.config import ConnectConfig, PackageManagerConfig, VIPConfig, WorkbenchConfig
+from vip_tests import conftest
 
 
-class TestResolvedUrl:
+class TestUrlFixturesResolveTheRightProductConfig:
     def setup_method(self):
         import vip.auth
 
         vip.auth._scheme_resolution_cache.clear()
 
-    def test_explicit_scheme_never_probes(self):
-        pc = ConnectConfig(url="https://connect.example.com")
-        vip_config = VIPConfig()
+    def test_connect_url_resolves_connect_config(self):
+        vip_config = VIPConfig(connect=ConnectConfig(url="connect.example.com"))
+
+        with patch("httpx.get", return_value=MagicMock(status_code=200)):
+            url = conftest.connect_url.__wrapped__(vip_config)
+
+        assert url == "https://connect.example.com"
+
+    def test_connect_url_falls_back_when_unreachable(self):
+        vip_config = VIPConfig(connect=ConnectConfig(url="connect.example.com"))
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            url = conftest.connect_url.__wrapped__(vip_config)
+
+        assert url == "http://connect.example.com"
+        assert vip_config.connect.url == "http://connect.example.com"
+
+    def test_connect_url_with_explicit_scheme_never_probes(self):
+        vip_config = VIPConfig(connect=ConnectConfig(url="https://connect.example.com"))
 
         with patch("httpx.get") as mock_get:
-            url = _resolved_url(pc, vip_config)
+            url = conftest.connect_url.__wrapped__(vip_config)
 
         assert url == "https://connect.example.com"
         mock_get.assert_not_called()
 
-    def test_inferred_scheme_kept_when_https_answers(self):
-        pc = ConnectConfig(url="connect.example.com")
-        assert pc.url_scheme_inferred is True
-        vip_config = VIPConfig()
-
-        with patch("httpx.get", return_value=MagicMock(status_code=200)):
-            url = _resolved_url(pc, vip_config)
-
-        assert url == "https://connect.example.com"
-        assert pc.url == "https://connect.example.com"
-
-    def test_inferred_scheme_falls_back_and_mutates_config_in_place(self):
-        """The fixture's whole point is that pc.url is corrected in place so
-        every other fixture that reads it afterward sees the same value."""
-        import httpx
-
-        pc = ConnectConfig(url="connect.example.com")
-        vip_config = VIPConfig()
+    def test_workbench_url_resolves_workbench_config_not_connect(self):
+        """Regression guard: passing the wrong ProductConfig (e.g. connect's
+        instead of workbench's) would silently resolve/mutate the wrong
+        product's URL."""
+        vip_config = VIPConfig(
+            connect=ConnectConfig(url="https://connect.example.com"),
+            workbench=WorkbenchConfig(url="workbench.example.com"),
+        )
 
         with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
-            url = _resolved_url(pc, vip_config)
+            url = conftest.workbench_url.__wrapped__(vip_config)
 
-        assert url == "http://connect.example.com"
-        assert pc.url == "http://connect.example.com"
+        assert url == "http://workbench.example.com"
+        assert vip_config.workbench.url == "http://workbench.example.com"
+        # The unrelated Connect config must be untouched.
+        assert vip_config.connect.url == "https://connect.example.com"
 
-    def test_second_call_does_not_probe_again(self):
-        """resolve_url_scheme's cache means calling this from more than one
-        fixture (connect_client, then connect_url) for the same product
-        probes the network only once."""
-        import httpx
+    def test_pm_url_resolves_package_manager_config(self):
+        vip_config = VIPConfig(package_manager=PackageManagerConfig(url="pm.example.com"))
 
-        pc = ConnectConfig(url="connect.example.com")
-        vip_config = VIPConfig()
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            url = conftest.pm_url.__wrapped__(vip_config)
 
-        with patch("httpx.get", side_effect=httpx.ConnectError("nope")) as mock_get:
-            first = _resolved_url(pc, vip_config)
-            second = _resolved_url(pc, vip_config)
-
-        assert first == second == "http://connect.example.com"
-        mock_get.assert_called_once()
+        assert url == "http://pm.example.com"
 
     def test_insecure_and_ca_bundle_are_forwarded(self, tmp_path):
         ca = tmp_path / "ca.pem"
-        pc = ConnectConfig(url="connect.example.com")
-        vip_config = VIPConfig(ca_bundle=ca)
+        vip_config = VIPConfig(
+            connect=ConnectConfig(url="connect.example.com"),
+            insecure=False,
+            ca_bundle=ca,
+        )
 
         with patch("httpx.get", return_value=MagicMock(status_code=200)) as mock_get:
-            _resolved_url(pc, vip_config)
+            conftest.connect_url.__wrapped__(vip_config)
 
         assert mock_get.call_args.kwargs["verify"] == str(ca)

--- a/selftests/test_plugin.py
+++ b/selftests/test_plugin.py
@@ -1588,6 +1588,88 @@ class TestAuthModeStash:
         )
 
 
+class TestWorkbenchUrlSyncAfterAuth:
+    """``pytest_configure`` must sync a resolved Workbench URL back into
+    ``vip_cfg`` the same way it already does for Connect (issue #562
+    comment-accuracy review).
+
+    Before this fix, only ``vip_cfg.connect.url`` was updated from
+    ``session._connect_url``; ``session._workbench_url`` was populated by
+    ``start_interactive_auth``/``start_headless_auth`` but never written
+    back. The resolved Workbench scheme still reached the rest of a real run
+    -- but only because ``conftest.py``'s fixtures call ``resolve_url_scheme``
+    again and hit a cache entry keyed on the URL string, an unstated
+    side-channel rather than an actual sync. This exercises the real
+    plugin-to-fixture path (a pytester run reading ``vip_cfg`` straight out
+    of the stash) rather than unit-testing the sync condition in isolation.
+    """
+
+    _FAKE_AUTH_CONFTEST_DOWNGRADED_WORKBENCH = """
+        import vip.auth
+        from pathlib import Path
+        from vip.auth import InteractiveAuthSession
+
+        def _fake_session(*args, **kwargs):
+            return InteractiveAuthSession(
+                storage_state_path=Path("/dev/null"),
+                api_key="fake-key",
+                _connect_url=kwargs.get("connect_url") or "",
+                # Simulates resolve_url_scheme downgrading an inferred
+                # Workbench https:// to http:// inside start_interactive_auth/
+                # start_headless_auth.
+                _workbench_url="http://wb.example.com",
+            )
+
+        vip.auth.start_interactive_auth = _fake_session
+        vip.auth.start_headless_auth = _fake_session
+        """
+
+    def test_interactive_auth_syncs_resolved_workbench_url(self, pytester):
+        pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                '[workbench]\nurl = "https://wb.example.com"\n'
+            ),
+        )
+        pytester.makeconftest(self._FAKE_AUTH_CONFTEST_DOWNGRADED_WORKBENCH)
+        pytester.makepyfile(
+            """
+            from vip.plugin import _vip_config_key
+
+            def test_workbench_url_synced(request):
+                vip_cfg = request.config.stash[_vip_config_key]
+                assert vip_cfg.workbench.url == "http://wb.example.com"
+            """
+        )
+        result = pytester.runpytest("--vip-config=vip.toml", "--interactive-auth", "-v")
+        result.assert_outcomes(passed=1)
+
+    def test_headless_auth_syncs_resolved_workbench_url(self, pytester, monkeypatch):
+        monkeypatch.setenv("VIP_TEST_USERNAME", "testuser")
+        monkeypatch.setenv("VIP_TEST_PASSWORD", "testpass")
+        pytester.makefile(
+            ".toml",
+            vip=(
+                '[general]\ndeployment_name = "Selftest"\n'
+                '[workbench]\nurl = "https://wb.example.com"\n'
+                '[auth]\nprovider = "password"\n'
+            ),
+        )
+        pytester.makeconftest(self._FAKE_AUTH_CONFTEST_DOWNGRADED_WORKBENCH)
+        pytester.makepyfile(
+            """
+            from vip.plugin import _vip_config_key
+
+            def test_workbench_url_synced(request):
+                vip_cfg = request.config.stash[_vip_config_key]
+                assert vip_cfg.workbench.url == "http://wb.example.com"
+            """
+        )
+        result = pytester.runpytest("--vip-config=vip.toml", "--headless-auth", "-v")
+        result.assert_outcomes(passed=1)
+
+
 class TestRestoreWorkerAuth:
     """``_restore_worker_auth`` recreates the controller's auth state on each
     xdist worker.  When the controller rewrote ``connect.url`` (split sub-path

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -431,6 +431,8 @@ def start_interactive_auth(
     cache_path: Path | None = None,
     insecure: bool = False,
     ca_bundle: Path | None = None,
+    connect_url_scheme_inferred: bool = False,
+    workbench_url_scheme_inferred: bool = False,
 ) -> InteractiveAuthSession:
     """Launch a headed browser, authenticate via OIDC, and optionally
     mint a Connect API key through the UI.
@@ -453,6 +455,12 @@ def start_interactive_auth(
     When *ca_bundle* is set, the path is exported as ``NODE_EXTRA_CA_CERTS``
     before launching Chromium so it trusts a custom CA (Chromium-level trust
     only; this does not update the OS certificate store).
+
+    *connect_url_scheme_inferred* / *workbench_url_scheme_inferred* mark a URL
+    whose ``https://`` scheme was inferred by ``vip.config._normalize_url``
+    rather than given explicitly (``ProductConfig.url_scheme_inferred``).
+    When set, :func:`resolve_url_scheme` probes the URL and falls back to
+    ``http://`` if https doesn't answer, before it's used for anything.
     """
     if not connect_url and not workbench_url:
         raise ValueError(
@@ -464,6 +472,11 @@ def start_interactive_auth(
         cached = _load_cached_auth(cache_path, connect_url, workbench_url)
         if cached is not None:
             return cached
+
+    if connect_url and connect_url_scheme_inferred:
+        connect_url = resolve_url_scheme(connect_url, insecure=insecure, ca_bundle=ca_bundle)
+    if workbench_url and workbench_url_scheme_inferred:
+        workbench_url = resolve_url_scheme(workbench_url, insecure=insecure, ca_bundle=ca_bundle)
 
     # Determine the primary login target.
     primary_url = connect_url or workbench_url
@@ -605,6 +618,8 @@ def start_headless_auth(
     verbose: bool = False,
     insecure: bool = False,
     ca_bundle: Path | None = None,
+    connect_url_scheme_inferred: bool = False,
+    workbench_url_scheme_inferred: bool = False,
 ) -> InteractiveAuthSession:
     """Launch a headless browser, automate OIDC login, and optionally
     mint a Connect API key through the UI.
@@ -622,6 +637,9 @@ def start_headless_auth(
     When *ca_bundle* is set, the path is exported as ``NODE_EXTRA_CA_CERTS``
     before launching Chromium so it trusts a custom CA (Chromium-level trust
     only; this does not update the OS certificate store).
+
+    *connect_url_scheme_inferred* / *workbench_url_scheme_inferred*: see
+    ``start_interactive_auth``.
     """
     import vip.idp as _idp_mod
 
@@ -668,6 +686,14 @@ def start_headless_auth(
             )
 
         fill_login = get_idp_strategy(idp)
+
+    # Resolve inferred https:// schemes now, after every fail-fast validation
+    # above and right before anything (Playwright or httpx) actually talks to
+    # the URLs, so a config error never pays for a network probe it doesn't need.
+    if connect_url and connect_url_scheme_inferred:
+        connect_url = resolve_url_scheme(connect_url, insecure=insecure, ca_bundle=ca_bundle)
+    if workbench_url and workbench_url_scheme_inferred:
+        workbench_url = resolve_url_scheme(workbench_url, insecure=insecure, ca_bundle=ca_bundle)
 
     # Determine the primary login target.
     primary_url = connect_url or workbench_url
@@ -1301,6 +1327,65 @@ def _body_snippet(resp, limit: int = 200) -> str:
     return text[:limit] if text else "<empty body>"
 
 
+# Cache of resolved schemes, keyed by the https:// URL that was probed. A
+# single `vip verify` run can reach ``resolve_url_scheme`` from more than one
+# place -- the interactive/headless auth flow, then again from a client
+# fixture reading the same config value -- so the second and later calls for
+# the same URL are a dict lookup instead of a second live probe.
+_scheme_resolution_cache: dict[str, str] = {}
+
+
+def resolve_url_scheme(
+    url: str,
+    *,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
+) -> str:
+    """Fall an *inferred* ``https://`` URL back to ``http://`` if https doesn't answer.
+
+    ``vip.config._normalize_url`` defaults a scheme-less host to ``https://``
+    but cannot verify reachability without a network call, which would break
+    config loading's purity (it must stay network-free so, e.g., CI's
+    ``--collect-only`` dry runs never dial out). This is the network-touching
+    counterpart: call it once, from the first place that is actually about to
+    talk to *url* (an auth flow or a client constructor) for a URL whose
+    scheme ``vip.config`` marked as inferred. Never call this for a URL whose
+    scheme the user gave explicitly -- an explicit scheme is authoritative
+    and must never be second-guessed, so this function does not take an
+    ``inferred`` flag itself; callers are expected to check
+    ``ProductConfig.url_scheme_inferred`` before calling.
+
+    A connection-level failure (refused connection, DNS failure, TLS
+    handshake failure, timeout -- ``httpx.TransportError``) is treated as
+    "https doesn't answer" and triggers the http:// fallback, logged loudly
+    so a user who meant https notices they got plaintext instead. Any actual
+    HTTP response -- including a 5xx -- counts as "https answered" and is
+    kept as-is; only a connection that never completes justifies downgrading.
+
+    Results are cached per URL for the life of the process (see
+    ``_scheme_resolution_cache``) so repeated calls for the same URL probe
+    the network only once.
+    """
+    if not url.startswith("https://"):
+        return url
+    if url in _scheme_resolution_cache:
+        return _scheme_resolution_cache[url]
+
+    verify = _httpx_verify(insecure, ca_bundle)
+    resolved = url
+    try:
+        httpx.get(url, timeout=scaled(10.0), verify=verify, follow_redirects=True)
+    except httpx.TransportError as exc:
+        resolved = "http://" + url.removeprefix("https://")
+        print(
+            f">>> Warning: {url} did not answer ({exc}); falling back to plaintext "
+            f"HTTP at {resolved}. Pass an explicit http:// or https:// scheme on the "
+            f"URL to silence this."
+        )
+    _scheme_resolution_cache[url] = resolved
+    return resolved
+
+
 def _resolve_connect_api_base(
     connect_url: str,
     *,
@@ -1399,6 +1484,11 @@ def _create_api_key_via_session(
     cannot accept a custom CA bundle, which caused ``CERTIFICATE_VERIFY_FAILED``
     errors when ``--insecure`` was set (issue #239).
 
+    The client is constructed with ``follow_redirects=True`` to match
+    ``_resolve_connect_api_base``'s probes: a deployment that redirects
+    HTTP -> HTTPS (or drops/adds a trailing slash) would otherwise turn a
+    301/302 into a treated-as-failure response here (issue #537).
+
     The XSRF token is still read from the browser's cookie jar via
     :func:`_xsrf_from_page` and sent as the ``X-Rsc-Xsrf`` request header —
     Connect's double-submit CSRF check requires the header and the cookie to
@@ -1450,6 +1540,7 @@ def _create_api_key_via_session(
             cookies=cookies,
             timeout=scaled(10.0),
             verify=verify,
+            follow_redirects=True,
         ) as client:
             me_resp = client.get("/v1/user")
             if not me_resp.is_success:

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -16,7 +16,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 from playwright.sync_api import (
@@ -31,6 +31,9 @@ from playwright.sync_api import (
 )
 
 from vip.timeouts import scaled
+
+if TYPE_CHECKING:
+    from vip.config import ProductConfig
 
 
 class AuthConfigError(ValueError):
@@ -425,6 +428,43 @@ def _save_auth_cache(session: InteractiveAuthSession, cache_path: Path) -> None:
     os.chmod(meta_path, 0o600)
 
 
+def _resolve_str_if_inferred(
+    url: str | None,
+    inferred: bool,
+    *,
+    insecure: bool,
+    ca_bundle: Path | None,
+) -> str | None:
+    """Resolve a bare url string through ``resolve_url_scheme``'s provenance check.
+
+    ``start_interactive_auth``/``start_headless_auth`` receive ``connect_url``/
+    ``workbench_url`` as plain strings plus a separate ``*_scheme_inferred``
+    bool -- that's the shape ``vip.plugin`` already has to pass across the
+    ``VIPConfig`` -> CLI-function boundary -- rather than a ``ProductConfig``
+    object. ``resolve_url_scheme`` only takes a ``ProductConfig`` (see its
+    docstring for why), so this builds a throwaway one to carry *inferred*
+    across, calls ``resolve_url_scheme``, and returns the resolved string.
+    """
+    if not url:
+        return url
+    from vip.config import ProductConfig
+
+    # ProductConfig.__post_init__ runs _normalize_url on construction, but
+    # *url* here has already been normalized upstream (it always has an
+    # explicit http:// or https:// prefix by the time it reaches this
+    # function) -- so the inferred flag __post_init__ computes is always
+    # False and meaningless. Overwrite it with the caller's *inferred*,
+    # which is the actual, authoritative provenance carried separately
+    # alongside the string. This overwrite-right-after-construction is a
+    # known wart, not a bug: the clean fix is changing start_interactive_auth/
+    # start_headless_auth to take ProductConfig objects directly instead of
+    # a string + a separate bool, which would touch ~15 call sites across
+    # test_auth.py plus plugin.py/cli.py -- out of scope for this bug fix.
+    pc = ProductConfig(url=url)
+    pc.url_scheme_inferred = inferred
+    return resolve_url_scheme(pc, insecure=insecure, ca_bundle=ca_bundle)
+
+
 def start_interactive_auth(
     connect_url: str | None = None,
     workbench_url: str | None = None,
@@ -473,10 +513,12 @@ def start_interactive_auth(
         if cached is not None:
             return cached
 
-    if connect_url and connect_url_scheme_inferred:
-        connect_url = resolve_url_scheme(connect_url, insecure=insecure, ca_bundle=ca_bundle)
-    if workbench_url and workbench_url_scheme_inferred:
-        workbench_url = resolve_url_scheme(workbench_url, insecure=insecure, ca_bundle=ca_bundle)
+    connect_url = _resolve_str_if_inferred(
+        connect_url, connect_url_scheme_inferred, insecure=insecure, ca_bundle=ca_bundle
+    )
+    workbench_url = _resolve_str_if_inferred(
+        workbench_url, workbench_url_scheme_inferred, insecure=insecure, ca_bundle=ca_bundle
+    )
 
     # Determine the primary login target.
     primary_url = connect_url or workbench_url
@@ -690,10 +732,12 @@ def start_headless_auth(
     # Resolve inferred https:// schemes now, after every fail-fast validation
     # above and right before anything (Playwright or httpx) actually talks to
     # the URLs, so a config error never pays for a network probe it doesn't need.
-    if connect_url and connect_url_scheme_inferred:
-        connect_url = resolve_url_scheme(connect_url, insecure=insecure, ca_bundle=ca_bundle)
-    if workbench_url and workbench_url_scheme_inferred:
-        workbench_url = resolve_url_scheme(workbench_url, insecure=insecure, ca_bundle=ca_bundle)
+    connect_url = _resolve_str_if_inferred(
+        connect_url, connect_url_scheme_inferred, insecure=insecure, ca_bundle=ca_bundle
+    )
+    workbench_url = _resolve_str_if_inferred(
+        workbench_url, workbench_url_scheme_inferred, insecure=insecure, ca_bundle=ca_bundle
+    )
 
     # Determine the primary login target.
     primary_url = connect_url or workbench_url
@@ -1327,62 +1371,147 @@ def _body_snippet(resp, limit: int = 200) -> str:
     return text[:limit] if text else "<empty body>"
 
 
-# Cache of resolved schemes, keyed by the https:// URL that was probed. A
-# single `vip verify` run can reach ``resolve_url_scheme`` from more than one
-# place -- the interactive/headless auth flow, then again from a client
-# fixture reading the same config value -- so the second and later calls for
-# the same URL are a dict lookup instead of a second live probe.
-_scheme_resolution_cache: dict[str, str] = {}
+# Cache of resolved schemes, keyed by (url, insecure, ca_bundle) -- the same
+# three inputs that determine what the probe below would decide. A single
+# `vip verify` run can reach ``resolve_url_scheme`` from more than one place
+# -- the interactive/headless auth flow, then again from a client fixture
+# reading the same config value -- so the second and later calls for the
+# same (url, insecure, ca_bundle) are a dict lookup instead of a second live
+# probe. Keying on URL alone would let a cached ``verify=True`` failure
+# silently authorise a downgrade for a later caller that actually passed
+# ``insecure=True`` (or a different ``ca_bundle``) and might have gotten a
+# different, correct answer.
+_scheme_resolution_cache: dict[tuple[str, bool, Path | None], str] = {}
+
+
+def _tls_listener_present(url: str, *, timeout: float) -> bool:
+    """True if something accepts a TCP connection at *url*'s host:port.
+
+    Used to tell "TLS is present but this client doesn't trust it" (a
+    self-signed, expired, or otherwise unverified certificate; a protocol
+    mismatch; any other handshake failure) apart from "nothing is listening
+    here" when an https:// probe fails at the transport level. Those are not
+    the same failure and must not share a remedy: a listener that completes
+    a TCP handshake but fails a TLS handshake is a real server, running TLS,
+    that this client's default verification does not trust -- downgrading to
+    http:// in that case would send credentials to that server in the clear.
+
+    Deciding this with a raw TCP connect rather than by inspecting the
+    httpx/httpcore/ssl exception chain is deliberate. Reproducing this
+    against a real self-signed listener showed ``httpx.ConnectError.__cause__``
+    is httpcore's own ``ConnectError``, not the underlying ``ssl.SSLError`` --
+    getting to the real cause takes walking multiple chain levels, and how
+    many is an implementation detail of httpx/httpcore that can change
+    between versions. A TCP-level check needs no exception introspection at
+    all: it is agnostic to *why* the TLS handshake failed, which is exactly
+    the property wanted here, since every reason it can fail means the same
+    thing -- there is a TLS listener, not an empty port.
+    """
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        return False
+    port = parsed.port or 443
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 
 def resolve_url_scheme(
-    url: str,
+    pc: ProductConfig,
     *,
     insecure: bool = False,
     ca_bundle: Path | None = None,
 ) -> str:
-    """Fall an *inferred* ``https://`` URL back to ``http://`` if https doesn't answer.
+    """Fall *pc*'s URL back to ``http://`` if an inferred ``https://`` doesn't answer.
 
     ``vip.config._normalize_url`` defaults a scheme-less host to ``https://``
     but cannot verify reachability without a network call, which would break
     config loading's purity (it must stay network-free so, e.g., CI's
     ``--collect-only`` dry runs never dial out). This is the network-touching
     counterpart: call it once, from the first place that is actually about to
-    talk to *url* (an auth flow or a client constructor) for a URL whose
-    scheme ``vip.config`` marked as inferred. Never call this for a URL whose
-    scheme the user gave explicitly -- an explicit scheme is authoritative
-    and must never be second-guessed, so this function does not take an
-    ``inferred`` flag itself; callers are expected to check
-    ``ProductConfig.url_scheme_inferred`` before calling.
+    talk to ``pc.url`` for real (an auth flow or a client constructor).
 
-    A connection-level failure (refused connection, DNS failure, TLS
-    handshake failure, timeout -- ``httpx.TransportError``) is treated as
-    "https doesn't answer" and triggers the http:// fallback, logged loudly
-    so a user who meant https notices they got plaintext instead. Any actual
-    HTTP response -- including a 5xx -- counts as "https answered" and is
-    kept as-is; only a connection that never completes justifies downgrading.
+    Provenance is checked here, not by the caller: if ``pc.url_scheme_inferred``
+    is ``False`` -- the user gave an explicit scheme -- this returns ``pc.url``
+    unchanged without touching the network. There is deliberately no way to
+    probe a URL without going through this check: an earlier version took a
+    bare ``url: str`` and trusted every caller to test the flag first, which a
+    type-design review flagged as a hole -- a caller that forgot, or a bare
+    string with the provenance already stripped off, would silently downgrade
+    a URL nobody ever marked as inferred. Taking the whole ``ProductConfig``
+    makes that structurally impossible: there is no bare-string entry point
+    left to misuse.
 
-    Results are cached per URL for the life of the process (see
-    ``_scheme_resolution_cache``) so repeated calls for the same URL probe
-    the network only once.
+    A transport-level failure (``httpx.TransportError``) splits into two
+    cases that must not share a remedy:
+
+    - Nothing answers at all (refused connection, DNS failure, timeout) --
+      "https doesn't answer" -- triggers the http:// fallback, logged loudly
+      so a user who meant https notices they got plaintext instead.
+    - Something answers at the TCP level but the TLS handshake itself fails
+      (untrusted/self-signed/expired certificate, protocol mismatch, ...) --
+      see :func:`_tls_listener_present`. This is a *trust* problem, not a
+      *reachability* problem, and downgrading here would silently send
+      credentials to a real server over plaintext. This case does NOT
+      downgrade: ``pc.url`` is left as https://, and a loud warning names the
+      actual remedy (``[tls] insecure`` / ``[tls] ca_bundle`` in ``vip.toml``,
+      or the equivalent flag on commands that have one) instead of a vague
+      connection failure.
+
+    Any actual HTTP response -- including a 5xx -- counts as "https
+    answered" and is kept as-is; only a transport failure reaches either
+    branch above.
+
+    On return, ``pc.url`` holds the resolved value and ``pc.url_scheme_inferred``
+    is reset to ``False`` -- resolution is a one-time transition from
+    "inferred, unverified" to "settled" (settled as https in the
+    trust-problem case above, not just the reachable-and-downgraded case),
+    not a repeatable state. A second call on the same ``pc`` is then a plain
+    attribute read, no cache lookup needed. Results are still cached per
+    ``(url, insecure, ca_bundle)`` in ``_scheme_resolution_cache`` so a
+    *different* ``ProductConfig`` for the same URL and TLS settings (e.g. a
+    fresh instance built from the same ``--connect-url``) doesn't re-probe.
     """
-    if not url.startswith("https://"):
-        return url
-    if url in _scheme_resolution_cache:
-        return _scheme_resolution_cache[url]
+    if not pc.url_scheme_inferred:
+        return pc.url
 
-    verify = _httpx_verify(insecure, ca_bundle)
-    resolved = url
-    try:
-        httpx.get(url, timeout=scaled(10.0), verify=verify, follow_redirects=True)
-    except httpx.TransportError as exc:
-        resolved = "http://" + url.removeprefix("https://")
-        print(
-            f">>> Warning: {url} did not answer ({exc}); falling back to plaintext "
-            f"HTTP at {resolved}. Pass an explicit http:// or https:// scheme on the "
-            f"URL to silence this."
-        )
-    _scheme_resolution_cache[url] = resolved
+    url = pc.url
+    cache_key = (url, insecure, ca_bundle)
+    if cache_key in _scheme_resolution_cache:
+        resolved = _scheme_resolution_cache[cache_key]
+    else:
+        verify = _httpx_verify(insecure, ca_bundle)
+        resolved = url
+        try:
+            httpx.get(url, timeout=scaled(10.0), verify=verify, follow_redirects=True)
+        except httpx.TransportError as exc:
+            if _tls_listener_present(url, timeout=scaled(5.0)):
+                print(
+                    f">>> Warning: {url} answers on the network but its TLS "
+                    f"certificate was not accepted ({exc}). NOT falling back to "
+                    f"plaintext HTTP -- that would send credentials to this server "
+                    f"in the clear. If this certificate is expected (e.g. "
+                    f"self-signed or an internal CA), set [tls] insecure = true or "
+                    f"[tls] ca_bundle in vip.toml, or pass --insecure/--ca-bundle "
+                    f"where the command supports it."
+                )
+            else:
+                resolved = "http://" + url.removeprefix("https://")
+                print(
+                    f">>> Warning: {url} did not answer ({exc}); falling back to plaintext "
+                    f"HTTP at {resolved}. Pass an explicit http:// or https:// scheme on the "
+                    f"URL to silence this."
+                )
+        _scheme_resolution_cache[cache_key] = resolved
+
+    pc.url = resolved
+    pc.url_scheme_inferred = False
     return resolved
 
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -723,28 +723,6 @@ def run_report(args: argparse.Namespace) -> None:
         webbrowser.open(output.resolve().as_uri())
 
 
-def _resolved_url(
-    pc: ProductConfig, *, insecure: bool = False, ca_bundle: Path | None = None
-) -> str:
-    """Resolve *pc*'s URL via ``resolve_url_scheme`` when its scheme was inferred.
-
-    Config loading only infers a scheme (``vip.config._normalize_url`` stays
-    network-free); this is the network-touching half, called right before
-    something in this module first talks to the server -- mirrors
-    ``src/vip_tests/conftest.py``'s fixture-level helper of the same name and
-    purpose. A URL with an explicit scheme (``url_scheme_inferred`` False) is
-    returned unchanged, no network call. Mutates ``pc.url`` in place so a
-    caller that reads ``pc.url`` again downstream (e.g. for a printed
-    message) sees the resolved value; ``resolve_url_scheme`` itself caches by
-    URL, so calling this more than once for the same product costs one probe.
-    """
-    if pc.url_scheme_inferred:
-        from vip.auth import resolve_url_scheme
-
-        pc.url = resolve_url_scheme(pc.url, insecure=insecure, ca_bundle=ca_bundle)
-    return pc.url
-
-
 def _collect_status(config: VIPConfig) -> dict:
     """Run health checks and return structured status data.
 
@@ -778,7 +756,9 @@ def _collect_status(config: VIPConfig) -> dict:
             products[name] = {"configured": False, "state": "skip", "detail": "not configured"}
             continue
         try:
-            _resolved_url(pc, insecure=config.insecure, ca_bundle=config.ca_bundle)
+            from vip.auth import resolve_url_scheme
+
+            resolve_url_scheme(pc, insecure=config.insecure, ca_bundle=config.ca_bundle)
             if name == "connect":
                 client: ConnectClient | WorkbenchClient | PackageManagerClient = ConnectClient(
                     pc.url,
@@ -958,6 +938,25 @@ def run_uninstall(args: argparse.Namespace) -> None:
         if cfg and cfg.connect and cfg.connect.url:
             connect_pc = cfg.connect
 
+    insecure = cfg.insecure if cfg else False
+    ca_bundle = cfg.ca_bundle if cfg else None
+    yes = bool(getattr(args, "yes", False))
+
+    # Resolve now, before the plan is built (and therefore before it's
+    # printed) -- but only when --yes was passed. execute_uninstall_plan
+    # prints format_uninstall_plan(plan) unconditionally, *before* its own
+    # --yes gate; resolving lazily inside cleanup_callable (the previous
+    # approach) meant the printed plan could announce
+    # "run vip cleanup against https://host" and then actually clean up
+    # against "http://host" once resolve_url_scheme downgraded it -- exactly
+    # the kind of scheme mismatch this whole feature exists to prevent.
+    # Gating on --yes preserves the dry-run guarantee: a plan preview must
+    # never probe the network.
+    if yes and connect_pc is not None:
+        from vip.auth import resolve_url_scheme
+
+        resolve_url_scheme(connect_pc, insecure=insecure, ca_bundle=ca_bundle)
+
     plan = build_uninstall_plan(
         manifest=manifest,
         connect_url=connect_pc.url if connect_pc else None,
@@ -966,26 +965,27 @@ def run_uninstall(args: argparse.Namespace) -> None:
     cleanup_callable = None
     if connect_pc is not None:
         api_key = getattr(args, "api_key", None) or os.environ.get("VIP_CONNECT_API_KEY", "")
-        insecure = cfg.insecure if cfg else False
-        ca_bundle = cfg.ca_bundle if cfg else None
 
         def cleanup_callable(_url: str) -> None:  # noqa: F811
+            from vip.auth import resolve_url_scheme
             from vip.clients.connect import ConnectClient
 
-            # ``_url`` (== plan.chained_cleanup) is connect_pc.url before
-            # resolution; resolve via connect_pc itself instead so the
-            # inferred-scheme fallback (unavailable on a bare string) applies
-            # here too. This only ever runs when execute_uninstall_plan
-            # actually executes (--yes was passed) -- never during a dry-run
-            # plan preview.
-            resolved = _resolved_url(connect_pc, insecure=insecure, ca_bundle=ca_bundle)
+            # connect_pc.url was already resolved above -- this callable only
+            # ever runs when execute_uninstall_plan actually executes
+            # (--yes was passed), which is the same condition that already
+            # triggered the resolve above, so the printed plan and the URL
+            # used here are guaranteed to match. resolve_url_scheme is
+            # idempotent (it resets url_scheme_inferred once resolved), so
+            # calling it again here is a plain attribute read -- kept as a
+            # belt-and-suspenders safety net rather than trusted by omission.
+            resolved = resolve_url_scheme(connect_pc, insecure=insecure, ca_bundle=ca_bundle)
             with ConnectClient(resolved, api_key) as client:
                 client.cleanup_vip_content()
 
     rc = execute_uninstall_plan(
         plan,
         manifest_path=manifest_path,
-        yes=bool(getattr(args, "yes", False)),
+        yes=yes,
         cleanup_callable=cleanup_callable,
     )
     sys.exit(rc)
@@ -1227,8 +1227,11 @@ def run_cleanup(args: argparse.Namespace) -> None:
     # previously a scheme-less --connect-url was handed to ConnectClient
     # completely unnormalized (a bug in its own right -- httpx requires an
     # absolute URL) and never got the probe-and-fallback treatment below.
-    # config.connect/config.workbench are already ProductConfig instances
-    # (normalized by load_config), so the vip.toml path needs no wrapping.
+    # config.connect/config.workbench are already normalized ProductConfig
+    # instances -- every ProductConfig runs _normalize_url in its own
+    # __post_init__ regardless of how it was constructed, including the bare
+    # VIPConfig() that _load_cleanup_config() returns when no vip.toml exists
+    # -- so the vip.toml path needs no wrapping here.
     connect_pc: ProductConfig = ProductConfig(url=connect_arg) if connect_arg else config.connect
     workbench_pc: ProductConfig = (
         ProductConfig(url=workbench_arg) if workbench_arg else config.workbench
@@ -1243,9 +1246,10 @@ def run_cleanup(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     if connect_pc.url:
+        from vip.auth import resolve_url_scheme
         from vip.clients.connect import ConnectClient
 
-        connect_url = _resolved_url(
+        connect_url = resolve_url_scheme(
             connect_pc, insecure=config.insecure, ca_bundle=config.ca_bundle
         )
         print(f"Cleaning up VIP test content on Connect at {connect_url}")
@@ -1254,7 +1258,9 @@ def run_cleanup(args: argparse.Namespace) -> None:
         print(f"Deleted {deleted} VIP test content item(s)")
 
     if workbench_pc.url:
-        workbench_url = _resolved_url(
+        from vip.auth import resolve_url_scheme
+
+        workbench_url = resolve_url_scheme(
             workbench_pc, insecure=config.insecure, ca_bundle=config.ca_bundle
         )
         _cleanup_workbench_sessions(workbench_url, args, config)

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -17,7 +17,7 @@ from vip.reporting import VALID_FORMATS
 from vip.timeouts import scaled
 
 if TYPE_CHECKING:
-    from vip.config import VIPConfig
+    from vip.config import ProductConfig, VIPConfig
 
 # Default for ``vip verify --test-timeout``.  Generous enough for a full
 # Connect suite with several content deployments (each can take 3-5 minutes
@@ -723,6 +723,28 @@ def run_report(args: argparse.Namespace) -> None:
         webbrowser.open(output.resolve().as_uri())
 
 
+def _resolved_url(
+    pc: ProductConfig, *, insecure: bool = False, ca_bundle: Path | None = None
+) -> str:
+    """Resolve *pc*'s URL via ``resolve_url_scheme`` when its scheme was inferred.
+
+    Config loading only infers a scheme (``vip.config._normalize_url`` stays
+    network-free); this is the network-touching half, called right before
+    something in this module first talks to the server -- mirrors
+    ``src/vip_tests/conftest.py``'s fixture-level helper of the same name and
+    purpose. A URL with an explicit scheme (``url_scheme_inferred`` False) is
+    returned unchanged, no network call. Mutates ``pc.url`` in place so a
+    caller that reads ``pc.url`` again downstream (e.g. for a printed
+    message) sees the resolved value; ``resolve_url_scheme`` itself caches by
+    URL, so calling this more than once for the same product costs one probe.
+    """
+    if pc.url_scheme_inferred:
+        from vip.auth import resolve_url_scheme
+
+        pc.url = resolve_url_scheme(pc.url, insecure=insecure, ca_bundle=ca_bundle)
+    return pc.url
+
+
 def _collect_status(config: VIPConfig) -> dict:
     """Run health checks and return structured status data.
 
@@ -756,6 +778,7 @@ def _collect_status(config: VIPConfig) -> dict:
             products[name] = {"configured": False, "state": "skip", "detail": "not configured"}
             continue
         try:
+            _resolved_url(pc, insecure=config.insecure, ca_bundle=config.ca_bundle)
             if name == "connect":
                 client: ConnectClient | WorkbenchClient | PackageManagerClient = ConnectClient(
                     pc.url,
@@ -904,15 +927,24 @@ def run_uninstall(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    # Resolve Connect URL for chained cleanup.
-    connect_url = getattr(args, "connect_url", None)
-    if not connect_url:
+    # Resolve Connect URL for chained cleanup. A CLI flag wins over vip.toml;
+    # wrapping it in ProductConfig routes a scheme-less --connect-url through
+    # the same _normalize_url every other entry point uses (it was previously
+    # handed to ConnectClient completely unnormalized). cfg carries the TLS
+    # settings (insecure/ca_bundle) for the probe-and-fallback below when the
+    # URL came from vip.toml; a CLI-flag-only invocation has no cfg to draw
+    # those from, so it probes with defaults (verify=True).
+    from vip.config import ProductConfig
+
+    connect_arg = getattr(args, "connect_url", None)
+    connect_pc: ProductConfig | None = ProductConfig(url=connect_arg) if connect_arg else None
+    cfg = None
+    if connect_pc is None:
         if sys.version_info >= (3, 11):
             import tomllib as _tomllib
         else:
             import tomli as _tomllib  # type: ignore[no-redef]
 
-        cfg = None
         try:
             from vip.config import load_config
 
@@ -924,21 +956,30 @@ def run_uninstall(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
         if cfg and cfg.connect and cfg.connect.url:
-            connect_url = cfg.connect.url
+            connect_pc = cfg.connect
 
     plan = build_uninstall_plan(
         manifest=manifest,
-        connect_url=connect_url,
+        connect_url=connect_pc.url if connect_pc else None,
     )
 
     cleanup_callable = None
-    if connect_url:
+    if connect_pc is not None:
         api_key = getattr(args, "api_key", None) or os.environ.get("VIP_CONNECT_API_KEY", "")
+        insecure = cfg.insecure if cfg else False
+        ca_bundle = cfg.ca_bundle if cfg else None
 
-        def cleanup_callable(url: str) -> None:  # noqa: F811
+        def cleanup_callable(_url: str) -> None:  # noqa: F811
             from vip.clients.connect import ConnectClient
 
-            with ConnectClient(url, api_key) as client:
+            # ``_url`` (== plan.chained_cleanup) is connect_pc.url before
+            # resolution; resolve via connect_pc itself instead so the
+            # inferred-scheme fallback (unavailable on a bare string) applies
+            # here too. This only ever runs when execute_uninstall_plan
+            # actually executes (--yes was passed) -- never during a dry-run
+            # plan preview.
+            resolved = _resolved_url(connect_pc, insecure=insecure, ca_bundle=ca_bundle)
+            with ConnectClient(resolved, api_key) as client:
                 client.cleanup_vip_content()
 
     rc = execute_uninstall_plan(
@@ -1162,24 +1203,38 @@ def run_cleanup(args: argparse.Namespace) -> None:
     persist despite the API reporting success. The Connect/Workbench URLs
     come from ``--connect-url``/``--workbench-url`` or, if omitted, from
     ``[connect] url``/``[workbench] url`` in ``vip.toml``. At least one of
-    the two must resolve.
+    the two must resolve. A scheme-less URL defaults to ``https://`` and
+    falls back to ``http://`` if https doesn't answer (see
+    ``vip.config._normalize_url`` / ``vip.auth.resolve_url_scheme``).
     """
     _ensure_cli_logging()
-    connect_url = getattr(args, "connect_url", None)
+
+    from vip.config import ProductConfig
+
+    connect_arg = getattr(args, "connect_url", None)
     api_key = getattr(args, "api_key", None) or os.environ.get("VIP_CONNECT_API_KEY", "")
-    workbench_url = getattr(args, "workbench_url", None)
+    workbench_arg = getattr(args, "workbench_url", None)
 
     # Load vip.toml when present to fill in any URL not passed on the CLI, and
     # to supply TLS/auth settings for the Workbench path. Loaded quietly: an
     # explicit `vip cleanup --connect-url ...` with no vip.toml must not emit a
     # "Config file not found" warning (env-based credentials still apply).
     config = _load_cleanup_config()
-    if not connect_url and config.connect and config.connect.url:
-        connect_url = config.connect.url
-    if not workbench_url and config.workbench and config.workbench.url:
-        workbench_url = config.workbench.url
 
-    if not connect_url and not workbench_url:
+    # A CLI flag wins over vip.toml, as before. Wrapping the CLI arg in
+    # ProductConfig routes it through the same _normalize_url a bare
+    # hostname gets from every other entry point (vip verify, vip status):
+    # previously a scheme-less --connect-url was handed to ConnectClient
+    # completely unnormalized (a bug in its own right -- httpx requires an
+    # absolute URL) and never got the probe-and-fallback treatment below.
+    # config.connect/config.workbench are already ProductConfig instances
+    # (normalized by load_config), so the vip.toml path needs no wrapping.
+    connect_pc: ProductConfig = ProductConfig(url=connect_arg) if connect_arg else config.connect
+    workbench_pc: ProductConfig = (
+        ProductConfig(url=workbench_arg) if workbench_arg else config.workbench
+    )
+
+    if not connect_pc.url and not workbench_pc.url:
         print(
             "Error: no Connect or Workbench URL found. Pass --connect-url / "
             "--workbench-url, or set [connect] url / [workbench] url in vip.toml.",
@@ -1187,15 +1242,21 @@ def run_cleanup(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    if connect_url:
+    if connect_pc.url:
         from vip.clients.connect import ConnectClient
 
+        connect_url = _resolved_url(
+            connect_pc, insecure=config.insecure, ca_bundle=config.ca_bundle
+        )
         print(f"Cleaning up VIP test content on Connect at {connect_url}")
         with ConnectClient(connect_url, api_key) as client:
             deleted = client.cleanup_vip_content()
         print(f"Deleted {deleted} VIP test content item(s)")
 
-    if workbench_url:
+    if workbench_pc.url:
+        workbench_url = _resolved_url(
+            workbench_pc, insecure=config.insecure, ca_bundle=config.ca_bundle
+        )
         _cleanup_workbench_sessions(workbench_url, args, config)
 
     print("Cleanup completed successfully")

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -15,10 +15,25 @@ else:
     import tomli as tomllib
 
 
-def _normalize_url(url: str) -> str:
+def _normalize_url(url: str) -> tuple[str, bool]:
     """Ensure a URL has a scheme and, for sub-path URLs, a trailing slash.
 
-    Scheme normalization: if no scheme is present, ``http://`` is added.
+    Scheme normalization: if no scheme is present, ``https://`` is added --
+    modern Posit Team deployments are essentially always TLS-terminated, and
+    defaulting a bare hostname to plaintext HTTP breaks API-key minting (and
+    anything else that doesn't follow redirects) against a deployment that
+    redirects HTTP -> HTTPS (see #537). The returned bool reports whether the
+    scheme was *inferred* (no scheme was given) rather than *explicit* (the
+    caller wrote ``http://`` or ``https://`` themselves); an explicit scheme
+    is authoritative and must never be second-guessed.
+
+    A scheme-less host that turns out to only serve plain HTTP still needs a
+    way back to ``http://`` -- that requires an actual network probe, which
+    has no place here. This function must stay pure and network-free so
+    config loading (including CI's ``--collect-only`` dry runs) never dials
+    out. Callers that are about to talk to the URL for real use the returned
+    "inferred" flag to decide whether ``vip.auth.resolve_url_scheme`` may
+    fall back to ``http://`` if ``https://`` doesn't answer.
 
     Trailing-slash normalization: a trailing slash is added **only** when the
     URL has a non-root path component (e.g. ``/pwb`` or ``/connect``).  Without
@@ -30,9 +45,10 @@ def _normalize_url(url: str) -> str:
     ``f"{url}/__api__/..."`` without introducing double slashes.
     """
     if not url:
-        return url
-    if not url.startswith(("http://", "https://")):
-        url = f"http://{url}"
+        return url, False
+    inferred = not url.startswith(("http://", "https://"))
+    if inferred:
+        url = f"https://{url}"
     parsed = urlparse(url)
     path = parsed.path
     if path and path != "/":
@@ -42,7 +58,7 @@ def _normalize_url(url: str) -> str:
     else:
         # Host-only URL: normalise to no trailing slash so f"{url}/..." is safe.
         path = ""
-    return urlunparse(parsed._replace(path=path))
+    return urlunparse(parsed._replace(path=path)), inferred
 
 
 def _as_str_list(value: object, field_name: str) -> list[str]:
@@ -67,9 +83,17 @@ class ProductConfig:
     enabled: bool = True
     url: str = ""
     version: str | None = None
+    # True when ``url`` was given without a scheme and ``https://`` was
+    # inferred by ``_normalize_url``. Read by ``vip.auth.resolve_url_scheme``
+    # to decide whether an unreachable https:// may fall back to http://; an
+    # explicit scheme (this flag False) is never second-guessed. Not part of
+    # the config's public identity -- excluded from repr/equality like the
+    # dataclass-generated repr already is for the subclasses below, which
+    # override ``__repr__`` entirely.
+    url_scheme_inferred: bool = field(default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        self.url = _normalize_url(self.url)
+        self.url, self.url_scheme_inferred = _normalize_url(self.url)
 
     @property
     def is_configured(self) -> bool:

--- a/src/vip/config.py
+++ b/src/vip/config.py
@@ -84,12 +84,18 @@ class ProductConfig:
     url: str = ""
     version: str | None = None
     # True when ``url`` was given without a scheme and ``https://`` was
-    # inferred by ``_normalize_url``. Read by ``vip.auth.resolve_url_scheme``
-    # to decide whether an unreachable https:// may fall back to http://; an
-    # explicit scheme (this flag False) is never second-guessed. Not part of
-    # the config's public identity -- excluded from repr/equality like the
-    # dataclass-generated repr already is for the subclasses below, which
-    # override ``__repr__`` entirely.
+    # inferred by ``_normalize_url``. ``vip.auth.resolve_url_scheme`` consults
+    # this to decide whether an unreachable https:// may fall back to
+    # http://, and resets it to False once resolved -- it tracks a transient
+    # "has this URL been vetted yet" state, not a value the caller chose, so
+    # it is excluded from equality/repr for the same reason a cache-hit flag
+    # would be: two configs that are otherwise identical but differ only in
+    # whether resolution has already run should compare equal, even though a
+    # network probe happening on one and not the other is a real (if
+    # temporary) behavioral difference this exclusion accepts as out of scope
+    # for `==`. Nothing in this codebase compares ProductConfig with `==`
+    # today, so the tradeoff is currently inert -- but it is intentional
+    # should that change, not an oversight.
     url_scheme_inferred: bool = field(default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -267,6 +267,8 @@ def pytest_configure(config: pytest.Config) -> None:
                 cache_path=cache_path,
                 insecure=vip_cfg.insecure,
                 ca_bundle=vip_cfg.ca_bundle,
+                connect_url_scheme_inferred=vip_cfg.connect.url_scheme_inferred,
+                workbench_url_scheme_inferred=vip_cfg.workbench.url_scheme_inferred,
             )
             config.stash[_auth_session_key] = session
             if session.api_key:
@@ -311,6 +313,8 @@ def pytest_configure(config: pytest.Config) -> None:
                     verbose=config.getoption("--vip-verbose", default=False),
                     insecure=vip_cfg.insecure,
                     ca_bundle=vip_cfg.ca_bundle,
+                    connect_url_scheme_inferred=vip_cfg.connect.url_scheme_inferred,
+                    workbench_url_scheme_inferred=vip_cfg.workbench.url_scheme_inferred,
                 )
             except AuthConfigError as exc:
                 raise pytest.UsageError(str(exc)) from None

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -274,9 +274,18 @@ def pytest_configure(config: pytest.Config) -> None:
             if session.api_key:
                 vip_cfg.connect.api_key = session.api_key
             # Auth may have rewritten the Connect URL (sub-path dashboard +
-            # root API).  Sync so the test clients hit the same base mint did.
+            # root API, or an inferred https:// downgraded to http:// -- see
+            # resolve_url_scheme).  Sync so the test clients hit the same
+            # base mint/login did.
             if session._connect_url and connect_url and session._connect_url != connect_url:
                 vip_cfg.connect.url = session._connect_url
+            # Same sync for Workbench: an inferred https:// that resolve_url_scheme
+            # downgraded to http:// must reach vip_cfg.workbench.url the same way,
+            # not rely on conftest.py's fixture-level resolve_url_scheme call
+            # hitting a cache entry keyed on the URL string as an unstated
+            # side-channel (issue #562 comment-accuracy review).
+            if session._workbench_url and wb_url and session._workbench_url != wb_url:
+                vip_cfg.workbench.url = session._workbench_url
             if not session.api_key and connect_url:
                 warnings.warn(
                     "VIP: --interactive-auth could not mint an API key. "
@@ -322,9 +331,14 @@ def pytest_configure(config: pytest.Config) -> None:
             if session.api_key:
                 vip_cfg.connect.api_key = session.api_key
             # Auth may have rewritten the Connect URL (sub-path dashboard +
-            # root API).  Sync so the test clients hit the same base mint did.
+            # root API, or an inferred https:// downgraded to http:// -- see
+            # resolve_url_scheme).  Sync so the test clients hit the same
+            # base mint/login did.
             if session._connect_url and connect_url and session._connect_url != connect_url:
                 vip_cfg.connect.url = session._connect_url
+            # Same sync for Workbench -- see the --interactive-auth branch above.
+            if session._workbench_url and wb_url and session._workbench_url != wb_url:
+                vip_cfg.workbench.url = session._workbench_url
             if not session.api_key and connect_url:
                 warnings.warn(
                     "VIP: --headless-auth could not mint an API key. "

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -11,7 +11,7 @@ from vip.clients.connect import ConnectClient
 from vip.clients.kubernetes import KubernetesClient
 from vip.clients.packagemanager import PackageManagerClient
 from vip.clients.workbench import WorkbenchClient
-from vip.config import PerformanceConfig, ProductConfig, VIPConfig
+from vip.config import PerformanceConfig, VIPConfig
 from vip.plugin import (
     _auth_mode_key,
     _auth_session_key,
@@ -46,26 +46,6 @@ def vip_verbose(request: pytest.FixtureRequest) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _resolved_url(pc: ProductConfig, vip_config: VIPConfig) -> str:
-    """Return *pc*'s URL, falling back to http:// if an inferred https:// scheme
-    doesn't answer.
-
-    ``--interactive-auth``/``--headless-auth`` already resolve this in
-    ``vip.plugin`` before any browser touches the URL. This covers the
-    ``--api-auth``/``--no-auth`` paths, where no auth flow runs and these
-    fixtures are the first thing to talk to the server. Mutates ``pc.url``
-    in place on first call so every fixture that reads it afterward --
-    whichever one a test asks for first -- converges on the same value;
-    ``resolve_url_scheme`` itself caches by URL, so calling this from more
-    than one fixture for the same product only probes the network once.
-    """
-    if pc.url_scheme_inferred:
-        pc.url = resolve_url_scheme(
-            pc.url, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
-        )
-    return pc.url
-
-
 @pytest.fixture(scope="session")
 def connect_client(request: pytest.FixtureRequest, vip_config: VIPConfig) -> ConnectClient | None:
     if not vip_config.connect.is_configured:
@@ -75,7 +55,18 @@ def connect_client(request: pytest.FixtureRequest, vip_config: VIPConfig) -> Con
         # ``return`` here would raise "connect_client did not yield a value".
         yield None
         return
-    url = _resolved_url(vip_config.connect, vip_config)
+    # --interactive-auth/--headless-auth already resolve this in vip.plugin
+    # before any browser touches the URL; resolve_url_scheme no-ops (and
+    # doesn't touch the network) if that already happened -- this call is
+    # what covers --api-auth/--no-auth, where no auth flow runs and this
+    # fixture is the first thing to talk to the server. resolve_url_scheme
+    # mutates vip_config.connect.url in place, so every fixture that reads it
+    # afterward -- whichever one a test asks for first -- converges on the
+    # same value, and its own cache means asking from more than one fixture
+    # for the same product only probes the network once.
+    url = resolve_url_scheme(
+        vip_config.connect, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+    )
     # A registered client-auth provider (e.g. Snowflake JWT) authenticates the
     # request itself, so a Connect API key is not required in that case.
     auth = build_client_auth(vip_config, "connect", url)
@@ -102,7 +93,9 @@ def connect_client(request: pytest.FixtureRequest, vip_config: VIPConfig) -> Con
 
 @pytest.fixture(scope="session")
 def connect_url(vip_config: VIPConfig) -> str:
-    return _resolved_url(vip_config.connect, vip_config)
+    return resolve_url_scheme(
+        vip_config.connect, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+    )
 
 
 @pytest.fixture(scope="session")
@@ -115,7 +108,9 @@ def workbench_client(
         # "fixture did not yield a value" from a bare return.
         yield None
         return
-    url = _resolved_url(vip_config.workbench, vip_config)
+    url = resolve_url_scheme(
+        vip_config.workbench, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+    )
     auth = build_client_auth(vip_config, "workbench", url)
     # Same gateway-cookie injection as connect_client: the identical OIDC proxy
     # that fronts Connect also fronts Workbench on these deployments.
@@ -135,7 +130,9 @@ def workbench_client(
 
 @pytest.fixture(scope="session")
 def workbench_url(vip_config: VIPConfig) -> str:
-    return _resolved_url(vip_config.workbench, vip_config)
+    return resolve_url_scheme(
+        vip_config.workbench, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+    )
 
 
 @pytest.fixture(scope="session")
@@ -154,7 +151,9 @@ def kubernetes_client(vip_config: VIPConfig) -> KubernetesClient | None:
 def pm_client(vip_config: VIPConfig) -> PackageManagerClient | None:
     if not vip_config.package_manager.is_configured:
         return None
-    url = _resolved_url(vip_config.package_manager, vip_config)
+    url = resolve_url_scheme(
+        vip_config.package_manager, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+    )
     auth = build_client_auth(vip_config, "package_manager", url)
     client = PackageManagerClient(
         url,
@@ -169,7 +168,9 @@ def pm_client(vip_config: VIPConfig) -> PackageManagerClient | None:
 
 @pytest.fixture(scope="session")
 def pm_url(vip_config: VIPConfig) -> str:
-    return _resolved_url(vip_config.package_manager, vip_config)
+    return resolve_url_scheme(
+        vip_config.package_manager, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/vip_tests/conftest.py
+++ b/src/vip_tests/conftest.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import pytest
 from pytest_bdd import given
 
+from vip.auth import resolve_url_scheme
 from vip.client_auth import build_client_auth
 from vip.clients.connect import ConnectClient
 from vip.clients.kubernetes import KubernetesClient
 from vip.clients.packagemanager import PackageManagerClient
 from vip.clients.workbench import WorkbenchClient
-from vip.config import PerformanceConfig, VIPConfig
+from vip.config import PerformanceConfig, ProductConfig, VIPConfig
 from vip.plugin import (
     _auth_mode_key,
     _auth_session_key,
@@ -45,6 +46,26 @@ def vip_verbose(request: pytest.FixtureRequest) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _resolved_url(pc: ProductConfig, vip_config: VIPConfig) -> str:
+    """Return *pc*'s URL, falling back to http:// if an inferred https:// scheme
+    doesn't answer.
+
+    ``--interactive-auth``/``--headless-auth`` already resolve this in
+    ``vip.plugin`` before any browser touches the URL. This covers the
+    ``--api-auth``/``--no-auth`` paths, where no auth flow runs and these
+    fixtures are the first thing to talk to the server. Mutates ``pc.url``
+    in place on first call so every fixture that reads it afterward --
+    whichever one a test asks for first -- converges on the same value;
+    ``resolve_url_scheme`` itself caches by URL, so calling this from more
+    than one fixture for the same product only probes the network once.
+    """
+    if pc.url_scheme_inferred:
+        pc.url = resolve_url_scheme(
+            pc.url, insecure=vip_config.insecure, ca_bundle=vip_config.ca_bundle
+        )
+    return pc.url
+
+
 @pytest.fixture(scope="session")
 def connect_client(request: pytest.FixtureRequest, vip_config: VIPConfig) -> ConnectClient | None:
     if not vip_config.connect.is_configured:
@@ -54,9 +75,10 @@ def connect_client(request: pytest.FixtureRequest, vip_config: VIPConfig) -> Con
         # ``return`` here would raise "connect_client did not yield a value".
         yield None
         return
+    url = _resolved_url(vip_config.connect, vip_config)
     # A registered client-auth provider (e.g. Snowflake JWT) authenticates the
     # request itself, so a Connect API key is not required in that case.
-    auth = build_client_auth(vip_config, "connect", vip_config.connect.url)
+    auth = build_client_auth(vip_config, "connect", url)
     if auth is None:
         require_connect_api_key(vip_config)
     # When an interactive/headless auth session exists, load the gateway cookies
@@ -67,7 +89,7 @@ def connect_client(request: pytest.FixtureRequest, vip_config: VIPConfig) -> Con
     session = request.config.stash.get(_auth_session_key, None)
     cookies = session.load_cookies() if session is not None else None
     client = ConnectClient(
-        vip_config.connect.url,
+        url,
         api_key=vip_config.connect.api_key,
         insecure=vip_config.insecure,
         ca_bundle=vip_config.ca_bundle,
@@ -80,7 +102,7 @@ def connect_client(request: pytest.FixtureRequest, vip_config: VIPConfig) -> Con
 
 @pytest.fixture(scope="session")
 def connect_url(vip_config: VIPConfig) -> str:
-    return vip_config.connect.url
+    return _resolved_url(vip_config.connect, vip_config)
 
 
 @pytest.fixture(scope="session")
@@ -93,13 +115,14 @@ def workbench_client(
         # "fixture did not yield a value" from a bare return.
         yield None
         return
-    auth = build_client_auth(vip_config, "workbench", vip_config.workbench.url)
+    url = _resolved_url(vip_config.workbench, vip_config)
+    auth = build_client_auth(vip_config, "workbench", url)
     # Same gateway-cookie injection as connect_client: the identical OIDC proxy
     # that fronts Connect also fronts Workbench on these deployments.
     session = request.config.stash.get(_auth_session_key, None)
     cookies = session.load_cookies() if session is not None else None
     client = WorkbenchClient(
-        vip_config.workbench.url,
+        url,
         api_key=vip_config.workbench.api_key,
         insecure=vip_config.insecure,
         ca_bundle=vip_config.ca_bundle,
@@ -112,7 +135,7 @@ def workbench_client(
 
 @pytest.fixture(scope="session")
 def workbench_url(vip_config: VIPConfig) -> str:
-    return vip_config.workbench.url
+    return _resolved_url(vip_config.workbench, vip_config)
 
 
 @pytest.fixture(scope="session")
@@ -131,9 +154,10 @@ def kubernetes_client(vip_config: VIPConfig) -> KubernetesClient | None:
 def pm_client(vip_config: VIPConfig) -> PackageManagerClient | None:
     if not vip_config.package_manager.is_configured:
         return None
-    auth = build_client_auth(vip_config, "package_manager", vip_config.package_manager.url)
+    url = _resolved_url(vip_config.package_manager, vip_config)
+    auth = build_client_auth(vip_config, "package_manager", url)
     client = PackageManagerClient(
-        vip_config.package_manager.url,
+        url,
         token=vip_config.package_manager.token,
         insecure=vip_config.insecure,
         ca_bundle=vip_config.ca_bundle,
@@ -145,7 +169,7 @@ def pm_client(vip_config: VIPConfig) -> PackageManagerClient | None:
 
 @pytest.fixture(scope="session")
 def pm_url(vip_config: VIPConfig) -> str:
-    return vip_config.package_manager.url
+    return _resolved_url(vip_config.package_manager, vip_config)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #537.

## The two defects

`vip verify --connect-url connect.posit.it` (no scheme) failed to mint a Connect API key against any deployment that redirects HTTP to HTTPS, leaving every Connect API test unauthenticated. Two independent causes:

`_normalize_url` defaulted a scheme-less URL to `http://`, which is wrong for essentially every modern Posit deployment. It now infers `https://`.

The API-key mint client omitted `follow_redirects=True`, so `GET http://.../__api__/v1/user` returned 301 and was read as a mint failure. `_resolve_connect_api_base` already passed that flag on its probes; the mint client now matches.

## Why an inferred scheme still needs a way back

Defaulting to https outright would break a genuinely plaintext deployment addressed by bare hostname. So the scheme is inferred, not decided: `_normalize_url` stays pure and network-free -- config loading, including CI's `--collect-only` runs, never dials out -- and records only whether it had to guess. `vip.auth.resolve_url_scheme` does the probing later, at first contact with the server.

The fallback rules are deliberately narrow. Only a transport-level failure (`httpx.TransportError`: connection refused, DNS, TLS, timeout) counts as "https doesn't answer". An https server returning 500 is answering, so it is kept. A URL the user gave a scheme for is never touched -- the function takes no `inferred` parameter, so there is no way to call it on an explicit URL by accident. Results are cached per URL, so multiple call sites cost one round trip.

## Every entry point, not just the reported one

The fallback is wired into the interactive and headless auth flows, the `connect_client`/`workbench_client`/`pm_client` fixtures, `vip status`, `vip cleanup`, and `vip uninstall`'s chained cleanup.

That breadth is load-bearing rather than thoroughness for its own sake: with the fallback wired only into `vip verify`, the https default would have *regressed* the other subcommands. A plaintext deployment addressed by bare hostname would keep working under `vip verify` and start failing under `vip status` -- same URL, same config, one command working and the other not.

`vip cleanup` and `vip uninstall` additionally passed `--connect-url` to `ConnectClient` without normalizing it at all, so a bare hostname raised inside httpx. Both now route through `ProductConfig` like every other entry point. That flag therefore goes from unconditionally erroring on a bare hostname to working -- a fix, not a behaviour change to an already-working path.

In `vip uninstall` the probe happens inside the chained-cleanup callable rather than at closure creation, so a dry-run plan preview makes no network call. There is a test asserting zero `httpx.get` calls in the dry-run path.

## Verification

Selftests cover: explicit `http://` and `https://` both preserved, an inferred scheme preferring https, falling back on `ConnectError`/`ConnectTimeout`, *not* falling back on an https 5xx, the downgrade being logged, the caching, and the probe honouring `verify`/`follow_redirects`. Each newly wired call site has explicit-never-probes and inferred-falls-back coverage, plus the dry-run no-probe assertion.

End-to-end: a real plaintext server 307-redirecting to a real self-signed HTTPS mock Connect proves the mint flow now completes through a redirect.

Full suite, ruff and mypy clean; the only failures are the two known macOS-sandbox timing flakes in `test_load_engine.py`, reproduced on an unmodified tree.

## Found while doing this, filed separately

#561 -- `_create_api_key_via_session` raises an uncaught `AttributeError` if a proxy redirects the key-creation POST with 301/302 rather than 307/308, because httpx downgrades POST to GET and the response becomes a list. `follow_redirects=True` is what makes that path reachable, so it is worth reading alongside this PR. Not fixed here.
