### PR TITLE
ci: relock uv.lock as part of the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Install python-semantic-release
         run: pip install python-semantic-release==9.21.0
 
+      # Needed by build_command ("just relock") in pyproject.toml's
+      # [tool.semantic_release], which regenerates uv.lock's own posit-vip
+      # version entry before semantic-release commits the release. `just
+      # relock` fetches its own pinned uv via `uvx`, so this step's uv version
+      # doesn't need to match -- only uv itself needs to be on PATH for uvx.
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
       # --no-vcs-release: the GitHub release is created by publish.yml (on the
       # tag push) so the locked constraints file can be attached before the
       # release is published and locked by immutable releases.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       # [tool.semantic_release], which regenerates uv.lock's own posit-vip
       # version entry before semantic-release commits the release. `just
       # relock` fetches its own pinned uv via `uvx`, so this step's uv version
-      # doesn't need to match -- only uv itself needs to be on PATH for uvx.
+      # doesn't need to match -- only `uvx` needs to be on PATH (provided by setup-uv).
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,12 @@ major_on_zero = false
 branch = "main"
 commit_message = "chore(release): {version}"
 tag_format = "v{version}"
+# Relock before committing so uv.lock's own posit-vip entry never lags behind
+# the version this commit just stamped into pyproject.toml. Runs `just relock`
+# rather than a bare `uv lock` so the pinned uv version in the justfile stays
+# the single source of truth. See issue #559.
+build_command = "just relock"
+assets = ["uv.lock"]
 
 [tool.semantic_release.remote]
 ignore_token_for_push = true

--- a/uv.lock
+++ b/uv.lock
@@ -1723,7 +1723,7 @@ wheels = [
 
 [[package]]
 name = "posit-vip"
-version = "0.58.9"
+version = "0.58.11"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
Closes #559.

## The problem

`chore(release)` commits stamp the new version into `pyproject.toml` and `src/vip/__init__.py` but never relock, so `uv.lock`'s own `posit-vip` entry sits one release behind `main` permanently. Any `uv run` or `uv sync` then corrects that line locally, so every contributor works with a dirty file — and cannot commit the correction, because the Lockfile Guard rejects a `uv.lock` change with no accompanying `pyproject.toml` change. The drift could only ever ride along on an unrelated dependency PR, which is how #556 came to carry it.

## The fix

`[tool.semantic_release]` gains `build_command = "just relock"` and `assets = ["uv.lock"]`. In python-semantic-release, `build_command` runs *after* the version is stamped and *before* the commit, and `assets` entries are git-added into that commit — so the release commit now carries a lock that matches the version it just stamped.

Using `just relock` rather than a bare `uv lock` keeps the pinned uv version in the justfile as the single source of truth, instead of writing the version down a third time. The release job gains `astral-sh/setup-uv` and `extractions/setup-just` so `build_command` can run; both are SHA-pinned like every other action here.

This PR also carries the relock that clears the drift present today (`0.58.9` → `0.58.11`, one line, no dependency churn). That is only legal because the PR edits `pyproject.toml` in the same change.

## Verification

Ran `semantic-release version --no-push --no-tag --no-vcs-release --changelog` against a throwaway `feat:` commit in a scratch clone of real history, **both with and without the fix**:

- Without it: `No build command specified, skipping.` The release commit contains `CHANGELOG.md`, `pyproject.toml`, `src/vip/__init__.py`. `uv.lock` is absent and its `posit-vip` entry stays at `0.58.9` while `pyproject.toml` says `0.59.0`. This reproduces the bug.
- With it: `Running build command: just relock` → `Updated posit-vip v0.58.9 -> v0.59.0` → `Build completed successfully!`. The release commit contains four files including `uv.lock`, whose `posit-vip` version matches the stamped `pyproject.toml`.

`zizmor` run exactly as `ci.yml`'s actions-lint job does reports 0 findings for both enforced audits (`unpinned-uses`, `artipacked`) and none referencing `release.yml`. The `extractions/setup-just` pin was confirmed against the tag: `53165ef7e734c5c07cb06b3c8e7b647c5aa16db3` is `v4.0.0`. `just check`, mypy and the selftests pass, apart from a known macOS-only timing flake in `test_load_engine.py` that reproduces on an unmodified tree.

## Failure mode

Simulated by removing `just` from `PATH` and re-running the dry run: semantic-release stamps the version files, the build command exits 127, it logs "Build failed, aborting release" and exits 1 — **no commit and no tag**. On a real runner the dirty working tree is simply discarded, `main` is untouched, and the unreleased commits are picked up by the next run. A broken relock cannot produce a half-finished release.

## Not addressed here

`publish.yml` is unaffected either way: its `uv export --frozen --no-emit-project` already excludes the self-entry and skips freshness validation, so the drift never broke it. This is a contributor-experience fix, not a correctness one — nothing in CI uses `--locked` or `uv lock --check`, so the stale lock was never fatal.
