### PR TITLE
ci(workbench): let Dependabot run the Workbench smoke suite

### DIFF
--- a/.github/workflows/workbench-smoke.yml
+++ b/.github/workflows/workbench-smoke.yml
@@ -87,10 +87,9 @@ jobs:
     # Scheduled/manual runs always execute (no PR diff for paths-filter to
     # score); PR/push runs still gate on the changed-paths filter.
     if: >-
-      (needs.changes.outputs.relevant == 'true'
-        || github.event_name == 'schedule'
-        || github.event_name == 'workflow_dispatch')
-      && github.actor != 'dependabot[bot]'
+      needs.changes.outputs.relevant == 'true'
+      || github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
     name: Smoke test against Workbench ${{ matrix.workbench-version }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Why Dependabot PRs currently cannot merge

`Workbench Smoke Tests Status` is a required check. Its aggregator is scope-aware: it passes when the suite was legitimately out of scope for the PR's changed paths, and fails when the suite *was* in scope but did not succeed — a skipped job included. That is deliberate, and it closed a real hole where a path-gated skip or a missing licence secret could report a green required check without the suite having run.

But `workbench-smoke.yml` also carried `&& github.actor != 'dependabot[bot]'` on the smoke job. So for any Dependabot PR touching a relevant path, the suite skipped, the aggregator saw "in scope but not successful", and the required check failed. Deterministically, with no way for the PR to pass.

Both open Dependabot PRs show it:

```
Workbench smoke was in scope for this PR but did not succeed (result=skipped)
```

— #564 (`chore(deps): bump the python-dependencies group`) and #566 (`chore(deps): bump the actions-dependencies group`).

## Why removing the skip is the right fix rather than a workaround

The skip was added in #69 for a reason that no longer holds: "smoke tests that require product license secrets unavailable to dependabot". Dependabot now has its own secret store containing `CONNECT_LICENSE`, `RSPM_LICENSE` and `WORKBENCH_LICENSE`.

More directly: #71, titled "remove dependabot skip from smoke tests", already removed this same condition from `connect-smoke.yml` and `packagemanager-smoke.yml` — and missed `workbench-smoke.yml`. Workbench was the only product suite still carrying it, which is why Package Manager smoke ran fine on both Dependabot branches while Workbench skipped. This finishes that change; the `if:` condition is now identical to `connect-smoke.yml`'s.

## Cost this restores, stated plainly

Every Dependabot bump touching relevant paths will now start a Workbench container and activate a licence seat. That is the same resource whose exhaustion separately failed #564's `example-report` job (`The product key has already been activated with the maximum number of computers`). This PR does not address that; it is a distinct, account-level problem.

## Verification

`zizmor` with the repo's config reports an identical finding count before and after the change (32 either way), so no new findings; the enforced audits (`unpinned-uses`, `artipacked`) are unaffected since no `uses:` line changes. The workflow parses as YAML, and no `dependabot[bot]` exclusion remains in any of the three smoke workflows.

This cannot be fully verified until it lands, because the behaviour only manifests on a Dependabot-authored PR. The check to watch after merge: #564 and #566 should show the Workbench suite actually running instead of skipping.
