### PR TITLE
fix(workbench): detect sign-in redirected to an external IdP

### DIFF
--- a/selftests/test_workbench_login.py
+++ b/selftests/test_workbench_login.py
@@ -41,6 +41,10 @@ class _AuthFakeLocator:
         if self._on_click is not None:
             self._on_click()
 
+    def or_(self, other):
+        """Model Playwright's Locator.or_ -- visible when either side is."""
+        return _AuthFakeLocator(visible=lambda: self._visible() or other._visible())
+
 
 class _OidcLoginFakePage:
     """Models an OIDC-only sign-in page: a "Sign in with OpenID" button and no
@@ -101,3 +105,96 @@ def test_interactive_auth_skips_when_sso_cannot_complete():
     with pytest.raises(Skipped):
         workbench_login(page, "https://wb.example.com", "", "", interactive_auth=True)
     assert page.sso_clicked is True
+
+
+class _ExternalIdpFakePage:
+    """Models a deployment that redirects sign-in out to a third-party IdP.
+
+    Hitting Workbench unauthenticated lands on the IdP's own page (e.g. Okta's
+    ``/oauth2/v1/authorize``), which has neither Workbench's ``#username`` field
+    nor a "Sign in with ..." button -- Okta's identifier-first submit is named
+    "Next".  The old detection read that as a password deployment and ground the
+    retry loop into "Login failed after 3 attempts".
+    """
+
+    def __init__(self):
+        self.url = (
+            "https://posit.okta.com/oauth2/v1/authorize?client_id=abc"
+            "&redirect_uri=https%3A%2F%2Fsso.example.com%2F__oauth__&response_type=code"
+        )
+        self.filled: list[tuple[str, str]] = []
+
+    def goto(self, *args, **kwargs):
+        pass
+
+    def wait_for_load_state(self, *args, **kwargs):
+        pass
+
+    def locator(self, selector):
+        # Nothing Workbench-specific exists on the IdP's page.
+        return _AuthFakeLocator(visible=lambda: False)
+
+    def get_by_role(self, role, name=None):
+        # No control matching /sign in/i -- Okta's button is named "Next".
+        return _AuthFakeLocator(visible=lambda: False)
+
+    def fill(self, selector, value):
+        self.filled.append((selector, value))
+
+
+def test_password_login_skips_when_workbench_federates_to_external_idp():
+    page = _ExternalIdpFakePage()
+    with pytest.raises(Skipped) as exc:
+        workbench_login(page, "https://wb.example.com", "user", "pass")
+    message = str(exc.value)
+    assert "posit.okta.com" in message, "the skip must name the IdP that took over sign-in"
+    assert page.filled == [], "must not attempt a password form on the IdP's page"
+
+
+def test_interactive_auth_skips_when_redirected_to_external_idp():
+    page = _ExternalIdpFakePage()
+    with pytest.raises(Skipped) as exc:
+        workbench_login(page, "https://wb.example.com", "", "", interactive_auth=True)
+    assert "posit.okta.com" in str(exc.value)
+
+
+class _PasswordLoginFakePage:
+    """A real Workbench password deployment: own origin, own ``#username`` field."""
+
+    def __init__(self):
+        self.url = "https://wb.example.com/auth-sign-in"
+        self._logged_in = False
+        self.filled: list[tuple[str, str]] = []
+
+    def goto(self, *args, **kwargs):
+        pass
+
+    def wait_for_load_state(self, *args, **kwargs):
+        pass
+
+    def locator(self, selector):
+        from vip_tests.workbench.pages import Homepage, LoginPage
+
+        if selector == Homepage.POSIT_LOGO:
+            return _AuthFakeLocator(visible=lambda: self._logged_in)
+        if selector in (LoginPage.USERNAME, f"{LoginPage.USERNAME}, button:has-text('Sign in')"):
+            return _AuthFakeLocator(visible=lambda: True)
+        return _AuthFakeLocator(visible=lambda: False)
+
+    def get_by_role(self, role, name=None):
+        # A password form's submit button also matches /sign in/i.
+        return _AuthFakeLocator(visible=lambda: True)
+
+    def fill(self, selector, value):
+        self.filled.append((selector, value))
+
+    def click(self, selector):
+        self._logged_in = True
+
+
+def test_password_deployment_still_uses_the_login_form():
+    """Guard: the SSO detection must not swallow genuine password deployments."""
+    page = _PasswordLoginFakePage()
+    workbench_login(page, "https://wb.example.com", "user", "pass")
+    assert ("#username", "user") in page.filled
+    assert ("#password", "pass") in page.filled

