### PR TITLE
fix(auth): validate cached auth sessions and unify the cache path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Key principles:
 |------------------------------------|------------------------------------|
 | `src/vip/cli.py` | CLI entry point: version, verify (including `--basic` to skip `@slow`-tagged scenarios), cleanup (Connect content + orphaned Workbench sessions via `--workbench-url`), install, uninstall, auth, scaffold commands; `--version` flag |
 | `src/vip/config.py` | TOML config loader and dataclasses |
-| `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers; `authenticated_page` opens a headless page from a cached auth session for `vip cleanup --workbench-url` |
+| `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers; `authenticated_page` opens a headless page from a cached auth session for `vip cleanup --workbench-url`; `auth_cache_path()` is the single source of truth for the `.vip-auth-cache.json` location (both `plugin.py` and `cli.py` must use it), and `_load_cached_auth` probes Workbench before trusting a cached session |
 | `src/vip/idp.py` | IdP login form strategies for headless auth (Keycloak, Okta) |
 | `src/vip/plugin.py` | pytest plugin: markers (including `slow`, used by `verify --basic`), auto-skip, JSON report output |
 | `src/vip/version.py` | `ProductVersion` parsing/comparison for `min_version` gating; `MINIMUM_SUPPORTED_POSIT_TEAM` support floor (powers `vip version`) |

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -2497,3 +2497,343 @@ class TestAuthenticatedPage:
 
         assert captured == [str(ca_file)]
         assert os.environ.get("NODE_EXTRA_CA_CERTS") is None
