### PR TITLE
fix: correct false skips, flaky search waits, and the header check

### DIFF
--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -130,6 +130,23 @@ def user_authenticated(page, connect_url):
 
 Then steps verify the outcome. Importantly, they should verify **actual system state**, not just the action's return value. Make a separate call to fetch current state when possible.
 
+### Fail, warn, or skip
+
+A Then step has three outcomes, and picking the wrong one is how a suite loses its signal:
+
+| Outcome | Use when | Example |
+|---|---|---|
+| **Fail** | The deployment is wrong *and* an administrator can fix it | `x-powered-by` leaks a proxy's version — suppress it at the proxy |
+| **Warn** (`warnings.warn`) | The finding is real and worth recording, but nothing in the deployment's control can change it | Package Manager's own `server` header carries its version and has no setting to suppress it |
+| **Skip** | The thing under test isn't present or configured, so there was nothing to verify | No OpenVSX repository is configured |
+
+Two failure modes to watch for, both of which have bitten this suite:
+
+- **A check that always fails.** Advice the product cannot satisfy turns a whole category red on every stock deployment and trains people to skim past it. Warn instead — the exposure stays on the record for a hardening baseline that cares.
+- **A check that can never fail.** If every branch of a Then step warns or skips, it is not a check. Whenever you downgrade one branch to a warning, confirm some other branch can still fail (see `no_version_headers` in `security/test_https.py`).
+
+Skips carry the same burden of accuracy as failures. A skip reason states *why* there was nothing to verify, so it must be true: `test_repos.py` used to report "package not available — repo may not be synced yet" after probing only the first repo whose name matched, when a synced mirror sitting beside it served the package fine. Probe every candidate before concluding anything, and name all of them in the reason.
+
 ### Fixtures as glue
 
 Pytest fixtures (`conftest.py`) are the glue between layers. They provide:

--- a/selftests/test_https_helper.py
+++ b/selftests/test_https_helper.py
@@ -15,7 +15,6 @@ import warnings
 
 import httpx
 import pytest
-from _pytest.outcomes import Failed
 
 from vip.config import VIPConfig
 from vip_tests.security.test_https import make_http_request, no_version_headers