--- a/selftests/test_workbench_login.py
+++ b/selftests/test_workbench_login.py
@@ -198,3 +198,75 @@ def test_password_deployment_still_uses_the_login_form():
     workbench_login(page, "https://wb.example.com", "user", "pass")
     assert ("#username", "user") in page.filled
     assert ("#password", "pass") in page.filled
+
+
+# ---------------------------------------------------------------------------
+# External-IdP detection edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "landed, configured",
+    [
+        # A default port spelled out on one side only is the same origin.
+        ("https://wb.example.com/auth-sign-in", "https://wb.example.com:443"),
+        ("https://wb.example.com:443/auth-sign-in", "https://wb.example.com"),
+        ("http://wb.example.com/auth-sign-in", "http://wb.example.com:80"),
+        ("http://wb.example.com:80/auth-sign-in", "http://wb.example.com"),
+        # Host comparison is case-insensitive.
+        ("https://WB.example.com/auth-sign-in", "https://wb.example.com"),
+    ],
+)
+def test_default_ports_do_not_look_like_an_external_idp(landed, configured):
+    """A `:443`/`:80` spelled out on one side must not read as a redirect away.
+
+    Misreading it skips every password-login scenario on a deployment that is
+    not federated at all.
+    """
+    from vip_tests.workbench.conftest import _external_idp_host
+
+    assert _external_idp_host(landed, configured) is None
+
+
+@pytest.mark.parametrize(
+    "landed, configured, expected",
+    [
+        ("https://posit.okta.com/oauth2/v1/authorize", "https://wb.example.com", "posit.okta.com"),
+        # A non-default port really is a different origin.
+        ("https://wb.example.com:8443/x", "https://wb.example.com", "wb.example.com:8443"),
+    ],
+)
+def test_genuinely_different_origins_are_still_detected(landed, configured, expected):
+    from vip_tests.workbench.conftest import _external_idp_host
+
+    assert _external_idp_host(landed, configured) == expected
+
+
+class _SsoRedirectsToIdpFakePage(_OidcLoginFakePage):
+    """Workbench's own SSO page whose sign-in click bounces to a dead IdP session.
+
+    The click navigates off-origin and never comes back, so the IdP host is only
+    knowable *after* the attempt -- computing it up front yields None.
+    """
+
+    def __init__(self):
+        super().__init__(idp_valid=False)
+
+    def get_by_role(self, role, name=None):
+        def _click():
+            self.sso_clicked = True
+            self.url = "https://posit.okta.com/oauth2/v1/authorize?client_id=abc"
+
+        return _AuthFakeLocator(visible=lambda: True, on_click=_click)
+
+
+def test_skip_names_the_idp_when_silent_sso_lands_there():
+    page = _SsoRedirectsToIdpFakePage()
+    with pytest.raises(Skipped) as exc:
+        workbench_login(page, "https://wb.example.com", "", "", interactive_auth=True)
+    assert page.sso_clicked is True
+    # Not merely "the URL happens to contain the host": the message must *say*
+    # sign-in was redirected there, which is only knowable after the attempt.
+    assert "redirected to the posit.okta.com sign-in page" in str(exc.value), (
+        f"the skip must name where sign-in actually ended up: {exc.value}"
+    )

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 import warnings
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 from filelock import FileLock, Timeout
@@ -236,11 +237,36 @@ def _on_login_page(url: str) -> bool:
     return any(kw in lower for kw in _LOGIN_KEYWORDS)
 
 
+def _external_idp_host(page_url: str, workbench_url: str) -> str | None:
+    """Return the IdP host if sign-in has left the Workbench origin.
+
+    Some deployments do not render a Workbench sign-in page at all: an
+    unauthenticated request redirects straight out to the identity provider
+    (e.g. ``https://posit.okta.com/oauth2/v1/authorize?...``).  That page has
+    neither Workbench's ``#username`` field nor a "Sign in with ..." button --
+    Okta's identifier-first submit is named "Next" -- so button/field probing
+    alone reads it as a password deployment and grinds the retry loop into
+    "Login failed after 3 attempts".  Comparing the landed host against the
+    configured Workbench host settles it without depending on any one IdP's
+    markup.  Returns ``None`` when still on the Workbench origin (or when
+    either URL cannot be parsed).
+    """
+    try:
+        current = urlparse(page_url).netloc
+        expected = urlparse(workbench_url).netloc
+    except ValueError:
+        return None
+    if current and expected and current.lower() != expected.lower():
+        return current
+    return None
+
+
 def _workbench_session_skip_message(
     *,
     auth_mode: str,
     workbench_auth_error: str | None,
     landed_url: str,
+    idp_host: str | None = None,
 ) -> str:
     """Build the skip text shown when storage state did not log Workbench in.
 
@@ -253,6 +279,11 @@ def _workbench_session_skip_message(
     When *auth_mode* is unknown (a caller forgot to thread the fixture
     through), the message names both ``--interactive-auth`` and
     ``--headless-auth`` so the reader isn't pointed at the wrong flag.
+
+    *idp_host* names the identity provider when the deployment redirected
+    sign-in off the Workbench origin entirely, so the reader knows the session
+    expired at the IdP rather than looking for a Workbench sign-in page that
+    was never rendered.
     """
     if auth_mode == "headless":
         flag = "--headless-auth"