+
+
+class TestCookiesFromStorageState:
+    """Playwright storage state is the only record of the cached browser
+    session, so the liveness probe has to read cookies straight out of it."""
+
+    @staticmethod
+    def _write(tmp_path, payload):
+        import json
+        from pathlib import Path as _Path
+
+        state = _Path(tmp_path) / ".vip-auth-cache.json"
+        state.write_text(json.dumps(payload))
+        return state
+
+    def test_extracts_name_value_pairs(self, tmp_path):
+        from vip.auth import _cookies_from_storage_state
+
+        state = self._write(
+            tmp_path,
+            {
+                "cookies": [
+                    {"name": "rstudio-rs-csrf-token", "value": "abc", "domain": "w.example.com"},
+                    {"name": "user-id", "value": "sam", "domain": "w.example.com"},
+                ]
+            },
+        )
+
+        assert _cookies_from_storage_state(state) == {
+            "rstudio-rs-csrf-token": "abc",
+            "user-id": "sam",
+        }
+
+    def test_returns_empty_for_state_without_cookies(self, tmp_path):
+        from vip.auth import _cookies_from_storage_state
+
+        assert _cookies_from_storage_state(self._write(tmp_path, {"origins": []})) == {}
+
+    def test_returns_empty_for_malformed_state(self, tmp_path):
+        """A truncated cache file must not crash the run before any test executes."""
+        from pathlib import Path as _Path
+
+        from vip.auth import _cookies_from_storage_state
+
+        state = _Path(tmp_path) / ".vip-auth-cache.json"
+        state.write_text("{not json")
+
+        assert _cookies_from_storage_state(state) == {}
+
+    def test_skips_cookies_missing_a_name(self, tmp_path):
+        from vip.auth import _cookies_from_storage_state
+
+        payload = {"cookies": [{"value": "orphan"}, {"name": "k", "value": "v"}]}
+        state = self._write(tmp_path, payload)
+
+        assert _cookies_from_storage_state(state) == {"k": "v"}
+
+
+class TestCachedWorkbenchSessionIsLive:
+    """The cached storage state can go stale long before the 4-hour TTL
+    expires (the IdP session dies, or an admin invalidates it).  Without a
+    liveness probe every Workbench test skips with a message that names no
+    cause, because ``workbench_auth_error`` is only set on the fresh-auth
+    path.  See issue: samcofer's 106-skip run."""
+
+    def test_live_session_is_reported_live(self, tmp_path):
+        import httpx
+
+        from vip.auth import _cached_workbench_session_is_live
+
+        def handler(request):
+            return httpx.Response(200, text="<html>dashboard</html>")
+
+        transport = httpx.MockTransport(handler)
+        assert (
+            _cached_workbench_session_is_live(
+                "https://w.example.com", {"user-id": "sam"}, transport=transport
+            )
+            is True
+        )
+
+    def test_redirect_to_sign_in_is_reported_dead(self, tmp_path):
+        import httpx
+
+        from vip.auth import _cached_workbench_session_is_live
+
+        def handler(request):
+            if "auth-sign-in" in str(request.url):
+                return httpx.Response(200, text="<html>sign in</html>")
+            return httpx.Response(302, headers={"Location": "/auth-sign-in?appUri=%2F"})
+
+        transport = httpx.MockTransport(handler)
+        assert (
+            _cached_workbench_session_is_live(
+                "https://w.example.com", {"user-id": "sam"}, transport=transport
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_unauthorized_without_redirect_is_reported_dead(self, status):
+        """Some Workbench configs answer an expired session with a bare 401/403
+        instead of redirecting, so the URL check alone would miss it."""
+        import httpx
+
+        from vip.auth import _cached_workbench_session_is_live
+
+        transport = httpx.MockTransport(lambda request: httpx.Response(status))
+        assert (
+            _cached_workbench_session_is_live(
+                "https://w.example.com", {"user-id": "sam"}, transport=transport
+            )
+            is False
+        )
+
+    def test_transport_error_is_inconclusive_not_dead(self):
+        """An unreachable deployment is not a dead session.  Failing closed here
+        would force an interactive browser re-auth that cannot succeed either,
+        and would bury the real reachability error.  Fail open and let the
+        tests report the outage with their own message."""
+        import httpx
+
+        from vip.auth import _cached_workbench_session_is_live
+
+        def boom(request):
+            raise httpx.ConnectError("connection refused")
+
+        transport = httpx.MockTransport(boom)
+        assert (
+            _cached_workbench_session_is_live(
+                "https://w.example.com", {"user-id": "sam"}, transport=transport
+            )
+            is None
+        )
+
+
+class TestLoadCachedAuthProbesWorkbench:
+    @staticmethod
+    def _write_cache(tmp_path, *, workbench_url: str, connect_url: str = ""):
+        import json
+        from pathlib import Path as _Path
+
+        cache = _Path(tmp_path) / ".vip-auth-cache.json"
+        cache.write_text('{"cookies": [{"name": "user-id", "value": "sam"}]}')
+        cache.with_suffix(".meta.json").write_text(
+            json.dumps(
+                {
+                    "api_key": "CACHED",
+                    "key_name": "_vip_interactive_1",
+                    "connect_url": connect_url,
+                    "requested_connect_url": connect_url,
+                    "workbench_url": workbench_url,
+                }
+            )
+        )
+        return cache
+
+    def test_dead_workbench_session_is_a_cache_miss(self, tmp_path, capsys, monkeypatch):
+        from vip import auth as auth_mod
+
+        cache = self._write_cache(tmp_path, workbench_url="https://w.example.com")
+        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: False)
+
+        session = auth_mod._load_cached_auth(
+            cache,
+            requested_connect_url=None,
+            requested_workbench_url="https://w.example.com",
+        )
+
+        assert session is None
+        out = capsys.readouterr().out
+        assert "Ignoring cached auth session" in out
+        assert "no longer authenticates Workbench" in out
+
+    def test_live_workbench_session_is_reused(self, tmp_path, monkeypatch):
+        from vip import auth as auth_mod
+
+        cache = self._write_cache(tmp_path, workbench_url="https://w.example.com")
+        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: True)
+
+        session = auth_mod._load_cached_auth(
+            cache,
+            requested_connect_url=None,
+            requested_workbench_url="https://w.example.com",
+        )
+
+        assert session is not None
+        assert session.api_key == "CACHED"
+
+    def test_inconclusive_probe_reuses_the_cache(self, tmp_path, monkeypatch):
+        from vip import auth as auth_mod
+
+        cache = self._write_cache(tmp_path, workbench_url="https://w.example.com")
+        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: None)
+
+        session = auth_mod._load_cached_auth(
+            cache,
+            requested_connect_url=None,
+            requested_workbench_url="https://w.example.com",
+        )
+
+        assert session is not None
+
+    def test_no_workbench_requested_skips_the_probe(self, tmp_path, monkeypatch):
+        """Connect-only runs must not pay for a Workbench round-trip."""
+        from vip import auth as auth_mod
+
+        cache = self._write_cache(tmp_path, workbench_url="", connect_url="https://c.example.com")
+
+        def boom(*a, **kw):
+            raise AssertionError("probed Workbench on a Connect-only run")
+
+        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", boom)
+
+        session = auth_mod._load_cached_auth(
+            cache,
+            requested_connect_url="https://c.example.com",
+            requested_workbench_url=None,
+        )
+
+        assert session is not None
+
+    def test_probe_receives_tls_settings(self, tmp_path, monkeypatch):
+        """``--insecure`` / ``--ca-bundle`` deployments must not fail the probe on
+        TLS and get sent through a pointless re-auth."""
+        from vip import auth as auth_mod
+
+        cache = self._write_cache(tmp_path, workbench_url="https://w.example.com")
+        seen = {}
+
+        def record(url, cookies, *, insecure=False, ca_bundle=None, transport=None):
+            seen["insecure"] = insecure
+            seen["ca_bundle"] = ca_bundle
+            return True
+
+        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", record)
+
+        auth_mod._load_cached_auth(
+            cache,
+            requested_connect_url=None,
+            requested_workbench_url="https://w.example.com",
+            insecure=True,
+            ca_bundle=None,
+        )
+
+        assert seen == {"insecure": True, "ca_bundle": None}
+
+
+class TestAuthCachePath:
+    """``vip verify`` (plugin) and ``vip cleanup`` (CLI) must resolve the same
+    cache file.  plugin.py used ``Path(config.rootpath)`` while cli.py used
+    ``Path.cwd()``; for a uv-tool install pytest's rootdir is the common
+    ancestor of cwd and site-packages, which lands in ``$HOME`` — so the two
+    silently disagreed and ``vip cleanup`` looked in the wrong place."""
+
+    def test_resolves_relative_to_the_invocation_directory(self, tmp_path, monkeypatch):
+        from vip.auth import auth_cache_path
+
+        monkeypatch.chdir(tmp_path)
+        assert auth_cache_path() == tmp_path / ".vip-auth-cache.json"
+
+    def test_call_sites_do_not_build_the_path_inline(self):
+        """Invariant: the filename literal lives in one place.  A second inline
+        copy is how the two call sites drifted apart in the first place."""
+        from pathlib import Path as _Path
+
+        import vip.auth
+        import vip.cli
+        import vip.plugin
+
+        for module in (vip.cli, vip.plugin):
+            source = _Path(module.__file__).read_text()
+            assert ".vip-auth-cache.json" not in source, (
+                f"{module.__name__} builds the auth cache path inline; "
+                "call vip.auth.auth_cache_path() instead"
+            )
+
+        assert ".vip-auth-cache.json" in _Path(vip.auth.__file__).read_text()
+
+
+class TestStaleCacheTriggersReauth:
+    """End-to-end wiring: a dead cached session must fall through to the real
+    auth flow, not be handed to the tests.  The helper-level tests above prove
+    the probe verdict; this proves ``start_interactive_auth`` acts on it."""
+
+    @staticmethod
+    def _write_cache(tmp_path):
+        import json
+        from pathlib import Path as _Path
+
+        cache = _Path(tmp_path) / ".vip-auth-cache.json"
+        cache.write_text('{"cookies": [{"name": "user-id", "value": "sam"}]}')
+        cache.with_suffix(".meta.json").write_text(
+            json.dumps(
+                {
+                    "api_key": None,
+                    "key_name": "",
+                    "connect_url": "",
+                    "requested_connect_url": "",
+                    "workbench_url": "https://w.example.com",
+                }
+            )
+        )
+        return cache
+
+    def test_dead_cache_falls_through_to_the_browser_flow(self, tmp_path, monkeypatch):
+        from vip import auth as auth_mod
+
+        cache = self._write_cache(tmp_path)
+        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: False)
+
+        reached = []
+
+        def sentinel(*args, **kwargs):
+            reached.append(True)
+            raise RuntimeError("browser flow reached")
+
+        monkeypatch.setattr(auth_mod, "sync_playwright", sentinel)
+
+        with pytest.raises(RuntimeError, match="browser flow reached"):
+            auth_mod.start_interactive_auth(workbench_url="https://w.example.com", cache_path=cache)
+
+        assert reached, "stale cache was reused instead of re-authenticating"
+
+    def test_live_cache_short_circuits_the_browser_flow(self, tmp_path, monkeypatch):
+        from vip import auth as auth_mod
+
+        cache = self._write_cache(tmp_path)
+        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: True)
+
+        def boom(*args, **kwargs):
+            raise AssertionError("launched a browser despite a live cached session")
+
+        monkeypatch.setattr(auth_mod, "sync_playwright", boom)
+
+        session = auth_mod.start_interactive_auth(
+            workbench_url="https://w.example.com", cache_path=cache
+        )
+
+        assert session.storage_state_path == cache

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -2499,6 +2499,20 @@ class TestAuthenticatedPage:
         assert os.environ.get("NODE_EXTRA_CA_CERTS") is None
 
 
