### PR TITLE
fix(workbench): cap Positron readback attempts and name a wedged console

### DIFF
--- a/selftests/test_workbench_exec.py
+++ b/selftests/test_workbench_exec.py
@@ -838,6 +838,73 @@ class TestReadFileRouting:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# _positron_console_state_label / _positron_wedged_state_detail (issue #390)
+# ---------------------------------------------------------------------------
+
+
+class TestPositronConsoleStateLabel:
+    """``_positron_console_state_label`` must be a safe, best-effort read: it
+    is polled on every terminal_run iteration, so it can never raise, and its
+    absence must mean "unknown", not "ready" (see the caveat in its
+    docstring -- a healthy console was never directly observed in the
+    investigation, only a permanently-"Starting" one)."""
+
+    def test_returns_stripped_text_when_present(self):
+        page = MagicMock()
+        page.locator.return_value.first.count.return_value = 1
+        page.locator.return_value.first.text_content.return_value = "  Starting  "
+
+        assert exec_mod._positron_console_state_label(page) == "Starting"
+
+    def test_returns_none_when_element_absent(self):
+        page = MagicMock()
+        page.locator.return_value.first.count.return_value = 0
+
+        assert exec_mod._positron_console_state_label(page) is None
+
+    def test_returns_none_when_text_content_empty(self):
+        page = MagicMock()
+        page.locator.return_value.first.count.return_value = 1
+        page.locator.return_value.first.text_content.return_value = ""
+
+        assert exec_mod._positron_console_state_label(page) is None
+
+    def test_never_raises_on_detached_node(self):
+        """A detached element or closed page must not turn a diagnostic read
+        into a new failure mode -- swallow and report "unknown"."""
+        page = MagicMock()
+        page.locator.side_effect = RuntimeError("page closed")
+
+        assert exec_mod._positron_console_state_label(page) is None
+
+    def test_scoped_under_console_panel(self):
+        """The selector must be scoped under CONSOLE_PANEL, not the bare
+        class name -- ``.state-label`` alone is not distinctive enough."""
+        page = MagicMock()
+        page.locator.return_value.first.count.return_value = 0
+
+        exec_mod._positron_console_state_label(page)
+
+        selector = page.locator.call_args[0][0]
+        assert PositronSession.CONSOLE_PANEL in selector
+        assert PositronSession.STATE_LABEL in selector
+
+
+class TestPositronWedgedStateDetail:
+    def test_empty_when_no_label(self, monkeypatch):
+        monkeypatch.setattr(exec_mod, "_positron_console_state_label", lambda p: None)
+
+        assert exec_mod._positron_wedged_state_detail(MagicMock()) == ""
+
+    def test_includes_label_text_when_present(self, monkeypatch):
+        monkeypatch.setattr(exec_mod, "_positron_console_state_label", lambda p: "Starting")
+
+        detail = exec_mod._positron_wedged_state_detail(MagicMock())
+
+        assert "'Starting'" in detail
+
+
 class TestVisibleTerminalInput:
     """A session may hold more than one terminal (VS Code's Python extension
     spawns one to activate a venv), so the input must be resolved by the
@@ -961,6 +1028,130 @@ class TestTerminalRun:
 
         with pytest.raises(ExecError, match="timed out"):
             exec_mod.terminal_run(page, "sleep 999", timeout=10)
+
+    def test_positron_attempt_timeout_is_capped(self, monkeypatch):
+        """Positron attempts must be capped to _POSITRON_READBACK_ATTEMPT_MS,
+        not handed the outer loop's entire remaining budget: read_file's
+        Positron path blocks for its whole timeout before giving up, so one
+        unresponsive attempt would otherwise starve every retry this loop is
+        meant to make (issue #390)."""
+        self._patch_common(monkeypatch, ide="positron")
+        monkeypatch.setattr(exec_mod, "_positron_console_state_label", lambda p: None)
+        mock_read_file = MagicMock(return_value="ok\nVIP_DONE_deadbeef:0")
+        monkeypatch.setattr(exec_mod, "read_file", mock_read_file)
+        page = MagicMock()
+
+        # timeout is far larger than _POSITRON_READBACK_ATTEMPT_MS, so an
+        # uncapped attempt would receive close to the full value.
+        exec_mod.terminal_run(page, "echo ok", timeout=120_000)
+
+        called_timeout = mock_read_file.call_args.kwargs["timeout"]
+        assert called_timeout <= exec_mod._POSITRON_READBACK_ATTEMPT_MS
+
+    def test_rstudio_attempt_timeout_is_not_capped(self, monkeypatch):
+        """RStudio's console is ready immediately (no retry loop to protect),
+        so its attempts must keep receiving the full remaining budget --
+        the cap is Positron-specific."""
+        self._patch_common(monkeypatch, ide="rstudio")
+        mock_read_file = MagicMock(return_value="ok\nVIP_DONE_deadbeef:0")
+        monkeypatch.setattr(exec_mod, "read_file", mock_read_file)
+        page = MagicMock()
+
+        exec_mod.terminal_run(page, "echo ok", timeout=120_000)
+
+        called_timeout = mock_read_file.call_args.kwargs["timeout"]
+        assert called_timeout > exec_mod._POSITRON_READBACK_ATTEMPT_MS
+
+    def test_positron_never_polls_state_label_for_other_ides(self, monkeypatch):
+        """The wedge check is Positron-specific; RStudio/VS Code must never
+        even query the state label."""
+        self._patch_common(monkeypatch, ide="rstudio")
+        monkeypatch.setattr(
+            exec_mod, "read_file", MagicMock(return_value="ok\nVIP_DONE_deadbeef:0")
+        )
+        mock_label = MagicMock(return_value=None)
+        monkeypatch.setattr(exec_mod, "_positron_console_state_label", mock_label)
+        page = MagicMock()
+
+        exec_mod.terminal_run(page, "echo ok", timeout=1_000)
+
+        mock_label.assert_not_called()
+
+    class _SteppingClock:
+        """A fake ``time.monotonic`` that advances by *step* seconds per call.
+
+        terminal_run's Positron branch calls ``time.monotonic()`` several times
+        per loop iteration (deadline check, remaining-budget calc, wedge-timer
+        bookkeeping); a fixed step per call is enough to deterministically walk
+        past the wedged threshold within a couple of iterations without relying
+        on wall-clock time or ``time.sleep``.
+        """
+
+        def __init__(self, step=20.0):
+            self._t = 0.0
+            self._step = step
+
+        def __call__(self):
+            self._t += self._step
+            return self._t
+
+    def test_positron_fails_fast_when_console_stuck_starting(self, monkeypatch):
+        """Regression coverage for issue #390: a console whose status label
+        reads "Starting" for longer than _POSITRON_WEDGED_THRESHOLD_S must
+        raise a specific, actionable ExecError well before the full timeout
+        elapses, instead of silently consuming the whole budget."""
+        self._patch_common(monkeypatch, ide="positron")
+        monkeypatch.setattr(exec_mod, "read_file", MagicMock(return_value="still starting..."))
+        monkeypatch.setattr(exec_mod, "_positron_console_state_label", lambda p: "Starting")
+        monkeypatch.setattr(exec_mod.time, "sleep", lambda s: None)
+        monkeypatch.setattr(exec_mod.time, "monotonic", self._SteppingClock(step=20.0))
+        page = MagicMock()
+
+        # A timeout far larger than _POSITRON_WEDGED_THRESHOLD_S: if the wedge
+        # check did not fire, this would either loop for a very long time
+        # (real timeout) or raise the generic "timed out" ExecError instead.
+        with pytest.raises(ExecError, match="wedged") as excinfo:
+            exec_mod.terminal_run(page, "git clone ...", timeout=600_000)
+
+        assert "Starting" in str(excinfo.value)
+        assert "390" in str(excinfo.value)
+
+    def test_positron_state_label_none_does_not_trigger_wedge_detection(self, monkeypatch):
+        """A console whose status label is absent/unreadable (an older
+        Positron build, or a genuinely healthy session where the investigation
+        never observed the label at all) must fall back to today's behavior --
+        the plain timeout -- rather than being treated as wedged."""
+        self._patch_common(monkeypatch, ide="positron")
+        monkeypatch.setattr(exec_mod, "read_file", MagicMock(return_value="still running..."))
+        monkeypatch.setattr(exec_mod, "_positron_console_state_label", lambda p: None)
+        monkeypatch.setattr(exec_mod.time, "sleep", lambda s: None)
+        page = MagicMock()
+
+        with pytest.raises(ExecError, match="timed out") as excinfo:
+            exec_mod.terminal_run(page, "sleep 999", timeout=10)
+
+        assert "wedged" not in str(excinfo.value)
+
+    def test_positron_wedge_timer_resets_when_label_changes(self, monkeypatch):
+        """A status label that moves off "Starting" (even transiently) must
+        reset the wedge timer -- only a *continuous* "Starting" reading is
+        evidence of a hang, not a single slow poll."""
+        self._patch_common(monkeypatch, ide="positron")
+        monkeypatch.setattr(exec_mod, "read_file", MagicMock(return_value="still running..."))
+        # Alternate between "Starting" and "Idle" on every call, so the
+        # continuous-duration tracker never accumulates enough evidence to fire.
+        labels = iter(["Starting", "Idle"] * 50)
+        monkeypatch.setattr(
+            exec_mod, "_positron_console_state_label", lambda p: next(labels, "Idle")
+        )
+        monkeypatch.setattr(exec_mod.time, "sleep", lambda s: None)
+        monkeypatch.setattr(exec_mod.time, "monotonic", self._SteppingClock(step=20.0))
+        page = MagicMock()
+
+        with pytest.raises(ExecError, match="timed out") as excinfo:
+            exec_mod.terminal_run(page, "sleep 999", timeout=600_000)
+
+        assert "wedged" not in str(excinfo.value)
 
     def _patch_vscode(self, monkeypatch, content):
         """VS Code polls via editor-open/read/close instead of ``read_file``."""

--- a/src/vip_tests/workbench/exec.py
+++ b/src/vip_tests/workbench/exec.py
@@ -266,6 +266,11 @@ _POSITRON_ACTIVE_CONSOLE = PositronSession.ACTIVE_CONSOLE
 _POSITRON_CONSOLE_INPUT = PositronSession.CONSOLE_INPUT
 _POSITRON_CONSOLE_LINES = f"{PositronSession.ACTIVE_CONSOLE} div span"
 _POSITRON_CONSOLE_READY = f"{PositronSession.ACTIVE_CONSOLE} .active-line-number"
+# Kernel/interpreter status label rendered inside the console panel (issue
+# #390 diagnostics). Scoped under the panel rather than the active console
+# instance: confirmed live to be present while the interpreter is still
+# starting, independently of which console instance is currently active.
+_POSITRON_STATE_LABEL = f"{PositronSession.CONSOLE_PANEL} {PositronSession.STATE_LABEL}"
 # The Console and Terminal share the bottom panel; a prior terminal_run leaves
 # the Terminal tab selected, hiding the console. Activate the Console tab first.
 _POSITRON_CONSOLE_TAB = PositronSession.CONSOLE_TAB
@@ -283,6 +288,28 @@ _POSITRON_R_GRACE_POLLS = 10
 # console hidden behind the Terminal is removed from the DOM on some Positron
 # builds, so we activate + briefly poll before concluding no console exists.
 _POSITRON_REACTIVATE_POLLS = 3
+# terminal_run's Positron branch (below) re-reads the marker file via a fresh
+# console-eval call on every poll iteration. positron_eval_r/positron_eval_python
+# each block for their *entire* passed-in timeout before giving up, so handing
+# them the outer loop's whole remaining budget on every attempt means a single
+# unresponsive attempt consumes it all -- the "poll every second" loop only ever
+# gets one real try (see issue #390 investigation). Cap each attempt to a
+# sub-budget generous enough for the happy path (prompt-wait + eval normally
+# resolve in well under a second once a console is up) while still leaving room
+# for dozens of retries across a typical multi-minute terminal_run timeout.
+_POSITRON_READBACK_ATTEMPT_MS = 10_000
+# How long the console's status label (see _positron_console_state_label) may
+# continuously read "Starting" before terminal_run treats it as wedged rather
+# than "still warming up", and fails fast instead of waiting out the full
+# timeout. Chosen well above the ~10s cold-start budgets already trusted
+# elsewhere in this file (_POSITRON_POLL_MS * _POSITRON_R_GRACE_POLLS,
+# ensure_positron_console's own default timeout), so a legitimately slow --
+# but eventually successful -- cold start is not mistaken for a hang. This
+# value was not validated against a session that recovers from "Starting" (the
+# investigation's repro environment never did); treat it as a conservative
+# extrapolation, not a measured threshold, and revisit if it proves too eager
+# or too slow once tested against a real deployment.
+_POSITRON_WEDGED_THRESHOLD_S = 45.0
 
 
 def ensure_positron_console(page: Page, timeout: int = 45_000) -> bool:
@@ -408,6 +435,43 @@ def _activate_positron_console(page: Page) -> None:
             pass
 
 
+def _positron_console_state_label(page: Page) -> str | None:
+    """Return the console panel's kernel/interpreter status label, if present.
+
+    Positron renders a short status label (e.g. "Starting") inside the console
+    panel while the interpreter is not yet interactive; it is confirmed live to
+    persist indefinitely on a kernel that never becomes ready to execute (issue
+    #390). Idle/ready consoles were not observed to render this element in the
+    same investigation, but that absence was never directly confirmed against a
+    healthy session -- treat ``None`` as "unknown", not "ready".
+
+    Best-effort and never raises: returns ``None`` if the element is absent, or
+    if reading it fails for any reason (detached node, closed page, etc.).
+    """
+    try:
+        label = page.locator(_POSITRON_STATE_LABEL).first
+        if label.count() == 0:
+            return None
+        text = label.text_content(timeout=_POSITRON_PROMPT_POLL_MS)
+        return text.strip() if text else None
+    except Exception:
+        return None
+
+
+def _positron_wedged_state_detail(page: Page) -> str:
+    """Return a human-readable suffix describing the console's status label.
+
+    Used to enrich a "the end marker never appeared" ExecError with ground
+    truth about *why*, when available, rather than leaving the caller to guess
+    whether the interpreter was still warming up or genuinely stuck. Returns an
+    empty string when no status label is present (nothing to add).
+    """
+    state = _positron_console_state_label(page)
+    if not state:
+        return ""
+    return f" Console status label reads {state!r} -- the interpreter may not be accepting input."
+
+
 # Interactive prompt shown on the active console line once the interpreter is
 # ready for input. Typing during "R x.y.z starting." is silently dropped and
 # leaves the REPL at a "+" continuation prompt, so we wait for one of these
@@ -526,7 +590,7 @@ def positron_eval_r(page: Page, expr: str, timeout: int = 30_000) -> str:
 
     raise ExecError(
         f"Positron R console did not return the expected output within {timeout} ms "
-        f"(end marker {end!r} not found)."
+        f"(end marker {end!r} not found).{_positron_wedged_state_detail(page)}"
     )
 
 
@@ -577,7 +641,7 @@ def positron_eval_python(page: Page, expr: str, timeout: int = 30_000) -> str:
 
     raise ExecError(
         f"Positron Python console did not return the expected output within {timeout} ms "
-        f"(end marker {end!r} not found)."
+        f"(end marker {end!r} not found).{_positron_wedged_state_detail(page)}"
     )
 
 
@@ -889,8 +953,11 @@ def terminal_run(
 
     Raises:
         ExecError: *cmd* exited with a non-zero status (message includes the
-            exit code and captured output), or the done marker never
-            appeared within *timeout*.
+            exit code and captured output); the done marker never appeared
+            within *timeout*; or, for Positron, the console's own status label
+            was observed reading "Starting" continuously for longer than
+            _POSITRON_WEDGED_THRESHOLD_S, in which case this raises early
+            (see issue #390) instead of waiting out the full *timeout*.
 
     Note:
         The VS Code editor-open polling path is UNVALIDATED and pending a live
@@ -973,15 +1040,48 @@ def terminal_run(
         # A cold Positron session discovers interpreters and starts its console
         # asynchronously, so read_file can raise (no console yet / output not
         # captured) on early polls; treat those as "not ready" and keep polling
-        # until the deadline. Each attempt gets the remaining budget so the first
-        # cold-start console has time to come up, instead of a fixed few seconds
-        # that guarantees failure. RStudio's console is ready immediately, so its
+        # until the deadline. RStudio's console is ready immediately, so its
         # ExecError is a real failure and stays fatal (as in the VS Code branch);
         # only the Positron cold-start ExecError is retried.
+        #
+        # Positron attempts are capped to _POSITRON_READBACK_ATTEMPT_MS rather than
+        # given the full remaining budget: read_file's Positron path blocks for its
+        # entire timeout before giving up, so handing it the whole remaining budget
+        # on every attempt means one unresponsive attempt starves every retry this
+        # loop was meant to make (see issue #390). RStudio keeps the original
+        # full-remaining-budget behavior -- its console is ready immediately, so
+        # there is nothing to retry around.
+        positron_wedged_since: float | None = None
         while time.monotonic() < deadline:
             remaining_ms = max(1, int((deadline - time.monotonic()) * 1000))
+            if ide == "positron":
+                # Distinguish "kernel still warming up" from "kernel wedged and
+                # will never accept input": if the console's own status label has
+                # read "Starting" continuously for longer than any legitimate cold
+                # start should take, stop burning the rest of the timeout finding
+                # that out the hard way. A missing/unreadable label (None) is
+                # treated as "unknown, not wedged" -- it never triggers this path,
+                # so an older Positron build without this element, or a console
+                # that is genuinely idle, behaves exactly as before.
+                state = _positron_console_state_label(page)
+                if state and state.strip().lower() == "starting":
+                    if positron_wedged_since is None:
+                        positron_wedged_since = time.monotonic()
+                    elif time.monotonic() - positron_wedged_since > _POSITRON_WEDGED_THRESHOLD_S:
+                        raise ExecError(
+                            "terminal_run: Positron console has read 'Starting' continuously "
+                            f"for over {_POSITRON_WEDGED_THRESHOLD_S:.0f}s -- the interpreter "
+                            "kernel appears wedged and unlikely to ever accept execute requests "
+                            "(see issue #390). Failing fast instead of waiting out the full "
+                            f"{timeout}ms timeout."
+                        )
+                else:
+                    positron_wedged_since = None
+                attempt_ms = min(remaining_ms, _POSITRON_READBACK_ATTEMPT_MS)
+            else:
+                attempt_ms = remaining_ms
             try:
-                content = read_file(page, tmpfile, timeout=remaining_ms, lang=readback_lang)
+                content = read_file(page, tmpfile, timeout=attempt_ms, lang=readback_lang)
             except ExecError:
                 if ide == "positron":
                     time.sleep(poll_interval)

--- a/src/vip_tests/workbench/pages/positron_session.py
+++ b/src/vip_tests/workbench/pages/positron_session.py
@@ -40,6 +40,13 @@ class PositronSession:
     # posit-dev/positron/test/e2e/pages/console.ts and exec.py).
     ACTIVE_CONSOLE = '.console-instance[style*="z-index: auto"]'
     CONSOLE_INPUT = ".console-input"
+    # Kernel/interpreter status label shown inside the console panel (e.g.
+    # "Starting") while the runtime is not yet accepting execute requests.
+    # Confirmed live: reads "Starting" continuously on a session whose kernel
+    # never becomes interactive (issue #390) -- see exec.py's
+    # _positron_console_state_label. Scope this under CONSOLE_PANEL, since the
+    # class name alone (".state-label") is not distinctive enough on its own.
+    STATE_LABEL = ".state-label"
     # Present even on the Welcome page (before any console starts), so it is a
     # console-independent "this is Positron" discriminator for _detect_ide.
     VARIABLES_PANE = ".positron-variables"


### PR DESCRIPTION
Refs #390. **Does not close it** -- see below.

## The substantive find: the poll loop never actually polled

`terminal_run`'s Positron branch re-reads the marker file through a fresh console eval on every iteration, and handed each attempt the outer loop's *entire* remaining timeout. But `positron_eval_r`/`positron_eval_python` block for their whole passed-in timeout before giving up, so a single unresponsive attempt consumed the entire budget. The "poll every second" loop only ever got one real try.

Each attempt is now capped at 10 seconds. That is generous for a healthy console -- prompt-wait plus eval resolve in well under a second once an interpreter is up -- and leaves room for many retries across a typical multi-minute timeout. RStudio's branch is deliberately untouched: its console is ready immediately, so there is nothing to retry around, and a regression test pins that its attempts stay uncapped.

## Making a wedged console say so

Positron renders a status label inside the console panel that reads `Starting` while the interpreter is not yet interactive. On a kernel that never becomes ready it stays there indefinitely, which is what the #390 investigation observed. The final `ExecError` from either eval helper now includes that label when present, and `terminal_run` raises early once it has read `Starting` continuously for more than 45 seconds instead of waiting out the full timeout.

## What this does not do

It does not resolve the underlying bug (see #390 -- deliberately avoiding the keyword-plus-number phrasing that GitHub reads as a closing directive). The clone succeeds and the marker is written correctly; the failure is that the console never executes the readback. This change makes that legible -- a wedged console names itself instead of reporting a generic missing end marker after two minutes.

It also does not touch `launch_positron` or the marker protocol. The launch-gate change belongs with the real fix, per #390, and the marker protocol has been sound since #439.

## Known limitation, stated plainly

The 45-second threshold is extrapolated from the ~10s cold-start budgets already trusted elsewhere in this file. It was **not** validated against a session that recovers from `Starting`, because the investigation environment never produced one. If a healthy cold start is ever observed sitting at `Starting` past 45 seconds, this number needs to move.

The escalation is deliberately hard to trigger by accident: it fires only on that one specific label string, sustained continuously, tracked independently of the attempt cap. A missing label is treated as *unknown* and behaves exactly as today, falling through to the ordinary timeout error -- notably, a healthy console's label was never directly confirmed, so absence is not read as readiness. Any other label value resets the timer.

## Verification

13 new selftests, all pure-logic with a stepping fake clock and mocked Playwright -- no live session required. They cover: label extraction and stripping, absent element and read failure both yielding `None` without raising, selector scoping, the attempt cap applying to Positron but not RStudio, the label never being queried for non-Positron IDEs, fail-fast firing on a sustained `Starting`, a `None` label falling through to the ordinary error without ever claiming "wedged", and an alternating label never accumulating enough evidence to escalate.

`selftests/test_workbench_exec.py`: 98 passed. `just check` clean. mypy unaffected (changes are entirely under `src/vip_tests/`, outside its CI scope).