@@ -260,7 +291,8 @@ def _workbench_session_skip_message(
         flag = "--interactive-auth"
     else:
         flag = "--interactive-auth / --headless-auth"
-    lines = [f"Workbench session not established by {flag} (landed on login page: {landed_url})."]
+    where = f"redirected to the {idp_host} sign-in page" if idp_host else "landed on login page"
+    lines = [f"Workbench session not established by {flag} ({where}: {landed_url})."]
     if workbench_auth_error:
         lines.append(f"Pre-test auth reported: {workbench_auth_error}")
     lines.append(
@@ -549,7 +581,15 @@ def workbench_login(
         # button, so the *absence* of the username field is what distinguishes a
         # true SSO-only page from a password form.
         sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
-        sso_only = sso_button.is_visible() and not page.locator(LoginPage.USERNAME).is_visible()
+        sso_button_present = sso_button.is_visible()
+        # A deployment can also skip its own sign-in page entirely and redirect
+        # straight to the IdP, whose markup matches neither probe above (see
+        # _external_idp_host). Landing off the Workbench origin is conclusive on
+        # its own: no Workbench password form is reachable from there.
+        idp_host = _external_idp_host(page.url, workbench_url)
+        sso_only = idp_host is not None or (
+            sso_button_present and not page.locator(LoginPage.USERNAME).is_visible()
+        )
 
         if interactive_auth and sso_only:
             # Storage state was pre-loaded by --interactive-auth / --headless-auth.
@@ -557,8 +597,11 @@ def workbench_login(
             # "Sign in with OpenID" button. Clicking it triggers a silent SSO round-trip
             # using the saved IdP cookies. The round-trip is serialized across xdist
             # workers (see _silent_sso_signin / oidc_login_lock) to avoid storming the
-            # shared IdP session (#484/#467).
-            if _silent_sso_signin(sso_button, homepage_logo, workbench_url):
+            # shared IdP session (#484/#467).  When the deployment redirected us
+            # off-origin instead there is no such button to click, so go straight
+            # to the skip -- clicking a locator that resolves to nothing would
+            # raise a Playwright error in place of an actionable skip.
+            if sso_button_present and _silent_sso_signin(sso_button, homepage_logo, workbench_url):
                 return  # Silent SSO succeeded
             # No usable IdP session (expired, or storage state was stripped for the
             # password-login test) — skip gracefully.
@@ -567,6 +610,7 @@ def workbench_login(
                     auth_mode=auth_mode,
                     workbench_auth_error=workbench_auth_error,
                     landed_url=page.url,
+                    idp_host=idp_host,
                 )
             )
 
@@ -576,6 +620,7 @@ def workbench_login(
                     auth_mode=auth_mode,
                     workbench_auth_error=workbench_auth_error,
                     landed_url=page.url,
+                    idp_host=idp_host,
                 )
             )
         # Even when auth_provider is reported as "password", the deployment may
@@ -584,10 +629,14 @@ def workbench_login(
         # a config-less run against an OIDC deployment.  The password login form
         # is unavailable there, so skip rather than fail the retry loop.
         if sso_only:
+            where = (
+                f"redirects sign-in to the identity provider at {idp_host}"
+                if idp_host
+                else "presents an SSO/OIDC sign-in page instead (no username/password fields)"
+            )
             pytest.skip(
                 "This scenario requires a Workbench password-login form, but the "
-                "deployment presents an SSO/OIDC sign-in page instead (no username/"
-                "password fields). Password login cannot be exercised on an SSO "
+                f"deployment {where}. Password login cannot be exercised on an SSO "
                 "deployment, so this scenario is skipped."
             )
         # Password auth - proceed with form login below

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -252,13 +252,42 @@ def _external_idp_host(page_url: str, workbench_url: str) -> str | None:
     either URL cannot be parsed).
     """
     try:
-        current = urlparse(page_url).netloc
-        expected = urlparse(workbench_url).netloc
+        landed = urlparse(page_url)
+        configured = urlparse(workbench_url)
     except ValueError:
         return None
-    if current and expected and current.lower() != expected.lower():
-        return current
+    current = _normalised_netloc(landed)
+    expected = _normalised_netloc(configured)
+    if current and expected and current != expected:
+        return landed.netloc
     return None
+
+
+# Ports that carry no information because they are implied by the scheme.
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _normalised_netloc(parsed) -> str:
+    """Return *parsed*'s host:port with a scheme-default port dropped, lowercased.
+
+    ``https://wb.example.com`` and ``https://wb.example.com:443`` are the same
+    origin, but their raw ``netloc`` strings differ.  Comparing raw values makes
+    a Workbench URL configured with an explicit default port look like a
+    redirect away from itself, which would skip every password-login scenario on
+    a deployment that is not federated at all.
+    """
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return ""
+    try:
+        port = parsed.port
+    except ValueError:
+        # A malformed port ("https://host:notaport") -- keep the raw form rather
+        # than silently treating it as the default.
+        return parsed.netloc.lower()
+    if port is None or port == _DEFAULT_PORTS.get(parsed.scheme.lower()):
+        return host
+    return f"{host}:{port}"
 
 
 def _workbench_session_skip_message(
@@ -604,13 +633,15 @@ def workbench_login(
             if sso_button_present and _silent_sso_signin(sso_button, homepage_logo, workbench_url):
                 return  # Silent SSO succeeded
             # No usable IdP session (expired, or storage state was stripped for the
-            # password-login test) — skip gracefully.
+            # password-login test) — skip gracefully.  Recompute the IdP host: the
+            # click above can navigate off-origin before timing out, so where we
+            # ended up is only knowable now, not before the attempt.
             pytest.skip(
                 _workbench_session_skip_message(
                     auth_mode=auth_mode,
                     workbench_auth_error=workbench_auth_error,
                     landed_url=page.url,
-                    idp_host=idp_host,
+                    idp_host=_external_idp_host(page.url, workbench_url),
                 )
             )
 
@@ -620,7 +651,7 @@ def workbench_login(
                     auth_mode=auth_mode,
                     workbench_auth_error=workbench_auth_error,
                     landed_url=page.url,
-                    idp_host=idp_host,
+                    idp_host=_external_idp_host(page.url, workbench_url),
                 )
             )
         # Even when auth_provider is reported as "password", the deployment may


### PR DESCRIPTION
`workbench_login` decided "password vs SSO" purely from markup on the page it landed on: a `#username` field, or a button named `/sign in/i`. A deployment that redirects unauthenticated requests straight to its IdP has neither — Okta's identifier-first submit is named "Next" — so the SSO branch never fired and the password retry loop ran to exhaustion, failing with `Login failed after 3 attempts` instead of skipping. Closes #375.

Landing off the Workbench origin is now conclusive on its own: no Workbench password form is reachable from an IdP's own domain, whatever that IdP's markup looks like. The skip messages name the IdP host so the reader isn't hunting for a Workbench sign-in page that was never rendered.

Also guards a latent crash: on the off-origin path the `--interactive-auth` branch would have clicked a locator resolving to nothing, raising a Playwright error in place of an actionable skip.

## How this was diagnosed

Probing the live sign-in page unauthenticated shows the redirect leaves Workbench entirely:

```
URL: https://posit.okta.com/oauth2/v1/authorize?client_id=...&response_type=code&scope=openid+profile+email
has #username: 0
role=button 'sign in': 0
role=link 'sign in': 0
```

Okta's submit is `button "Next"`, which is why every markup probe missed.

## Verification

Live Workbench 2026.06.0 behind Okta:

```
test_workbench_login   SKIPPED (This scenario requires a Workbench password-login form, but the
                       deployment redirects sign-in to the identity provider at posit.okta.com...)
test_workbench_signout PASSED
```

Selftests add an `_ExternalIdpFakePage` covering both the password and `--interactive-auth` paths, plus a `_PasswordLoginFakePage` regression test proving genuine password deployments still fill the form — the detection must not swallow those. 1313 passed; the 2 failures are the pre-existing flaky threadpool tests (#517), which fail identically on clean main. Ruff and mypy clean.