+def _jar(**cookies):
+    """Build an httpx cookie jar for probe tests that don't care about scoping.
+
+    The probe takes a jar rather than a flat dict so cookie domain/path survive;
+    scoping itself is covered by TestProbeCookieScoping.
+    """
+    import httpx
+
+    jar = httpx.Cookies()
+    for name, value in cookies.items():
+        jar.set(name, value, domain="w.example.com")
+    return jar
+
+
 class TestCookiesFromStorageState:
     """Playwright storage state is the only record of the cached browser
     session, so the liveness probe has to read cookies straight out of it."""
@@ -2525,15 +2539,16 @@ class TestCookiesFromStorageState:
             },
         )
 
-        assert _cookies_from_storage_state(state) == {
-            "rstudio-rs-csrf-token": "abc",
-            "user-id": "sam",
-        }
+        jar = _cookies_from_storage_state(state)
+
+        assert dict(jar) == {"rstudio-rs-csrf-token": "abc", "user-id": "sam"}
+        # Scope must survive, or the probe cannot apply cookie matching.
+        assert {c.domain for c in jar.jar} == {"w.example.com"}
 
     def test_returns_empty_for_state_without_cookies(self, tmp_path):
         from vip.auth import _cookies_from_storage_state
 
-        assert _cookies_from_storage_state(self._write(tmp_path, {"origins": []})) == {}
+        assert len(_cookies_from_storage_state(self._write(tmp_path, {"origins": []})).jar) == 0
 
     def test_returns_empty_for_malformed_state(self, tmp_path):
         """A truncated cache file must not crash the run before any test executes."""
@@ -2544,7 +2559,7 @@ class TestCookiesFromStorageState:
         state = _Path(tmp_path) / ".vip-auth-cache.json"
         state.write_text("{not json")
 
-        assert _cookies_from_storage_state(state) == {}
+        assert len(_cookies_from_storage_state(state).jar) == 0
 
     def test_skips_cookies_missing_a_name(self, tmp_path):
         from vip.auth import _cookies_from_storage_state
@@ -2552,7 +2567,7 @@ class TestCookiesFromStorageState:
         payload = {"cookies": [{"value": "orphan"}, {"name": "k", "value": "v"}]}
         state = self._write(tmp_path, payload)
 
-        assert _cookies_from_storage_state(state) == {"k": "v"}
+        assert dict(_cookies_from_storage_state(state)) == {"k": "v"}
 
 
 class TestCachedWorkbenchSessionIsLive:
@@ -2573,8 +2588,8 @@ class TestCachedWorkbenchSessionIsLive:
         transport = httpx.MockTransport(handler)
         assert (
             _cached_workbench_session_is_live(
-                "https://w.example.com", {"user-id": "sam"}, transport=transport
-            )
+                "https://w.example.com", _jar(), transport=transport
+            ).is_live
             is True
         )
 