@@ -164,7 +163,7 @@ class TestNoVersionHeaders:
         so it stays a failure -- otherwise this check can never fail at all."""
         headers = {"x-powered-by": "Express/4.18.2"}
 
-        with pytest.raises(Failed, match="x-powered-by"):
+        with pytest.raises(pytest.fail.Exception, match="x-powered-by"):
             no_version_headers(headers)
 
     def test_versionless_server_header_neither_warns_nor_fails(self):
@@ -187,5 +186,5 @@ class TestNoVersionHeaders:
             "x-powered-by": "Express/4.18.2",
         }
 
-        with pytest.warns(UserWarning), pytest.raises(Failed, match="x-powered-by"):
+        with pytest.warns(UserWarning), pytest.raises(pytest.fail.Exception, match="x-powered-by"):
             no_version_headers(headers)

--- a/selftests/test_https_helper.py
+++ b/selftests/test_https_helper.py
@@ -11,11 +11,14 @@ acceptable "port closed" outcome. See #457, #555.
 
 from __future__ import annotations
 
+import warnings
+
 import httpx
 import pytest
+from _pytest.outcomes import Failed
 
 from vip.config import VIPConfig
-from vip_tests.security.test_https import make_http_request
+from vip_tests.security.test_https import make_http_request, no_version_headers
 
 
 def test_make_http_request_classifies_connect_error_as_refused(monkeypatch):
@@ -116,3 +119,73 @@ def test_make_http_request_does_not_classify_read_timeout_as_refused(monkeypatch
 
     with pytest.raises(httpx.ReadTimeout):
         make_http_request("https://connect.example.com", VIPConfig())
+
+
+# ---------------------------------------------------------------------------
+# no_version_headers: version disclosure in response headers
+# ---------------------------------------------------------------------------
+
+
+class TestNoVersionHeaders:
+    """Version disclosure is reported, but only ``x-powered-by`` fails.
+
+    Package Manager emits ``server: Posit Package Manager v2026.06.0`` itself
+    and offers no setting to suppress it, so failing on it made the security
+    category permanently red on every stock deployment with advice nobody
+    could act on -- a finding that fires unconditionally trains people to
+    ignore the whole category.
+
+    ``x-powered-by`` is different: no Posit product sets it, so seeing one
+    means a reverse proxy or app server in front of the deployment is leaking
+    its own version, which *is* configurable where it originates. Keeping that
+    one fatal is what stops this check from becoming vacuous (#555).
+    """
+
+    def test_product_server_header_with_version_warns_instead_of_failing(self):
+        headers = {"server": "Posit Package Manager v2026.06.0"}
+
+        with pytest.warns(UserWarning, match=r"2026\.06\.0"):
+            no_version_headers(headers)
+
+    def test_warning_names_the_product_and_the_remediation(self):
+        headers = {"server": "Posit Package Manager v2026.06.0"}
+
+        with pytest.warns(UserWarning) as record:
+            no_version_headers(headers)
+
+        message = str(record[0].message)
+        assert "server" in message
+        assert "proxy" in message.lower(), (
+            f"warning must point at the only place this can be stripped: {message}"
+        )
+
+    def test_x_powered_by_with_version_still_fails(self):
+        """A fronting proxy leaking its version is actionable where it is set,
+        so it stays a failure -- otherwise this check can never fail at all."""
+        headers = {"x-powered-by": "Express/4.18.2"}
+
+        with pytest.raises(Failed, match="x-powered-by"):
+            no_version_headers(headers)
+
+    def test_versionless_server_header_neither_warns_nor_fails(self):
+        """``server: nginx`` discloses no version -- nothing to report."""
+        headers = {"server": "nginx"}
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            no_version_headers(headers)
+
+    def test_absent_headers_neither_warn_nor_fail(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            no_version_headers({})
+
+    def test_both_headers_present_fails_on_the_actionable_one(self):
+        """The fatal finding must not be masked by the warned-about one."""
+        headers = {
+            "server": "Posit Package Manager v2026.06.0",
+            "x-powered-by": "Express/4.18.2",
+        }
+
+        with pytest.warns(UserWarning), pytest.raises(Failed, match="x-powered-by"):
+            no_version_headers(headers)

--- a/selftests/test_pm_repo_selection.py
+++ b/selftests/test_pm_repo_selection.py
@@ -1,0 +1,179 @@
+"""Selftests for repository selection in
+``src/vip_tests/package_manager/test_repos.py``.
+
+A deployment commonly hosts several repos per ecosystem -- a full mirror
+alongside curated or vulnerability-blocked subsets (``pypi``,
+``curated-pypi``, ``pypi-vulns-blocked``). Selecting only the *first*
+name-matched repo made the check depend on alphabetical ordering: on a real
+deployment ``curated-pypi`` sorts first and by design carries only a handful
+of approved packages, so the PyPI scenario skipped with "'requests' not
+available -- repo may not be synced yet" while the ``pypi`` mirror right next
+to it served the package fine. That is a false skip: it silently drops
+coverage on a healthy deployment and reports an inaccurate reason.
+
+Every ecosystem step must therefore probe each candidate repo until one
+serves the package, the way ``query_openvsx`` already did.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vip_tests.package_manager.test_repos import (
+    query_bioconductor,
+    query_cran,
+    query_openvsx,
+    query_pypi,
+)
+
+# ---------------------------------------------------------------------------
+# Fake client
+# ---------------------------------------------------------------------------
+
+
+class FakePMClient:
+    """Minimal stand-in for ``PackageManagerClient``.
+
+    *repos* is the ``list_repos`` payload; *serving* maps repo name -> the set
+    of packages that repo serves. ``probed`` records every availability call so
+    a test can assert the step actually walked past a non-serving repo.
+    """
+
+    def __init__(self, repos, serving=None):
+        self._repos = repos
+        self._serving = serving or {}
+        self.probed: list[tuple[str, str]] = []
+
+    def list_repos(self):
+        return self._repos
+
+    def _available(self, repo_name, package):
+        self.probed.append((repo_name, package))
+        return package in self._serving.get(repo_name, set())
+
+    cran_package_available = _available
+    pypi_package_available = _available
+    bioconductor_package_available = _available
+    openvsx_extension_available = _available
+
+
+def _repo(name, type_=""):
+    return {"name": name, "type": type_}
+
+
+def _run_expecting_no_skip(step, client):
+    """Call *step*, converting an unexpected ``pytest.skip`` into a failure.
+
+    Letting the skip propagate would mark *this selftest* as skipped rather
+    than failed -- the regression these tests exist to catch would sail
+    through green. Catch it and fail loudly with the reason instead.
+    """
+    try:
+        return step(client)
+    except pytest.skip.Exception as exc:
+        pytest.fail(f"step skipped instead of finding the package: {exc.msg}")
+
+
+# Each ecosystem's step function, the repo names that match its hint, and the
+# package it looks for -- so one parametrized body covers all four.
+#
+# The two repo names per ecosystem are deliberately NOT substrings of one
+# another ("cran-mirror", not "cran", alongside "curated-cran"): the skip-reason
+# assertion below checks that every probed repo is named in the message, and a
+# substring would satisfy that check even when only the first repo was listed.
+ECOSYSTEMS = [
+    pytest.param(query_cran, ["curated-cran", "cran-mirror"], "Matrix", "CRAN", id="cran"),
+    pytest.param(query_pypi, ["curated-pypi", "pypi-mirror"], "requests", "PyPI", id="pypi"),
+    pytest.param(
+        query_bioconductor,
+        ["curated-bioc", "bioc-mirror"],
+        "BiocGenerics",
+        "Bioconductor",
+        id="bioconductor",
+    ),
+    pytest.param(
+        query_openvsx, ["curated-vsx", "vsx-mirror"], "golang.Go", "OpenVSX", id="openvsx"
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_falls_through_to_a_later_repo_that_serves_the_package(step, repo_names, package, label):
+    """The regression: the package lives in the second matching repo.
+
+    The first repo sorts earlier and does not carry the package (a curated
+    subset), so stopping at ``repos[0]`` produced a false skip.
+    """
+    client = FakePMClient(
+        [_repo(n) for n in repo_names],
+        serving={repo_names[1]: {package}},
+    )
+
+    assert _run_expecting_no_skip(step, client) is True
+    assert client.probed == [(repo_names[0], package), (repo_names[1], package)]
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_stops_probing_once_a_repo_serves_the_package(step, repo_names, package, label):
+    """No wasted requests: the walk short-circuits on the first hit."""
+    client = FakePMClient(
+        [_repo(n) for n in repo_names],
+        serving={n: {package} for n in repo_names},
+    )
+
+    assert _run_expecting_no_skip(step, client) is True
+    assert client.probed == [(repo_names[0], package)]
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_skips_when_no_repo_serves_the_package(step, repo_names, package, label):
+    """Still a skip when the package is genuinely absent everywhere -- but the
+    reason must name every repo tried, not just the first, so the message
+    doesn't misattribute an unsynced mirror."""
+    client = FakePMClient([_repo(n) for n in repo_names], serving={})
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        step(client)
+
+    message = exc_info.value.msg
+    assert package in message
+    for name in repo_names:
+        assert name in message, f"skip reason should name every repo tried: {message}"
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_skips_when_no_repo_of_that_ecosystem_is_configured(step, repo_names, package, label):
+    """A deployment with no repo of this ecosystem skips with a distinct
+    reason -- "none configured" is a different state from "configured but not
+    synced", and conflating them hides a misconfiguration."""
+    client = FakePMClient([_repo("unrelated-repo")], serving={})
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        step(client)
+
+    assert "configured" in exc_info.value.msg
+    assert client.probed == []
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_matches_on_declared_type_not_only_the_name_hint(step, repo_names, package, label):
+    """A repo whose name carries no hint is still a candidate when the server
+    declares a matching ``type``, so a deployment free to name its repos
+    anything is not silently skipped."""
+    declared_type = {
+        "CRAN": "cran",
+        "PyPI": "pypi",
+        "Bioconductor": "bioconductor",
+        "OpenVSX": "VSX",
+    }[label]
+    client = FakePMClient(
+        [_repo("packages", declared_type)],
+        serving={"packages": {package}},
+    )
+
+    assert _run_expecting_no_skip(step, client) is True

--- a/selftests/test_pm_repo_selection.py
+++ b/selftests/test_pm_repo_selection.py
@@ -177,3 +177,46 @@ def test_matches_on_declared_type_not_only_the_name_hint(step, repo_names, packa
     )
 
     assert _run_expecting_no_skip(step, client) is True
+
+
+# ---------------------------------------------------------------------------
+# Malformed repo payloads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_explicit_null_type_does_not_crash_the_step(step, repo_names, package, label):
+    """``{"type": null}`` is valid JSON the server can send, and ``.get("type",
+    "")`` returns None for it rather than the default -- which the OpenVSX
+    matcher's ``.upper()`` turned into an AttributeError, crashing repo
+    selection instead of skipping or passing. The name hint must still match."""
+    client = FakePMClient(
+        [{"name": repo_names[1], "type": None}],
+        serving={repo_names[1]: {package}},
+    )
+
+    assert _run_expecting_no_skip(step, client) is True
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_explicit_null_name_is_skipped_over(step, repo_names, package, label):
+    """A repo with a null name cannot be queried, so it must be dropped rather
+    than probed as the empty string."""
+    client = FakePMClient(
+        [{"name": None, "type": None}, {"name": repo_names[1], "type": None}],
+        serving={repo_names[1]: {package}},
+    )
+
+    assert _run_expecting_no_skip(step, client) is True
+    assert client.probed == [(repo_names[1], package)]
+
+
+@pytest.mark.parametrize(("step", "repo_names", "package", "label"), ECOSYSTEMS)
+def test_repo_payload_missing_both_keys_is_ignored(step, repo_names, package, label):
+    client = FakePMClient([{}], serving={})
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        step(client)
+
+    assert "configured" in exc_info.value.msg
+    assert client.probed == []

--- a/selftests/test_pm_search_wait.py
+++ b/selftests/test_pm_search_wait.py
@@ -1,0 +1,178 @@
+"""Selftests for ``wait_for_search_results`` in
+``src/vip_tests/package_manager/pages/ui.py``.
+
+Package search against a full mirror is far slower than the other UI waits in
+that module: measured against a real deployment, the first result row on the
+``pypi`` repo rendered in ~4s eleven times out of twelve and took 53.8s once,
+while ``cran`` stayed at ~1s. The shared 15s ceiling sat inside that tail, so
+the PyPI search and detail scenarios failed intermittently on a healthy
+deployment.
+
+Raising the ceiling alone would trade a false failure for a silent one -- a
+deployment whose package search takes a minute is worth reporting. Hence the
+split: wait up to TIMEOUT_SEARCH, warn past SLOW_SEARCH_MS, fail with a
+readable message only when nothing renders at all.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from vip_tests.package_manager.pages.ui import (
+    SLOW_SEARCH_MS,
+    TIMEOUT_PAGE_LOAD,
+    TIMEOUT_SEARCH,
+    wait_for_search_results,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeLocator:
+    """Stands in for ``page.locator(...).first``.
+
+    *delay* is the wall-clock time ``wait_for`` pretends the row took to
+    appear; *timeout_after* makes it raise Playwright's timeout instead.
+    """
+
+    def __init__(self, clock, delay=0.0, timeout_after=False):
+        self._clock = clock
+        self._delay = delay
+        self._timeout_after = timeout_after
+        self.first = self
+        self.waited_with: dict | None = None
+
+    def wait_for(self, **kwargs):
+        self.waited_with = kwargs
+        self._clock.advance(self._delay)
+        if self._timeout_after:
+            raise PlaywrightTimeoutError("Timeout exceeded")
+
+
+class FakePage:
+    def __init__(self, locator):
+        self._locator = locator
+        self.selectors: list[str] = []
+
+    def locator(self, selector):
+        self.selectors.append(selector)
+        return self._locator
+
+
+class FakeClock:
+    """Monotonic clock the test drives, so nothing here actually sleeps."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def advance(self, seconds):
+        self.now += seconds
+
+    def __call__(self):
+        return self.now
+
+
+@pytest.fixture()
+def clock(monkeypatch):
+    fake = FakeClock()
+    monkeypatch.setattr("vip_tests.package_manager.pages.ui.time.monotonic", fake)
+    return fake
+
+
+def _page(clock, **locator_kwargs):
+    return FakePage(FakeLocator(clock, **locator_kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFastSearch:
+    def test_returns_elapsed_without_warning(self, clock):
+        page = _page(clock, delay=4.0)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            elapsed = wait_for_search_results(page)
+
+        assert elapsed == pytest.approx(4.0)
+
+    def test_waits_on_the_shared_result_row_selector(self, clock):
+        """Ecosystem-agnostic: the prefix hook, not a per-package id."""
+        page = _page(clock, delay=1.0)
+
+        wait_for_search_results(page)
+
+        assert page.selectors == ["[data-automation^='package-link-']"]
+
+    def test_uses_the_search_ceiling_not_the_page_load_one(self, clock):
+        """The regression: at TIMEOUT_PAGE_LOAD this wait failed on a healthy
+        deployment whose PyPI search sat in the slow tail."""
+        page = _page(clock, delay=1.0)
+
+        wait_for_search_results(page)
+
+        assert page._locator.waited_with == {"state": "visible", "timeout": TIMEOUT_SEARCH}
+        assert TIMEOUT_SEARCH > TIMEOUT_PAGE_LOAD
+
+
+class TestSlowSearch:
+    def test_search_past_the_threshold_warns_but_still_passes(self, clock):
+        """The 53.8s observation: slow, not broken. It must be reported and
+        must not fail."""
+        page = _page(clock, delay=53.8)
+
+        with pytest.warns(UserWarning, match="package search took 53.8s"):
+            elapsed = wait_for_search_results(page)
+
+        assert elapsed == pytest.approx(53.8)
+
+    def test_warning_is_actionable(self, clock):
+        page = _page(clock, delay=53.8)
+
+        with pytest.warns(UserWarning) as record:
+            wait_for_search_results(page)
+
+        message = str(record[0].message)
+        assert "Search works" in message
+        assert "repo" in message
+
+    def test_just_under_the_threshold_stays_quiet(self, clock):
+        """Boundary: SLOW_SEARCH_MS is the line, and a search below it is
+        unremarkable -- no warning noise on every normal run."""
+        page = _page(clock, delay=(SLOW_SEARCH_MS / 1000) - 0.1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            wait_for_search_results(page)
+
+
+class TestNoResults:
+    def test_timeout_raises_a_readable_assertion_not_a_playwright_error(self, clock):
+        """A raw Playwright timeout surfaces as "an unexpected error occurred:
+        Locator.wait_for: Timeout 15000ms exceeded", which tells an
+        administrator nothing. Fail with the diagnosis instead."""
+        page = _page(clock, delay=90.0, timeout_after=True)
+
+        with pytest.raises(AssertionError) as exc_info:
+            wait_for_search_results(page)
+
+        message = str(exc_info.value)
+        assert "90s" in message
+        assert "confirmed to exist over the API" in message
+        assert "VIP_TIMEOUT_SCALE" in message
+
+    def test_timeout_does_not_also_warn_about_slowness(self, clock):
+        """A failure is not also a slow-search report -- one finding, not two."""
+        page = _page(clock, delay=90.0, timeout_after=True)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(AssertionError):
+                wait_for_search_results(page)

--- a/selftests/test_pm_ui_target.py
+++ b/selftests/test_pm_ui_target.py
@@ -1,0 +1,175 @@
+"""Selftests for ``ui_target`` / ``_find_ui_target`` in
+``src/vip_tests/package_manager/test_ui.py``.
+
+The UI scenarios skip when the deployment has nothing to exercise, and the
+reason has to say *which* nothing. ``_find_ui_target`` returned a bare ``{}``
+for two unrelated states -- no repo of that ecosystem is configured at all, and
+a repo is configured but does not serve the known package -- so the caller
+reported both as "repo may not be synced yet". On a deployment with no OpenVSX
+repository whatsoever that sent an administrator looking for a stalled sync
+that did not exist, while ``test_repos.py`` described the very same deployment
+accurately as "No OpenVSX repository configured in Package Manager".
+
+Two files disagreeing about one fact in a single run is the bug. These tests
+pin both messages and assert the two modules stay consistent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vip_tests.package_manager.test_repos import (
+    query_bioconductor,
+    query_cran,
+    query_openvsx,
+    query_pypi,
+)
+from vip_tests.package_manager.test_ui import ui_target
+
+# ---------------------------------------------------------------------------
+# Fake client
+# ---------------------------------------------------------------------------
+
+
+class FakePMClient:
+    """Stand-in for ``PackageManagerClient``; see the twin in
+    ``test_pm_repo_selection.py``."""
+
+    def __init__(self, repos, serving=None):
+        self._repos = repos
+        self._serving = serving or {}
+        self.probed: list[tuple[str, str]] = []
+
+    def list_repos(self):
+        return self._repos
+
+    def _available(self, repo_name, package):
+        self.probed.append((repo_name, package))
+        return package in self._serving.get(repo_name, set())
+
+    cran_package_available = _available
+    pypi_package_available = _available
+    bioconductor_package_available = _available
+    openvsx_extension_available = _available
+
+
+# Ecosystem label, two repo names matching its hint, and its known package.
+# Names are deliberately not substrings of each other so an assertion that both
+# appear in a message cannot pass on a partial match.
+ECOSYSTEMS = [
+    pytest.param("CRAN", ["curated-cran", "cran-mirror"], "Matrix", id="cran"),
+    pytest.param("PyPI", ["curated-pypi", "pypi-mirror"], "requests", id="pypi"),
+    pytest.param(
+        "Bioconductor", ["curated-bioc", "bioc-mirror"], "BiocGenerics", id="bioconductor"
+    ),
+    pytest.param("OpenVSX", ["curated-vsx", "vsx-mirror"], "golang.Go", id="openvsx"),
+]
+
+# Maps an ecosystem to the equivalent test_repos.py step, for the
+# cross-module consistency check at the bottom.
+REPOS_STEP = {
+    "CRAN": query_cran,
+    "PyPI": query_pypi,
+    "Bioconductor": query_bioconductor,
+    "OpenVSX": query_openvsx,
+}
+
+
+def _repo(name, type_=""):
+    return {"name": name, "type": type_}
+
+
+def _skip_reason(fn, *args):
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        fn(*args)
+    return exc_info.value.msg
+
+
+# ---------------------------------------------------------------------------
+# Finding a target
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("ecosystem", "repo_names", "package"), ECOSYSTEMS)
+def test_returns_the_repo_that_serves_the_package(ecosystem, repo_names, package):
+    client = FakePMClient(
+        [_repo(n) for n in repo_names],
+        serving={repo_names[1]: {package}},
+    )
+
+    target = ui_target(client, ecosystem)
+
+    assert target == {"repo": repo_names[1], "package": package, "ecosystem": ecosystem}
+
+
+@pytest.mark.parametrize(("ecosystem", "repo_names", "package"), ECOSYSTEMS)
+def test_null_repo_name_does_not_crash(ecosystem, repo_names, package):
+    """``{"name": null}`` is valid JSON; ``.get("name", "")`` hands back None
+    for it and ``.lower()`` then raises, taking the step down with an
+    AttributeError instead of skipping."""
+    client = FakePMClient(
+        [{"name": None, "type": None}, _repo(repo_names[1])],
+        serving={repo_names[1]: {package}},
+    )
+
+    assert ui_target(client, ecosystem)["repo"] == repo_names[1]
+
+
+# ---------------------------------------------------------------------------
+# The two skip states must be distinguishable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("ecosystem", "repo_names", "package"), ECOSYSTEMS)
+def test_nothing_configured_does_not_blame_syncing(ecosystem, repo_names, package):
+    """The OpenVSX case from a real run: no repo of this ecosystem exists at
+    all, so "may not be synced yet" points at a stalled sync that isn't there."""
+    client = FakePMClient([_repo("unrelated-repo")], serving={})
+
+    reason = _skip_reason(ui_target, client, ecosystem)
+
+    assert "configured" in reason
+    assert "synced" not in reason, f"nothing is configured, so syncing is not the cause: {reason}"
+    assert client.probed == []
+
+
+@pytest.mark.parametrize(("ecosystem", "repo_names", "package"), ECOSYSTEMS)
+def test_configured_but_unserved_names_every_repo_tried(ecosystem, repo_names, package):
+    """The other state: repos exist and genuinely may still be syncing. Here
+    the reason must name them, so the administrator knows where to look."""
+    client = FakePMClient([_repo(n) for n in repo_names], serving={})
+
+    reason = _skip_reason(ui_target, client, ecosystem)
+
+    assert "synced" in reason
+    assert package in reason
+    for name in repo_names:
+        assert name in reason, f"skip reason should name every repo tried: {reason}"
+
+
+# ---------------------------------------------------------------------------
+# Cross-module consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("ecosystem", "repo_names", "package"), ECOSYSTEMS)
+def test_agrees_with_test_repos_when_nothing_is_configured(ecosystem, repo_names, package):
+    """One deployment fact, one explanation. test_ui.py and test_repos.py ran
+    in the same session and described an OpenVSX-less server two different
+    ways; the "nothing configured" reason must now match verbatim."""
+    client = FakePMClient([_repo("unrelated-repo")], serving={})
+
+    ui_reason = _skip_reason(ui_target, client, ecosystem)
+    repos_reason = _skip_reason(REPOS_STEP[ecosystem], FakePMClient([_repo("unrelated-repo")]))
+
+    assert ui_reason == repos_reason
+
+
+@pytest.mark.parametrize(("ecosystem", "repo_names", "package"), ECOSYSTEMS)
+def test_agrees_with_test_repos_when_configured_but_unserved(ecosystem, repo_names, package):
+    repos = [_repo(n) for n in repo_names]
+
+    ui_reason = _skip_reason(ui_target, FakePMClient(repos), ecosystem)
+    repos_reason = _skip_reason(REPOS_STEP[ecosystem], FakePMClient(repos))
+
+    assert ui_reason == repos_reason

--- a/src/vip_tests/package_manager/pages/__init__.py
+++ b/src/vip_tests/package_manager/pages/__init__.py
@@ -8,6 +8,7 @@ from .ui import (
     open_package_detail_via_click,
     open_repo_packages,
     search_packages,
+    wait_for_search_results,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "open_package_detail_via_click",
     "open_repo_packages",
     "search_packages",
+    "wait_for_search_results",
 ]

--- a/src/vip_tests/package_manager/pages/ui.py
+++ b/src/vip_tests/package_manager/pages/ui.py
@@ -10,6 +10,9 @@ full page load.
 
 from __future__ import annotations
 
+import time
+import warnings
+
 from playwright.sync_api import Page, expect
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -18,6 +21,29 @@ from vip.timeouts import timeout_scale
 # Scaled the same way the Workbench UI tests scale theirs, via VIP_TIMEOUT_SCALE.
 TIMEOUT_PAGE_LOAD = int(15_000 * timeout_scale())
 TIMEOUT_ELEMENT = int(10_000 * timeout_scale())
+
+# Package search gets its own, much longer ceiling. Searching a full PyPI or
+# CRAN mirror is not comparable to the other waits in this module: the repo
+# packages page fires an unfiltered first-page listing and a popular-packages
+# query alongside the debounced search, and on a large repo those pile up.
+#
+# Measured, not guessed. Across 12 runs against a real deployment, the first
+# result row on the ``pypi`` repo rendered in ~4s eleven times and took 53.8s
+# once -- on the first search of the session, so the tail reads as a cold
+# cache rather than steady-state load. (The same wait on ``cran`` was ~1s
+# throughout, which is why only the large mirrors are affected.) A 15s ceiling
+# sits right inside that tail, so the PyPI search and detail scenarios failed
+# intermittently on a perfectly healthy deployment. 90s clears the observed
+# worst case with room to spare; anything genuinely broken still fails, just
+# later.
+TIMEOUT_SEARCH = int(90_000 * timeout_scale())
+
+# A search slower than this is reported but not failed: it is a real complaint
+# about the deployment (nobody waits 15s for a package search) without being
+# evidence that search is broken. Deliberately the same value as
+# TIMEOUT_PAGE_LOAD, so every wait that previously failed now surfaces as a
+# warning instead of vanishing.
+SLOW_SEARCH_MS = TIMEOUT_PAGE_LOAD
 
 
 def _settle_network(page: Page) -> None:
@@ -115,6 +141,44 @@ def search_packages(page: Page, package: str) -> None:
     )
 
 
+def wait_for_search_results(page: Page) -> float:
+    """Wait for the first search-result row; warn when the wait was long.
+
+    Returns the elapsed seconds. Raises ``AssertionError`` (not a raw
+    Playwright timeout) when no row appears within TIMEOUT_SEARCH, so a genuine
+    search outage reports as a readable failure rather than "an unexpected
+    error occurred: Locator.wait_for: Timeout exceeded".
+
+    The warning above SLOW_SEARCH_MS is the point of this helper: raising the
+    ceiling alone would silently absorb a deployment whose package search takes
+    a minute, which is worth telling an administrator about even though it is
+    not a broken deployment.
+    """
+    started = time.monotonic()
+    try:
+        page.locator(PackagesPage.RESULT_ITEMS).first.wait_for(
+            state="visible", timeout=TIMEOUT_SEARCH
+        )
+    except PlaywrightTimeoutError:
+        raise AssertionError(
+            f"No package search result rendered within {TIMEOUT_SEARCH / 1000:g}s. "
+            "The package was confirmed to exist over the API before the browser "
+            "was driven, so either the search UI is broken or the deployment is "
+            "far slower than the timeout allows (raise it with VIP_TIMEOUT_SCALE)."
+        ) from None
+
+    elapsed = time.monotonic() - started
+    if elapsed * 1000 > SLOW_SEARCH_MS:
+        warnings.warn(
+            f"VIP: package search took {elapsed:.1f}s to render its first result "
+            f"(over the {SLOW_SEARCH_MS / 1000:g}s expected). Search works, but "
+            "this is slow enough for users to notice — check Package Manager's "
+            "database and the size of the repo being searched.",
+            stacklevel=2,
+        )
+    return elapsed
+
+
 def open_package_detail_via_click(page: Page) -> None:
     """Click the first search-result row and wait for its detail page.
 
@@ -127,7 +191,6 @@ def open_package_detail_via_click(page: Page) -> None:
     Assumes a search has already been run so at least one result row is present;
     clicks the first result and waits for the detail hero.
     """
-    result = page.locator(PackagesPage.RESULT_ITEMS).first
-    result.wait_for(state="visible", timeout=TIMEOUT_PAGE_LOAD)
-    result.click()
+    wait_for_search_results(page)
+    page.locator(PackagesPage.RESULT_ITEMS).first.click()
     expect(page.locator(PackageDetailPage.TITLE)).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)

--- a/src/vip_tests/package_manager/test_repos.py
+++ b/src/vip_tests/package_manager/test_repos.py
@@ -32,6 +32,38 @@ def test_repo_exists():
 
 
 # ---------------------------------------------------------------------------
+# Repository selection
+# ---------------------------------------------------------------------------
+
+
+def _first_repo_serving(pm_client, *, ecosystem, matches, available, package, noun="package"):
+    """Return the first repo matching *ecosystem* that actually serves *package*.
+
+    A deployment routinely hosts several repos per ecosystem -- a full mirror
+    alongside curated or vulnerability-blocked subsets. Probing only the first
+    match made the result depend on the order the server happens to list them
+    in: ``curated-pypi`` sorts ahead of ``pypi`` and by design carries only a
+    handful of approved packages, so the PyPI scenario skipped as "not
+    available -- repo may not be synced yet" while the full mirror beside it
+    served the package fine. Walk every candidate before concluding anything.
+
+    Skips (never fails) in two distinguishable states: no repo of this
+    ecosystem is configured at all, or one is configured but none serves the
+    package. Those are different deployment problems and the reason says which.
+    """
+    candidates = [r.get("name", "") for r in pm_client.list_repos() if matches(r)]
+    if not candidates:
+        pytest.skip(f"No {ecosystem} repository configured in Package Manager")
+    for repo_name in candidates:
+        if available(repo_name, package):
+            return repo_name
+    pytest.skip(
+        f"{ecosystem} {noun} {package!r} not available in any of {candidates} — "
+        "repo may not be synced yet"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Steps
 # ---------------------------------------------------------------------------
 
@@ -48,19 +80,13 @@ def pm_running(pm_client):
     target_fixture="package_found",
 )
 def query_cran(pm_client):
-    repos = pm_client.list_repos()
-    cran_repos = [
-        r for r in repos if r.get("type") == "cran" or "cran" in r.get("name", "").lower()
-    ]
-    if not cran_repos:
-        pytest.skip("No CRAN repository configured in Package Manager")
-    repo_name = cran_repos[0]["name"]
-    found = pm_client.cran_package_available(repo_name, "Matrix")
-    if not found:
-        pytest.skip(
-            f"CRAN package 'Matrix' not available in repo {repo_name!r} — "
-            "repo may not be synced yet"
-        )
+    _first_repo_serving(
+        pm_client,
+        ecosystem="CRAN",
+        matches=lambda r: r.get("type") == "cran" or "cran" in r.get("name", "").lower(),
+        available=pm_client.cran_package_available,
+        package="Matrix",
+    )
     return True
 
 
@@ -69,19 +95,13 @@ def query_cran(pm_client):
     target_fixture="package_found",
 )
 def query_pypi(pm_client):
-    repos = pm_client.list_repos()
-    pypi_repos = [
-        r for r in repos if r.get("type") == "pypi" or "pypi" in r.get("name", "").lower()
-    ]
-    if not pypi_repos:
-        pytest.skip("No PyPI repository configured in Package Manager")
-    repo_name = pypi_repos[0]["name"]
-    found = pm_client.pypi_package_available(repo_name, "requests")
-    if not found:
-        pytest.skip(
-            f"PyPI package 'requests' not available in repo {repo_name!r} — "
-            "repo may not be synced yet"
-        )
+    _first_repo_serving(
+        pm_client,
+        ecosystem="PyPI",
+        matches=lambda r: r.get("type") == "pypi" or "pypi" in r.get("name", "").lower(),
+        available=pm_client.pypi_package_available,
+        package="requests",
+    )
     return True
 
 
@@ -90,19 +110,13 @@ def query_pypi(pm_client):
     target_fixture="package_found",
 )
 def query_bioconductor(pm_client):
-    repos = pm_client.list_repos()
-    bioc_repos = [
-        r for r in repos if r.get("type") == "bioconductor" or "bioc" in r.get("name", "").lower()
-    ]
-    if not bioc_repos:
-        pytest.skip("No Bioconductor repository configured in Package Manager")
-    repo_name = bioc_repos[0]["name"]
-    found = pm_client.bioconductor_package_available(repo_name, "BiocGenerics")
-    if not found:
-        pytest.skip(
-            f"Bioconductor package 'BiocGenerics' not available in repo {repo_name!r} — "
-            "repo may not be synced yet"
-        )
+    _first_repo_serving(
+        pm_client,
+        ecosystem="Bioconductor",
+        matches=lambda r: r.get("type") == "bioconductor" or "bioc" in r.get("name", "").lower(),
+        available=pm_client.bioconductor_package_available,
+        package="BiocGenerics",
+    )
     return True
 
 
@@ -111,27 +125,15 @@ def query_bioconductor(pm_client):
     target_fixture="package_found",
 )
 def query_openvsx(pm_client):
-    repos = pm_client.list_repos()
-
-    def is_vsx(r):
-        return r.get("type", "").upper() == "VSX" or "vsx" in r.get("name", "").lower()
-
-    vsx_repos = [r for r in repos if is_vsx(r)]
-    if not vsx_repos:
-        pytest.skip("No OpenVSX repository configured in Package Manager")
-    # A deployment can host several VSX repos (e.g. a full openvsx mirror
-    # alongside a curated subset). Check each until the extension is found,
-    # rather than assuming the first repo carries it.
-    tried = []
-    for repo in vsx_repos:
-        repo_name = repo["name"]
-        tried.append(repo_name)
-        if pm_client.openvsx_extension_available(repo_name, "golang.Go"):
-            return True
-    pytest.skip(
-        f"OpenVSX extension 'golang.Go' not available in any VSX repo {tried} — "
-        "repo may not be synced yet"
+    _first_repo_serving(
+        pm_client,
+        ecosystem="OpenVSX",
+        matches=lambda r: r.get("type", "").upper() == "VSX" or "vsx" in r.get("name", "").lower(),
+        available=pm_client.openvsx_extension_available,
+        package="golang.Go",
+        noun="extension",
     )
+    return True
 
 
 @when("I list all repositories", target_fixture="repo_list")

--- a/src/vip_tests/package_manager/test_repos.py
+++ b/src/vip_tests/package_manager/test_repos.py
@@ -50,8 +50,19 @@ def _first_repo_serving(pm_client, *, ecosystem, matches, available, package, no
     Skips (never fails) in two distinguishable states: no repo of this
     ecosystem is configured at all, or one is configured but none serves the
     package. Those are different deployment problems and the reason says which.
+
+    *matches* is called with the repo's ``type`` and ``name`` already coerced
+    to strings. The server can send an explicit JSON null for either, which
+    ``.get("type", "")`` would hand straight through as None and crash the
+    matcher on ``.upper()``; normalising here means no matcher has to remember.
+    A repo with no usable name is dropped outright -- there is nothing to query.
     """
-    candidates = [r.get("name", "") for r in pm_client.list_repos() if matches(r)]
+    candidates = []
+    for repo in pm_client.list_repos():
+        name = repo.get("name") or ""
+        repo_type = repo.get("type") or ""
+        if name and matches(repo_type, name):
+            candidates.append(name)
     if not candidates:
         pytest.skip(f"No {ecosystem} repository configured in Package Manager")
     for repo_name in candidates:
@@ -83,7 +94,7 @@ def query_cran(pm_client):
     _first_repo_serving(
         pm_client,
         ecosystem="CRAN",
-        matches=lambda r: r.get("type") == "cran" or "cran" in r.get("name", "").lower(),
+        matches=lambda t, n: t == "cran" or "cran" in n.lower(),
         available=pm_client.cran_package_available,
         package="Matrix",
     )
@@ -98,7 +109,7 @@ def query_pypi(pm_client):
     _first_repo_serving(
         pm_client,
         ecosystem="PyPI",
-        matches=lambda r: r.get("type") == "pypi" or "pypi" in r.get("name", "").lower(),
+        matches=lambda t, n: t == "pypi" or "pypi" in n.lower(),
         available=pm_client.pypi_package_available,
         package="requests",
     )
@@ -113,7 +124,7 @@ def query_bioconductor(pm_client):
     _first_repo_serving(
         pm_client,
         ecosystem="Bioconductor",
-        matches=lambda r: r.get("type") == "bioconductor" or "bioc" in r.get("name", "").lower(),
+        matches=lambda t, n: t == "bioconductor" or "bioc" in n.lower(),
         available=pm_client.bioconductor_package_available,
         package="BiocGenerics",
     )
@@ -128,7 +139,7 @@ def query_openvsx(pm_client):
     _first_repo_serving(
         pm_client,
         ecosystem="OpenVSX",
-        matches=lambda r: r.get("type", "").upper() == "VSX" or "vsx" in r.get("name", "").lower(),
+        matches=lambda t, n: t.upper() == "VSX" or "vsx" in n.lower(),
         available=pm_client.openvsx_extension_available,
         package="golang.Go",
         noun="extension",

--- a/src/vip_tests/package_manager/test_ui.py
+++ b/src/vip_tests/package_manager/test_ui.py
@@ -76,28 +76,49 @@ _ECOSYSTEMS: dict[str, dict] = {
         "type": "vsx",
         "hint": "vsx",
         "package": "golang.Go",
+        # OpenVSX ships extensions, not packages; the skip reason says so.
+        "noun": "extension",
         "available": lambda c, r, p: c.openvsx_extension_available(r, p),
     },
 }
 
 
-def _find_ui_target(pm_client, ecosystem: str) -> dict[str, str]:
-    """Return the first repo of *ecosystem* that serves its known package.
+def _find_ui_target(pm_client, ecosystem: str) -> tuple[dict[str, str], list[str]]:
+    """Return the first repo of *ecosystem* serving its package, and the
+    candidates considered.
 
     Matches by repo ``type`` or a name hint (a deployment may name a repo
     ``cran`` without setting a canonical type), then confirms availability over
-    the API. Returns ``{}`` when nothing suitable is configured/synced.
+    the API.
+
+    Returning the candidate list alongside the target is what lets the caller
+    tell two very different states apart: no repo of this ecosystem exists at
+    all (empty list), versus repos exist but none serves the package (populated
+    list). Collapsing both into a bare ``{}`` made every skip read "repo may not
+    be synced yet" — so a deployment with no OpenVSX repository whatsoever sent
+    administrators hunting a stalled sync that did not exist, while
+    ``test_repos.py`` described the same deployment correctly in the same run.
+
+    ``name`` and ``type`` are coerced because the server can send an explicit
+    JSON null for either, which ``.get(key, "")`` passes straight through;
+    ``.lower()`` on that raises. Repos with no usable name are dropped — there
+    is nothing to query.
     """
     eco = _ECOSYSTEMS[ecosystem]
+    candidates: list[str] = []
+    target: dict[str, str] = {}
     for repo in pm_client.list_repos():
-        name = repo.get("name", "")
-        type_matches = (repo.get("type") or "").lower() == eco["type"]
-        hint_matches = eco["hint"] in name.lower()
-        if not (type_matches or hint_matches):
+        name = repo.get("name") or ""
+        repo_type = repo.get("type") or ""
+        if not name:
             continue
+        if not (repo_type.lower() == eco["type"] or eco["hint"] in name.lower()):
+            continue
+        candidates.append(name)
         if eco["available"](pm_client, name, eco["package"]):
-            return {"repo": name, "package": eco["package"], "ecosystem": ecosystem}
-    return {}
+            target = {"repo": name, "package": eco["package"], "ecosystem": ecosystem}
+            break
+    return target, candidates
 
 
 # ---------------------------------------------------------------------------
@@ -120,13 +141,19 @@ def ui_reachable(pm_client):
 def ui_target(pm_client, ecosystem: str) -> dict[str, str]:
     if ecosystem not in _ECOSYSTEMS:
         pytest.fail(f"Unknown ecosystem in feature examples: {ecosystem!r}")
-    target = _find_ui_target(pm_client, ecosystem)
-    if not target:
-        pkg = _ECOSYSTEMS[ecosystem]["package"]
-        pytest.skip(
-            f"No {ecosystem} repository with {pkg!r} available — repo may not be synced yet"
-        )
-    return target
+    eco = _ECOSYSTEMS[ecosystem]
+    target, candidates = _find_ui_target(pm_client, ecosystem)
+    if target:
+        return target
+    # Same two states, same wording as test_repos.py::_first_repo_serving —
+    # these scenarios describe the same deployment in the same run, so the two
+    # modules must not explain one fact two different ways. Keep them in sync.
+    if not candidates:
+        pytest.skip(f"No {ecosystem} repository configured in Package Manager")
+    pytest.skip(
+        f"{ecosystem} {eco.get('noun', 'package')} {eco['package']!r} not available "
+        f"in any of {candidates} — repo may not be synced yet"
+    )
 
 
 @when("I open the Package Manager homepage")

--- a/src/vip_tests/package_manager/test_ui.py
+++ b/src/vip_tests/package_manager/test_ui.py
@@ -25,11 +25,11 @@ from vip.version import ProductVersion
 from vip_tests.package_manager.pages import (
     Homepage,
     PackageDetailPage,
-    PackagesPage,
     open_homepage,
     open_package_detail_via_click,
     open_repo_packages,
     search_packages,
+    wait_for_search_results,
 )
 from vip_tests.package_manager.pages.ui import TIMEOUT_ELEMENT, TIMEOUT_PAGE_LOAD
 
@@ -179,7 +179,11 @@ def then_search_result(page: Page):
     # returning at least one result row is the signal that search works. Assert
     # on the shared result-row selector rather than a per-id hook so this holds
     # for every ecosystem (see PackagesPage.RESULT_ITEMS).
-    expect(page.locator(PackagesPage.RESULT_ITEMS).first).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    #
+    # wait_for_search_results owns the timeout: search against a full mirror is
+    # far slower than the other UI waits and warns rather than fails when it is
+    # merely slow. See its docstring for the measurements.
+    wait_for_search_results(page)
 
 
 @when("I open that package's detail page in the web UI")

--- a/src/vip_tests/security/test_https.feature
+++ b/src/vip_tests/security/test_https.feature
@@ -15,10 +15,10 @@ Feature: HTTPS enforcement
       | Workbench       |
       | Package Manager |
 
-  Scenario Outline: <product> does not expose sensitive headers
+  Scenario Outline: <product> response headers are checked for version disclosure
     Given <product> is configured in vip.toml
     When I inspect response headers from <product>
-    Then the server does not expose version information in headers
+    Then any version information in response headers is reported
 
     Examples:
       | product         |

--- a/src/vip_tests/security/test_https.py
+++ b/src/vip_tests/security/test_https.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import ssl
+import warnings
 
 import httpx
 import pytest
@@ -146,17 +147,47 @@ def inspect_headers(product, vip_config):
     return dict(resp.headers)
 
 
-@then("the server does not expose version information in headers")
+@then("any version information in response headers is reported")
 def no_version_headers(response_headers):
-    # Check for common headers that leak server version info.
-    risky_headers = ["x-powered-by", "server"]
-    for header in risky_headers:
-        value = response_headers.get(header, "")
-        # Having the header is OK, but it shouldn't contain version numbers.
-        if value:
-            version_pattern = re.compile(r"\d+\.\d+")
-            if version_pattern.search(value):
-                pytest.fail(
-                    f"Header '{header}: {value}' exposes version info. "
-                    "Configure the server to suppress version details."
-                )
+    """Report version disclosure in response headers; fail only where it is
+    fixable at the source.
+
+    Both headers below leak a version, but they are not the same finding:
+
+    ``server`` is the product identifying itself -- Package Manager sends
+    ``Posit Package Manager v2026.06.0`` and offers no setting to suppress it,
+    so the only remediation is stripping it at the reverse proxy in front. A
+    check that fails on every stock Posit deployment, with advice the product
+    can't satisfy, is noise: it turns the whole security category red by
+    default and teaches people to skim past it. Warn instead, so the exposure
+    is still on the record for a hardening baseline that forbids it.
+
+    ``x-powered-by`` is a real finding. No Posit product sets it, so its
+    presence means a reverse proxy or app server in front is disclosing its
+    own version -- and that is configurable exactly where it originates. This
+    stays fatal, which is also what keeps this check from being vacuous: a
+    warning-only check can never fail, and a check that can never fail is not
+    a check (#555).
+    """
+    version_pattern = re.compile(r"\d+\.\d+")
+
+    server = response_headers.get("server", "")
+    if server and version_pattern.search(server):
+        warnings.warn(
+            f"VIP: response header 'server: {server}' discloses a version number. "
+            "Posit products emit this themselves and have no setting to suppress it — "
+            "strip or rewrite the header at the reverse proxy in front of the "
+            "deployment (nginx: `proxy_hide_header Server`) if your hardening "
+            "baseline forbids version disclosure.",
+            stacklevel=2,
+        )
+
+    powered_by = response_headers.get("x-powered-by", "")
+    if powered_by and version_pattern.search(powered_by):
+        pytest.fail(
+            f"Header 'x-powered-by: {powered_by}' exposes version info. No Posit "
+            "product sets this header, so it comes from a reverse proxy or "
+            "application server in front of the deployment. Suppress it there "
+            "(nginx: `proxy_hide_header X-Powered-By`; Express: "
+            "`app.disable('x-powered-by')`)."
+        )


### PR DESCRIPTION
## What

Three checks in `vip verify --package-manager-url` reported results that were not true. Found while investigating a run against a live 2026.06.0 deployment.

| Check | Was | Now |
|---|---|---|
| `test_pypi_mirror` | falsely SKIPPED | PASSED |
| `test_package_search/detail[PyPI]` | intermittently FAILED | PASSED, warns when slow |
| `test_product_does_not_expose_sensitive_headers` | always FAILED | PASSED with a warning |

Against the same deployment: **1 failed / 22 passed / 9 skipped → 24 passed / 8 skipped / 1 warning**, with the control run taken on untouched `main` immediately beforehand.

## Repository selection

`test_repos.py` picked `repos[0]` from the name-matched candidates, making the outcome depend on the order the server happened to list them in. A `_first_repo_serving()` walk now backs all four ecosystems — the shape `query_openvsx` already had — and the skip reason names every repo tried.

## Search timeout

Package search against a full mirror is not comparable to the other UI waits, so it gets its own ceiling rather than a bump to the shared one. The 90s figure is measured, not guessed: eleven of twelve runs at ~4s, one at 53.8s on the session's first search, `cran` at ~1s throughout. Raising the ceiling alone would trade a false failure for a silent one, so `wait_for_search_results()` warns past 15s and fails with a readable diagnosis instead of a raw `Locator.wait_for: Timeout exceeded`.

## Header check

`server` is warned about, `x-powered-by` still fails. Splitting them is deliberate: a check where every branch warns can never fail, which is the failure mode #555 exists to remove. The scenario and step are renamed to match what they now assert.

## Tests

Two new selftest files (28 cases) plus header coverage in `test_https_helper.py`, which had none. The regression tests were confirmed to go red against the old behaviour, and the timeout constant was mutation-tested — the first draft of the repo-selection tests passed spuriously because the step's `pytest.skip` marked the *selftest* skipped rather than failed.

`docs/test-architecture.md` gains a fail/warn/skip section, since that distinction is now load-bearing.

Full suite green: ruff, format, mypy, 1321 selftests. (`test_load_engine.py` has a flaky timing assertion that fails on untouched `main` too.)