@@ -2591,8 +2606,8 @@ class TestCachedWorkbenchSessionIsLive:
         transport = httpx.MockTransport(handler)
         assert (
             _cached_workbench_session_is_live(
-                "https://w.example.com", {"user-id": "sam"}, transport=transport
-            )
+                "https://w.example.com", _jar(), transport=transport
+            ).is_live
             is False
         )
 
@@ -2607,8 +2622,8 @@ class TestCachedWorkbenchSessionIsLive:
         transport = httpx.MockTransport(lambda request: httpx.Response(status))
         assert (
             _cached_workbench_session_is_live(
-                "https://w.example.com", {"user-id": "sam"}, transport=transport
-            )
+                "https://w.example.com", _jar(), transport=transport
+            ).is_live
             is False
         )
 
@@ -2627,8 +2642,8 @@ class TestCachedWorkbenchSessionIsLive:
         transport = httpx.MockTransport(boom)
         assert (
             _cached_workbench_session_is_live(
-                "https://w.example.com", {"user-id": "sam"}, transport=transport
-            )
+                "https://w.example.com", _jar(), transport=transport
+            ).is_live
             is None
         )
 
@@ -2658,7 +2673,11 @@ class TestLoadCachedAuthProbesWorkbench:
         from vip import auth as auth_mod
 
         cache = self._write_cache(tmp_path, workbench_url="https://w.example.com")
-        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: False)
+        monkeypatch.setattr(
+            auth_mod,
+            "_cached_workbench_session_is_live",
+            lambda *a, **kw: auth_mod._ProbeResult(False, "Workbench answered 401"),
+        )
 
         session = auth_mod._load_cached_auth(
             cache,
@@ -2675,7 +2694,11 @@ class TestLoadCachedAuthProbesWorkbench:
         from vip import auth as auth_mod
 
         cache = self._write_cache(tmp_path, workbench_url="https://w.example.com")
-        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: True)
+        monkeypatch.setattr(
+            auth_mod,
+            "_cached_workbench_session_is_live",
+            lambda *a, **kw: auth_mod._ProbeResult(True),
+        )
 
         session = auth_mod._load_cached_auth(
             cache,
@@ -2690,7 +2713,11 @@ class TestLoadCachedAuthProbesWorkbench:
         from vip import auth as auth_mod
 
         cache = self._write_cache(tmp_path, workbench_url="https://w.example.com")
-        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            auth_mod,
+            "_cached_workbench_session_is_live",
+            lambda *a, **kw: auth_mod._ProbeResult(None, "could not reach Workbench"),
+        )
 
         session = auth_mod._load_cached_auth(
             cache,
@@ -2730,7 +2757,7 @@ class TestLoadCachedAuthProbesWorkbench:
         def record(url, cookies, *, insecure=False, ca_bundle=None, transport=None):
             seen["insecure"] = insecure
             seen["ca_bundle"] = ca_bundle
-            return True
+            return auth_mod._ProbeResult(True)
 
         monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", record)
 
@@ -2806,7 +2833,11 @@ class TestStaleCacheTriggersReauth:
         from vip import auth as auth_mod
 
         cache = self._write_cache(tmp_path)
-        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: False)
+        monkeypatch.setattr(
+            auth_mod,
+            "_cached_workbench_session_is_live",
+            lambda *a, **kw: auth_mod._ProbeResult(False, "Workbench answered 401"),
+        )
 
         reached = []
 
@@ -2825,7 +2856,11 @@ class TestStaleCacheTriggersReauth:
         from vip import auth as auth_mod
 
         cache = self._write_cache(tmp_path)
-        monkeypatch.setattr(auth_mod, "_cached_workbench_session_is_live", lambda *a, **kw: True)
+        monkeypatch.setattr(
+            auth_mod,
+            "_cached_workbench_session_is_live",
+            lambda *a, **kw: auth_mod._ProbeResult(True),
+        )
 
         def boom(*args, **kwargs):
             raise AssertionError("launched a browser despite a live cached session")
@@ -2837,3 +2872,163 @@ class TestStaleCacheTriggersReauth:
         )
 
         assert session.storage_state_path == cache
+
+
+class TestProbeCookieScoping:
+    """The storage state is a whole browser context: the auth flow visits the
+    IdP and Connect as well as Workbench, so the file holds cookies for all of
+    them.  The probe must apply normal cookie scoping rather than firing every
+    cookie at the Workbench host."""
+
+    @staticmethod
+    def _state(tmp_path, cookies):
+        import json
+        from pathlib import Path as _Path
+
+        state = _Path(tmp_path) / ".vip-auth-cache.json"
+        state.write_text(json.dumps({"cookies": cookies}))
+        return state
+
+    def _probe_and_capture(self, state, url):
+        """Run the probe against *url* and return the Cookie header it sent."""
+        import httpx
+
+        from vip.auth import _cached_workbench_session_is_live, _cookies_from_storage_state
+
+        sent = {}
+
+        def handler(request):
+            sent["cookie"] = request.headers.get("cookie", "")
+            return httpx.Response(200, text="dashboard")
+
+        _cached_workbench_session_is_live(
+            url,
+            _cookies_from_storage_state(state),
+            transport=httpx.MockTransport(handler),
+        )
+        return sent["cookie"]
+
+    def test_idp_cookies_are_not_sent_to_workbench(self, tmp_path):
+        """Sending the IdP's session cookie to the Workbench host is unintended
+        cross-host leakage; a browser would never do it."""
+        state = self._state(
+            tmp_path,
+            [
+                {"name": "wb-session", "value": "wb", "domain": "w.example.com", "path": "/"},
+                {"name": "okta-sid", "value": "secret", "domain": "posit.okta.com", "path": "/"},
+            ],
+        )
+
+        header = self._probe_and_capture(state, "https://w.example.com")
+
+        assert "wb-session=wb" in header
+        assert "okta-sid" not in header
+        assert "secret" not in header
+
+    def test_same_cookie_name_on_two_hosts_sends_the_workbench_value(self, tmp_path):
+        """A flat name->value dict silently overwrites one host's cookie with
+        another's.  Sending the IdP's value for a name Workbench also uses would
+        make a *live* session read as dead and force a pointless re-auth."""
+        state = self._state(
+            tmp_path,
+            [
+                {"name": "session", "value": "workbench-value", "domain": "w.example.com"},
+                {"name": "session", "value": "idp-value", "domain": "posit.okta.com"},
+            ],
+        )
+
+        header = self._probe_and_capture(state, "https://w.example.com")
+
+        assert "session=workbench-value" in header
+        assert "idp-value" not in header
+
+    def test_parent_domain_cookie_reaches_a_subdomain_host(self, tmp_path):
+        """Leading-dot domains are host-suffix cookies and must still be sent,
+        or a deployment sharing a parent domain would read as signed out."""
+        state = self._state(
+            tmp_path,
+            [{"name": "shared", "value": "yes", "domain": ".example.com", "path": "/"}],
+        )
+
+        header = self._probe_and_capture(state, "https://w.example.com")
+
+        assert "shared=yes" in header
+
+    def test_path_scoping_is_respected(self, tmp_path):
+        """A cookie scoped to an unrelated sub-path must not be sent to the root."""
+        state = self._state(
+            tmp_path,
+            [
+                {"name": "root", "value": "r", "domain": "w.example.com", "path": "/"},
+                {"name": "deep", "value": "d", "domain": "w.example.com", "path": "/somewhere"},
+            ],
+        )
+
+        header = self._probe_and_capture(state, "https://w.example.com/")
+
+        assert "root=r" in header
+        assert "deep" not in header
+
+
+class TestProbeDetailNamesTheEvidence:
+    """The cache-miss message quoted "sent back to the sign-in page" for every
+    dead verdict, including bare 401/403 where no redirect happened.  A 401 and
+    an expiry redirect point at different causes (a proxy stripping cookies vs a
+    dead session), so the message has to name what was actually seen."""
+
+    def test_sign_in_redirect_detail(self):
+        import httpx
+
+        from vip.auth import _cached_workbench_session_is_live
+
+        def handler(request):
+            if "auth-sign-in" in str(request.url):
+                return httpx.Response(200, text="sign in")
+            return httpx.Response(302, headers={"Location": "/auth-sign-in"})
+
+        result = _cached_workbench_session_is_live(
+            "https://w.example.com", httpx.Cookies(), transport=httpx.MockTransport(handler)
+        )
+
+        assert result.is_live is False
+        assert "sign-in page" in result.detail
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_unauthorized_detail_does_not_claim_a_redirect(self, status):
+        import httpx
+
+        from vip.auth import _cached_workbench_session_is_live
+
+        result = _cached_workbench_session_is_live(
+            "https://w.example.com",
+            httpx.Cookies(),
+            transport=httpx.MockTransport(lambda request: httpx.Response(status)),
+        )
+
+        assert result.is_live is False
+        assert str(status) in result.detail
+        assert "sign-in page" not in result.detail
+
+    def test_cache_miss_message_quotes_the_detail(self, tmp_path, capsys, monkeypatch):
+        import json
+
+        from vip import auth as auth_mod
+
+        cache = tmp_path / ".vip-auth-cache.json"
+        cache.write_text('{"cookies": []}')
+        cache.with_suffix(".meta.json").write_text(
+            json.dumps({"api_key": None, "workbench_url": "https://w.example.com"})
+        )
+        monkeypatch.setattr(
+            auth_mod,
+            "_cached_workbench_session_is_live",
+            lambda *a, **kw: auth_mod._ProbeResult(False, "Workbench answered 401 Unauthorized"),
+        )
+
+        auth_mod._load_cached_auth(
+            cache, requested_connect_url=None, requested_workbench_url="https://w.example.com"
+        )
+
+        out = capsys.readouterr().out
+        assert "Workbench answered 401 Unauthorized" in out
+        assert "sent back to the sign-in page" not in out

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -260,20 +260,114 @@ def authenticated_page(
                 os.environ["NODE_EXTRA_CA_CERTS"] = _prev_node_ca
 
 
+AUTH_CACHE_FILENAME = ".vip-auth-cache.json"
+
+
+def auth_cache_path() -> Path:
+    """Path to the auth-session cache for the current invocation directory.
+
+    Single source of truth for both call sites: ``plugin.py`` (``vip verify``)
+    and ``cli.py`` (``vip cleanup --workbench-url``).  They must agree, or
+    ``cleanup`` cannot find the session ``verify`` just cached.
+
+    Keyed on the *invocation* directory rather than pytest's ``config.rootpath``.
+    For a repo checkout the two are the same, but for an installed VIP (``uv tool
+    install posit-vip``) pytest derives rootdir from the common ancestor of the
+    invocation directory and the ``site-packages`` test paths — which lands in
+    ``$HOME``.  That put the cache nowhere near the user's ``vip.toml`` and made
+    the two call sites read different files.
+    """
+    return Path.cwd() / AUTH_CACHE_FILENAME
+
+
+def _cookies_from_storage_state(storage_state_path: Path) -> dict[str, str]:
+    """Extract ``name -> value`` cookies from a Playwright storage-state file.
+
+    Lets the liveness probe below reuse the cached browser session over plain
+    httpx, with no Playwright launch.  A malformed or truncated cache yields an
+    empty dict rather than raising: the probe then reads as inconclusive and the
+    cache is reused, which is exactly the pre-probe behaviour.
+    """
+    import json
+
+    try:
+        state = json.loads(Path(storage_state_path).read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(state, dict):
+        return {}
+
+    cookies: dict[str, str] = {}
+    for cookie in state.get("cookies") or []:
+        if not isinstance(cookie, dict):
+            continue
+        name = cookie.get("name")
+        if not name:
+            continue
+        cookies[str(name)] = str(cookie.get("value", ""))
+    return cookies
+
+
+def _cached_workbench_session_is_live(
+    workbench_url: str,
+    cookies: dict[str, str],
+    *,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> bool | None:
+    """Report whether *cookies* still authenticate Workbench at *workbench_url*.
+
+    Returns ``True`` when the session lands on the dashboard, ``False`` on
+    positive evidence that it is dead (a redirect to the sign-in page, or a bare
+    401/403 from configs that do not redirect), and ``None`` when the probe could
+    not reach a verdict.
+
+    ``None`` is deliberately distinct from ``False``.  An unreachable deployment
+    is not a dead session: treating a transport error as dead would discard a
+    perfectly good cache, trigger an interactive re-auth that cannot succeed
+    either, and bury the real reachability error behind an auth-shaped one.
+    """
+    verify = _httpx_verify(insecure, ca_bundle)
+    try:
+        with httpx.Client(
+            timeout=scaled(10.0),
+            verify=verify,
+            follow_redirects=True,
+            cookies=cookies,
+            transport=transport,
+        ) as client:
+            response = client.get(workbench_url)
+    except httpx.HTTPError:
+        return None
+
+    if response.status_code in (401, 403):
+        return False
+    return not _on_login_page(str(response.url))
+
+
 def _load_cached_auth(
     cache_path: Path,
     requested_connect_url: str | None = None,
     requested_workbench_url: str | None = None,
+    *,
+    insecure: bool = False,
+    ca_bundle: Path | None = None,
 ) -> InteractiveAuthSession | None:
-    """Load a cached auth session if the storage state file exists and is recent.
+    """Load a cached auth session if it exists, is recent, and still works.
 
-    The cache lives at ``Path(config.rootpath) / .vip-auth-cache.json`` —
-    one slot per checkout directory, not per site.  If the caller is now
-    targeting a different Connect or Workbench URL than the one the cache
-    was minted against, reusing the saved storage state would silently
-    send the wrong session cookies (and the wrong API key) to the new
-    site.  We treat any URL mismatch as a cache miss so the next run
-    re-authenticates cleanly.
+    The cache lives at :func:`auth_cache_path` — one slot per invocation
+    directory, not per site.  If the caller is now targeting a different Connect
+    or Workbench URL than the one the cache was minted against, reusing the saved
+    storage state would silently send the wrong session cookies (and the wrong
+    API key) to the new site.  We treat any URL mismatch as a cache miss so the
+    next run re-authenticates cleanly.
+
+    The four-hour TTL alone is not enough: the saved IdP session can die well
+    inside it (expiry, an admin revoking it, a password change).  Nothing on this
+    path ran :func:`_authenticate_workbench`, so ``workbench_auth_error`` stayed
+    ``None`` and every Workbench test skipped with a message that named no cause.
+    So when Workbench is requested we probe it before trusting the cache.
     """
     if not cache_path.exists():
         return None
@@ -326,6 +420,23 @@ def _load_cached_auth(
             f"workbench={requested_workbench_url or '∅'})."
         )
         return None
+
+    # Liveness probe: only when Workbench is actually requested, so Connect-only
+    # runs pay nothing for it.
+    if requested_workbench_url:
+        is_live = _cached_workbench_session_is_live(
+            requested_workbench_url,
+            _cookies_from_storage_state(cache_path),
+            insecure=insecure,
+            ca_bundle=ca_bundle,
+        )
+        if is_live is False:
+            print(
+                ">>> Ignoring cached auth session: the saved browser session no longer "
+                f"authenticates Workbench at {requested_workbench_url} "
+                "(it was sent back to the sign-in page). Re-authenticating."
+            )
+            return None
 
     print(f">>> Reusing cached auth session from {cache_path}")
     return InteractiveAuthSession(
@@ -509,7 +620,9 @@ def start_interactive_auth(
 
     # Check for a valid cached session.
     if cache_path:
-        cached = _load_cached_auth(cache_path, connect_url, workbench_url)
+        cached = _load_cached_auth(
+            cache_path, connect_url, workbench_url, insecure=insecure, ca_bundle=ca_bundle
+        )
         if cached is not None:
             return cached
 
@@ -695,7 +808,9 @@ def start_headless_auth(
     # Check for a valid cached session before validating credentials/idp,
     # so a warm cache works even when env vars are not set.
     if cache_path:
-        cached = _load_cached_auth(cache_path, connect_url, workbench_url)
+        cached = _load_cached_auth(
+            cache_path, connect_url, workbench_url, insecure=insecure, ca_bundle=ca_bundle
+        )
         if cached is not None:
             return cached
 

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -16,7 +16,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import httpx
 from playwright.sync_api import (
@@ -280,45 +280,76 @@ def auth_cache_path() -> Path:
     return Path.cwd() / AUTH_CACHE_FILENAME
 
 
-def _cookies_from_storage_state(storage_state_path: Path) -> dict[str, str]:
-    """Extract ``name -> value`` cookies from a Playwright storage-state file.
+def _cookies_from_storage_state(storage_state_path: Path) -> httpx.Cookies:
+    """Load cookies from a Playwright storage-state file, preserving their scope.
 
-    Lets the liveness probe below reuse the cached browser session over plain
-    httpx, with no Playwright launch.  A malformed or truncated cache yields an
-    empty dict rather than raising: the probe then reads as inconclusive and the
-    cache is reused, which is exactly the pre-probe behaviour.
+    Returns an ``httpx.Cookies`` jar with each cookie's ``domain`` and ``path``
+    intact, so httpx applies ordinary cookie-matching rules when the probe fires
+    and we don't hand-roll host matching.
+
+    Scope has to survive the round trip.  ``context.storage_state()`` captures a
+    whole browser context, and the auth flow deliberately visits the IdP and
+    Connect as well as Workbench — so this file holds their cookies too.
+    Flattening it to ``name -> value`` would fire all of them at the Workbench
+    host, leaking the IdP's session cookie somewhere a browser would never send
+    it, and would let two hosts using the same cookie name overwrite each other.
+    That second case is the dangerous one: sending the IdP's value for a name
+    Workbench also uses makes a *live* session read as dead and forces a
+    pointless re-auth.
+
+    A malformed or truncated cache yields an empty jar rather than raising: the
+    probe then reads as inconclusive and the cache is reused, which is exactly
+    the pre-probe behaviour.
     """
     import json
 
+    cookies = httpx.Cookies()
     try:
         state = json.loads(Path(storage_state_path).read_text())
     except (OSError, ValueError):
-        return {}
+        return cookies
     if not isinstance(state, dict):
-        return {}
+        return cookies
 
-    cookies: dict[str, str] = {}
     for cookie in state.get("cookies") or []:
         if not isinstance(cookie, dict):
             continue
         name = cookie.get("name")
         if not name:
             continue
-        cookies[str(name)] = str(cookie.get("value", ""))
+        cookies.set(
+            str(name),
+            str(cookie.get("value", "")),
+            domain=str(cookie.get("domain") or ""),
+            path=str(cookie.get("path") or "/"),
+        )
     return cookies
+
+
+class _ProbeResult(NamedTuple):
+    """A liveness verdict plus the evidence behind it.
+
+    ``detail`` is quoted in the cache-miss message.  A sign-in redirect and a
+    bare 401 point at different causes — an expired session versus something
+    stripping cookies in front of Workbench — so the message has to say which
+    one was seen rather than assume the redirect.
+    """
+
+    is_live: bool | None
+    detail: str = ""
 
 
 def _cached_workbench_session_is_live(
     workbench_url: str,
-    cookies: dict[str, str],
+    cookies: httpx.Cookies,
     *,
     insecure: bool = False,
     ca_bundle: Path | None = None,
     transport: httpx.BaseTransport | None = None,
-) -> bool | None:
+) -> _ProbeResult:
     """Report whether *cookies* still authenticate Workbench at *workbench_url*.
 
-    Returns ``True`` when the session lands on the dashboard, ``False`` on
+    ``is_live`` is ``True`` when the session lands on the dashboard, ``False`` on
     positive evidence that it is dead (a redirect to the sign-in page, or a bare
     401/403 from configs that do not redirect), and ``None`` when the probe could
     not reach a verdict.
@@ -338,12 +369,14 @@ def _cached_workbench_session_is_live(
             transport=transport,
         ) as client:
             response = client.get(workbench_url)
-    except httpx.HTTPError:
-        return None
+    except httpx.HTTPError as exc:
+        return _ProbeResult(None, f"could not reach Workbench: {exc}")
 
     if response.status_code in (401, 403):
-        return False
-    return not _on_login_page(str(response.url))
+        return _ProbeResult(False, f"Workbench answered {response.status_code}")
+    if _on_login_page(str(response.url)):
+        return _ProbeResult(False, f"the request landed on the sign-in page at {response.url}")
+    return _ProbeResult(True)
 
 
 def _load_cached_auth(
@@ -424,17 +457,17 @@ def _load_cached_auth(
     # Liveness probe: only when Workbench is actually requested, so Connect-only
     # runs pay nothing for it.
     if requested_workbench_url:
-        is_live = _cached_workbench_session_is_live(
+        probe = _cached_workbench_session_is_live(
             requested_workbench_url,
             _cookies_from_storage_state(cache_path),
             insecure=insecure,
             ca_bundle=ca_bundle,
         )
-        if is_live is False:
+        if probe.is_live is False:
             print(
                 ">>> Ignoring cached auth session: the saved browser session no longer "
                 f"authenticates Workbench at {requested_workbench_url} "
-                "(it was sent back to the sign-in page). Re-authenticating."
+                f"({probe.detail}). Re-authenticating."
             )
             return None
 

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -1077,6 +1077,7 @@ def _cleanup_workbench_sessions(
     """
     from vip.auth import (
         AuthConfigError,
+        auth_cache_path,
         authenticated_page,
         start_headless_auth,
         start_interactive_auth,
@@ -1086,11 +1087,10 @@ def _cleanup_workbench_sessions(
 
     insecure = config.insecure
     ca_bundle = config.ca_bundle
-    # Mirrors plugin.py's cache path (Path(config.rootpath) / ".vip-auth-cache.json"):
-    # there is no pytest config here, so the invocation directory stands in for
-    # rootpath, matching where a prior `vip verify` run from the same directory
-    # would have written its cache.
-    cache_path = Path.cwd() / ".vip-auth-cache.json"
+    # Same helper plugin.py uses, so this finds the session a prior `vip verify`
+    # from this directory cached.  These two used to build the path independently
+    # and disagreed for installed VIP -- see auth_cache_path.
+    cache_path = auth_cache_path()
 
     username = config.auth.username
     password = config.auth.password

--- a/src/vip/plugin.py
+++ b/src/vip/plugin.py
@@ -258,9 +258,9 @@ def pytest_configure(config: pytest.Config) -> None:
                 stacklevel=1,
             )
         else:
-            from vip.auth import start_interactive_auth
+            from vip.auth import auth_cache_path, start_interactive_auth
 
-            cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
+            cache_path = auth_cache_path()
             session = start_interactive_auth(
                 connect_url=connect_url,
                 workbench_url=wb_url,
@@ -307,9 +307,9 @@ def pytest_configure(config: pytest.Config) -> None:
                 stacklevel=1,
             )
         else:
-            from vip.auth import AuthConfigError, start_headless_auth
+            from vip.auth import AuthConfigError, auth_cache_path, start_headless_auth
 
-            cache_path = Path(config.rootpath) / ".vip-auth-cache.json"
+            cache_path = auth_cache_path()
             try:
                 session = start_headless_auth(
                     connect_url=connect_url,


### PR DESCRIPTION
No linked issue — this came out of a Local Launcher run where all 106 collected tests reported skipped, initially read as a parallelism regression. It is not one.

## The two defects

A cached auth session in `.vip-auth-cache.json` was trusted on nothing but a four-hour mtime TTL. Nothing on the cache-hit path verified the saved browser session still worked, and `_authenticate_workbench` only runs on the *fresh*-auth path — so `workbench_auth_error` stayed `None`. A dead IdP session (expiry, an admin revoking it, a password change) therefore made every Workbench test skip through `_workbench_session_skip_message`, with a message that named no cause and told the user to rerun with `--vip-verbose`. The absence of the `Pre-test auth reported:` line in that skip text is the diagnostic tell for this path.

Separately, `vip verify` and `vip cleanup --workbench-url` read different cache files. `plugin.py` built the path from `Path(config.rootpath)` while `cli.py` used `Path.cwd()`, and cli.py's comment asserted the two matched. For an installed VIP (`uv tool install posit-vip`) the test paths live in site-packages, so pytest derives rootdir from the common ancestor of the invocation directory and site-packages — which lands in `$HOME`. The cache went nowhere near the user's `vip.toml`, and `cleanup` looked somewhere `verify` never wrote.

## Why the probe has three outcomes, not two

`_cached_workbench_session_is_live` returns `True`, `False`, or `None`, and the third value is load-bearing. `False` requires positive evidence that the session is dead: a redirect landing on the sign-in page, or a bare 401/403 for the configs that answer an expired session without redirecting. A transport error returns `None` and the cache is reused.

Treating an unreachable deployment as a dead session would be actively worse than the bug being fixed. It would discard a good cache, trigger an interactive re-auth that cannot succeed either because the server is down, and bury the real reachability error behind an auth-shaped one. `None` preserves exactly the pre-probe behaviour, so the tests report the outage with their own message.

The probe runs over plain httpx with cookies read out of the Playwright storage state, so there is no browser launch. Those cookies keep their domain and path, and go into an `httpx.Cookies` jar so httpx applies ordinary cookie matching. That scoping is not hygiene: the storage state spans a whole browser context including the IdP, so flattening it to `name -> value` would both leak the IdP's session cookie to the Workbench host and let two hosts sharing a cookie name overwrite each other — and sending the IdP's value for a name Workbench also uses would make a live session read as dead, causing the very re-auth this PR removes. It fires only when Workbench is requested, and only after the existing URL-match check, so Connect-only runs pay nothing. TLS settings thread through the existing `_httpx_verify`, so `--insecure` and `--ca-bundle` deployments are not failed on TLS and sent through a pointless re-auth. A malformed cache file yields no cookies rather than raising before any test executes.

## Why cwd, not rootpath

`auth_cache_path()` is now the single source of truth and both call sites use it. Keying on the invocation directory rather than rootdir makes the code match what its own docstring already claimed — one slot per checkout directory. For a repo checkout the two were always identical; rootdir only diverges for installed VIP, which is the case that broke. A selftest enforces the invariant by asserting neither `plugin.py` nor `cli.py` contains the filename literal, since that inline duplication is how the two drifted apart.

This orphans any existing cache under `$HOME`, costing one re-auth. The orphaned file is `0600` and holds a Connect API key.

## Verification

18 new selftests: cookie extraction including malformed and nameless-cookie input, each probe verdict including the inconclusive path and the 401/403 pair, the cache-miss wiring including Connect-only skipping the probe and TLS settings reaching it, the path helper and its invariant, and two end-to-end tests asserting a dead cache actually reaches the browser flow while a live one short-circuits it.

1302 selftests pass, `just check` clean, mypy clean across 29 files. The only failures are the two known macOS timing flakes in `test_load_engine.py`, reproduced on a stashed unmodified tree.

## Deliberately not fixed

The probe validates Workbench only. A revoked cached *Connect API key* has the same failure shape and is still trusted unvalidated.

