### PR TITLE
fix(workbench): run sign-out last and restore the shared session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,7 @@ Register warning filters in `src/vip/plugin.py::pytest_configure` (via `config.a
 -   Changing ruff version locally without updating the pinned version in `ci.yml`.
 -   Adding product SDK imports (use httpx directly).
 -   Writing tests that modify or delete existing customer content.
+-   Adding a Workbench scenario that ends the shared auth session (sign-out, session revocation, password change) without ordering it last *and* restoring the session afterwards. Under `--interactive-auth` / `--headless-auth` every Workbench scenario shares one account, so ending that session breaks every scenario still running on other xdist workers, plus the cached auth session on disk. `test_workbench_signout` is the worked example.
 -   Creating `.py` step files without a matching `.feature` file (or vice versa).
 -   Forgetting the `@connect`/`@workbench`/`@package_manager` tag in feature files (breaks auto-skip).
 -   Using non-conventional PR titles (must be `type: description`).

--- a/selftests/test_workbench_login.py
+++ b/selftests/test_workbench_login.py
@@ -101,3 +101,110 @@ def test_interactive_auth_skips_when_sso_cannot_complete():
     with pytest.raises(Skipped):
         workbench_login(page, "https://wb.example.com", "", "", interactive_auth=True)
     assert page.sso_clicked is True
+
+
+# ---------------------------------------------------------------------------
+# Sign-out must not leave the shared session signed out (issue #467 / #263)
+# ---------------------------------------------------------------------------
+
+
+def test_signout_runs_after_every_other_workbench_scenario():
+    """Sign-out destroys the session every other Workbench test shares.
+
+    It must therefore be ordered *after* them.  It used to inherit the module's
+    ``order(10)`` -- the earliest mark in the whole Workbench suite -- so the
+    one test that signs the shared account out ran before nearly everything
+    else, while sibling xdist workers were mid-test.
+    """
+    from vip_tests.workbench import test_auth
+
+    signout_order = [
+        m.args[0] for m in test_auth.test_workbench_signout.pytestmark if m.name == "order"
+    ]
+    assert signout_order, "test_workbench_signout needs its own explicit order mark"
+
+    # Every other Workbench module's order mark must come first.
+    other_orders = [10, 20, 30, 40, 45, 50, 60, 90]
+    assert signout_order[-1] > max(other_orders), (
+        f"sign-out is ordered {signout_order[-1]}, which runs before other Workbench "
+        f"scenarios (max {max(other_orders)})"
+    )
+
+
+def test_login_scenario_still_runs_early():
+    """The login scenario uses its own logged-out context, so it stays early."""
+    from vip_tests.workbench import test_auth
+
+    login_order = [
+        m.args[0] for m in test_auth.test_workbench_login.pytestmark if m.name == "order"
+    ]
+    assert login_order, "test_workbench_login needs its own explicit order mark"
+    assert login_order[-1] <= 10
+
+
+def test_auth_module_does_not_set_a_shared_order_mark():
+    """The two scenarios run at opposite ends, so neither may inherit one order.
+
+    A module-level ``pytestmark`` stacked under a per-function mark leaves the
+    winner up to pytest-order's resolution; keep both explicit instead.
+    """
+    from vip_tests.workbench import test_auth
+
+    module_marks = getattr(test_auth, "pytestmark", [])
+    marks = module_marks if isinstance(module_marks, list) else [module_marks]
+    assert not [m for m in marks if getattr(m, "name", "") == "order"]
+
+
+def test_restore_shared_session_reports_failure_to_reauthenticate(caplog):
+    """When silent SSO cannot get back in, say so loudly rather than silently.
+
+    A failed restore leaves every later scenario -- and the cached auth session
+    on disk -- pointing at a signed-out server session, so it must not be
+    swallowed.
+    """
+    import logging
+
+    from vip_tests.workbench.test_auth import _restore_shared_session
+
+    class _DeadPage:
+        url = "https://wb.example.com/auth-sign-in"
+
+        def goto(self, *a, **k):
+            pass
+
+        def wait_for_load_state(self, *a, **k):
+            pass
+
+        def locator(self, selector):
+            return _AuthFakeLocator(visible=lambda: False)
+
+        def get_by_role(self, role, name=None):
+            return _AuthFakeLocator(visible=lambda: False)
+
+    with caplog.at_level(logging.WARNING):
+        assert _restore_shared_session(_DeadPage(), "https://wb.example.com") is False
+    assert any("sign" in r.message.lower() for r in caplog.records), caplog.records
+
+
+def test_restore_shared_session_returns_true_when_homepage_comes_back():
+    from vip_tests.workbench.test_auth import _restore_shared_session
+
+    class _RecoveredPage:
+        url = "https://wb.example.com/"
+
+        def goto(self, *a, **k):
+            pass
+
+        def wait_for_load_state(self, *a, **k):
+            pass
+
+        def locator(self, selector):
+            from vip_tests.workbench.pages import Homepage
+
+            visible = selector == Homepage.POSIT_LOGO
+            return _AuthFakeLocator(visible=lambda: visible)
+
+        def get_by_role(self, role, name=None):
+            return _AuthFakeLocator(visible=lambda: True)
+
+    assert _restore_shared_session(_RecoveredPage(), "https://wb.example.com") is True

--- a/selftests/test_workbench_login.py
+++ b/selftests/test_workbench_login.py
@@ -108,53 +108,6 @@ def test_interactive_auth_skips_when_sso_cannot_complete():
 # ---------------------------------------------------------------------------
 
 
-def test_signout_runs_after_every_other_workbench_scenario():
-    """Sign-out destroys the session every other Workbench test shares.
-
-    It must therefore be ordered *after* them.  It used to inherit the module's
-    ``order(10)`` -- the earliest mark in the whole Workbench suite -- so the
-    one test that signs the shared account out ran before nearly everything
-    else, while sibling xdist workers were mid-test.
-    """
-    from vip_tests.workbench import test_auth
-
-    signout_order = [
-        m.args[0] for m in test_auth.test_workbench_signout.pytestmark if m.name == "order"
-    ]
-    assert signout_order, "test_workbench_signout needs its own explicit order mark"
-
-    # Every other Workbench module's order mark must come first.
-    other_orders = [10, 20, 30, 40, 45, 50, 60, 90]
-    assert signout_order[-1] > max(other_orders), (
-        f"sign-out is ordered {signout_order[-1]}, which runs before other Workbench "
-        f"scenarios (max {max(other_orders)})"
-    )
-
-
-def test_login_scenario_still_runs_early():
-    """The login scenario uses its own logged-out context, so it stays early."""
-    from vip_tests.workbench import test_auth
-
-    login_order = [
-        m.args[0] for m in test_auth.test_workbench_login.pytestmark if m.name == "order"
-    ]
-    assert login_order, "test_workbench_login needs its own explicit order mark"
-    assert login_order[-1] <= 10
-
-
-def test_auth_module_does_not_set_a_shared_order_mark():
-    """The two scenarios run at opposite ends, so neither may inherit one order.
-
-    A module-level ``pytestmark`` stacked under a per-function mark leaves the
-    winner up to pytest-order's resolution; keep both explicit instead.
-    """
-    from vip_tests.workbench import test_auth
-
-    module_marks = getattr(test_auth, "pytestmark", [])
-    marks = module_marks if isinstance(module_marks, list) else [module_marks]
-    assert not [m for m in marks if getattr(m, "name", "") == "order"]
-
-
 def test_restore_shared_session_reports_failure_to_reauthenticate(caplog):
     """When silent SSO cannot get back in, say so loudly rather than silently.
 
@@ -164,7 +117,7 @@ def test_restore_shared_session_reports_failure_to_reauthenticate(caplog):
     """
     import logging
 
-    from vip_tests.workbench.test_auth import _restore_shared_session
+    from vip_tests.workbench.conftest import restore_shared_session
 
     class _DeadPage:
         url = "https://wb.example.com/auth-sign-in"
@@ -182,12 +135,12 @@ def test_restore_shared_session_reports_failure_to_reauthenticate(caplog):
             return _AuthFakeLocator(visible=lambda: False)
 
     with caplog.at_level(logging.WARNING):
-        assert _restore_shared_session(_DeadPage(), "https://wb.example.com") is False
+        assert restore_shared_session(_DeadPage(), "https://wb.example.com") is False
     assert any("sign" in r.message.lower() for r in caplog.records), caplog.records
 
 
 def test_restore_shared_session_returns_true_when_homepage_comes_back():
-    from vip_tests.workbench.test_auth import _restore_shared_session
+    from vip_tests.workbench.conftest import restore_shared_session
 
     class _RecoveredPage:
         url = "https://wb.example.com/"
@@ -207,4 +160,4 @@ def test_restore_shared_session_returns_true_when_homepage_comes_back():
         def get_by_role(self, role, name=None):
             return _AuthFakeLocator(visible=lambda: True)
 
-    assert _restore_shared_session(_RecoveredPage(), "https://wb.example.com") is True
+    assert restore_shared_session(_RecoveredPage(), "https://wb.example.com") is True

--- a/selftests/test_workbench_ordering.py
+++ b/selftests/test_workbench_ordering.py
@@ -10,7 +10,9 @@ markers (epic #480 / issues #481, #482):
 - Session launch is foundational: it must collect before both the IDE
   extensions checks and Git operations, which depend on a launched session.
 - IDE extensions is the last in-session feature to validate, so it must be
-  the last Workbench test file in collection order.
+  the last Workbench file whose scenarios need a live session.
+- Sign-out collects dead last, after everything: it ends the shared auth
+  session every other scenario depends on, so nothing may follow it.
 
 We only assert these invariants (not the full brittle sequence) so future
 insertions between the documented rank gaps don't churn this test.
@@ -130,13 +132,46 @@ def test_ide_launch_collects_before_git_ops(tmp_path: Path) -> None:
     )
 
 
-def test_ide_extensions_is_last_workbench_file(tmp_path: Path) -> None:
+def test_ide_extensions_is_the_last_in_session_workbench_file(tmp_path: Path) -> None:
+    """Extensions stays last among scenarios that need a live session.
+
+    Sign-out now collects after it (see
+    :func:`test_signout_collects_dead_last`), so this asserts "last of the
+    in-session files" rather than "last overall". Sign-out is not an in-session
+    feature check -- it tears the session down.
+    """
     nodeids = _collect_workbench_nodeids(tmp_path)
-    last_file = _file_of(nodeids[-1])
+    in_session = [n for n in nodeids if not n.endswith("test_workbench_signout[chromium]")]
+    last_file = _file_of(in_session[-1])
     assert last_file == "test_ide_extensions", (
-        f"test_ide_extensions must be the last Workbench test file collected, "
-        f"got {last_file!r} last: {nodeids}"
+        f"test_ide_extensions must be the last in-session Workbench test file collected, "
+        f"got {last_file!r} last: {in_session}"
     )
+
+
+def test_signout_collects_dead_last(tmp_path: Path) -> None:
+    """Nothing may collect after sign-out.
+
+    Under --interactive-auth / --headless-auth every Workbench scenario shares
+    one account, so signing out ends the session the rest of them are using.
+    Anything ordered after it inherits a signed-out browser.
+    """
+    nodeids = _collect_workbench_nodeids(tmp_path)
+    assert nodeids[-1].endswith("test_workbench_signout[chromium]"), (
+        f"test_workbench_signout must collect last, got {nodeids[-1]!r}: {nodeids}"
+    )
+
+
+def test_login_collects_before_signout(tmp_path: Path) -> None:
+    """The login scenario keeps its own logged-out context and stays early."""
+    nodeids = _collect_workbench_nodeids(tmp_path)
+    login_idx = next(
+        i for i, n in enumerate(nodeids) if n.endswith("test_workbench_login[chromium]")
+    )
+    signout_idx = next(
+        i for i, n in enumerate(nodeids) if n.endswith("test_workbench_signout[chromium]")
+    )
+    assert login_idx < signout_idx, f"login must collect before sign-out: {nodeids}"
 
 
 def test_basic_marker_deselects_slow_workbench_features(tmp_path: Path) -> None:

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -468,6 +468,41 @@ def _silent_sso_signin(sso_button, homepage_logo, workbench_url: str) -> bool:
             return False
 
 
+def restore_shared_session(page: Page, workbench_url: str) -> bool:
+    """Sign back in after the sign-out scenario, returning whether it worked.
+
+    The scenario deliberately ends the session every other scenario shares, so
+    it has to hand one back. Navigating to Workbench and completing the silent
+    SSO round-trip mints a fresh session in this browser context.
+
+    Returns False -- and warns -- when the round-trip cannot complete, e.g. the
+    IdP applied single-logout and cleared its own cookies too. That is not
+    something this fixture can repair, but it must be visible: silently leaving
+    the suite signed out is how a sign-out turns into a cascade of unrelated
+    auth failures in later scenarios.
+    """
+    logo = page.locator(Homepage.POSIT_LOGO)
+    try:
+        page.goto(workbench_url)
+        page.wait_for_load_state("load")
+        if logo.is_visible():
+            return True
+        sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
+        if sso_button.is_visible() and _silent_sso_signin(sso_button, logo, workbench_url):
+            return True
+    except (PlaywrightTimeoutError, PlaywrightError) as exc:
+        logger.warning("Could not sign back in after the sign-out scenario: %s", exc)
+        return False
+    logger.warning(
+        "Could not sign back in after the sign-out scenario at %s: the silent SSO round-trip "
+        "did not reach an authenticated homepage (the identity provider may have applied "
+        "single-logout). Later scenarios and the cached auth session are now signed out; "
+        "rerun with --interactive-auth to re-establish one.",
+        workbench_url,
+    )
+    return False
+
+
 def workbench_login(
     page: Page,
     workbench_url: str,

--- a/src/vip_tests/workbench/test_auth.py
+++ b/src/vip_tests/workbench/test_auth.py
@@ -2,20 +2,17 @@
 
 from __future__ import annotations
 
-import logging
 import re
 
 import pytest
 from playwright.sync_api import Browser, Page, expect
-from playwright.sync_api import Error as PlaywrightError
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from pytest_bdd import given, scenario, then, when
 
 from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_PAGE_LOAD,
-    _silent_sso_signin,
     assert_homepage_loaded,
+    restore_shared_session,
     workbench_login,
 )
 from vip_tests.workbench.pages import Homepage, LoginPage
@@ -32,10 +29,8 @@ _LOGIN_ORDER = 10
 # session on disk) are using. Inheriting the module's order(10) -- the earliest
 # mark in the whole Workbench suite -- ran it before nearly everything else,
 # while sibling xdist workers were mid-test. Order it last instead, and have it
-# put the session back afterwards (see _restore_shared_session).
+# put the session back afterwards (see restore_shared_session in conftest).
 _SIGNOUT_ORDER = 95
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.mark.order(_LOGIN_ORDER)
@@ -50,46 +45,11 @@ def test_workbench_signout():
     pass
 
 
-def _restore_shared_session(page: Page, workbench_url: str) -> bool:
-    """Sign back in after the sign-out scenario, returning whether it worked.
-
-    The scenario deliberately ends the session every other scenario shares, so
-    it has to hand one back. Navigating to Workbench and completing the silent
-    SSO round-trip mints a fresh session in this browser context.
-
-    Returns False -- and warns -- when the round-trip cannot complete, e.g. the
-    IdP applied single-logout and cleared its own cookies too. That is not
-    something this fixture can repair, but it must be visible: silently leaving
-    the suite signed out is how a sign-out turns into a cascade of unrelated
-    auth failures in later scenarios.
-    """
-    logo = page.locator(Homepage.POSIT_LOGO)
-    try:
-        page.goto(workbench_url)
-        page.wait_for_load_state("load")
-        if logo.is_visible():
-            return True
-        sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
-        if sso_button.is_visible() and _silent_sso_signin(sso_button, logo, workbench_url):
-            return True
-    except (PlaywrightTimeoutError, PlaywrightError) as exc:
-        logger.warning("Could not sign back in after the sign-out scenario: %s", exc)
-        return False
-    logger.warning(
-        "Could not sign back in after the sign-out scenario at %s: the silent SSO round-trip "
-        "did not reach an authenticated homepage (the identity provider may have applied "
-        "single-logout). Later scenarios and the cached auth session are now signed out; "
-        "rerun with --interactive-auth to re-establish one.",
-        workbench_url,
-    )
-    return False
-
-
 @pytest.fixture
 def _restore_session_after_signout(page: Page, workbench_url: str):
     """Put the shared Workbench session back after the sign-out scenario."""
     yield
-    _restore_shared_session(page, workbench_url)
+    restore_shared_session(page, workbench_url)
 
 
 @pytest.fixture

--- a/src/vip_tests/workbench/test_auth.py
+++ b/src/vip_tests/workbench/test_auth.py
@@ -2,31 +2,94 @@
 
 from __future__ import annotations
 
+import logging
 import re
 
 import pytest
 from playwright.sync_api import Browser, Page, expect
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from pytest_bdd import given, scenario, then, when
 
 from vip_tests.workbench.conftest import (
     TIMEOUT_DIALOG,
     TIMEOUT_PAGE_LOAD,
+    _silent_sso_signin,
     assert_homepage_loaded,
     workbench_login,
 )
 from vip_tests.workbench.pages import Homepage, LoginPage
 
-pytestmark = pytest.mark.order(10)
+# Both scenarios carry their own order mark rather than sharing a module-level
+# one: they must run at opposite ends of the suite, and stacking a per-function
+# mark on top of a module-level `pytestmark` leaves which one wins up to
+# pytest-order's mark resolution. Explicit beats inherited here.
+_LOGIN_ORDER = 10
+
+# Sign-out is the one Workbench scenario that destroys shared state: under
+# --interactive-auth / --headless-auth every scenario authenticates as the same
+# account, so signing out ends the session all of them (and the cached auth
+# session on disk) are using. Inheriting the module's order(10) -- the earliest
+# mark in the whole Workbench suite -- ran it before nearly everything else,
+# while sibling xdist workers were mid-test. Order it last instead, and have it
+# put the session back afterwards (see _restore_shared_session).
+_SIGNOUT_ORDER = 95
+
+logger = logging.getLogger(__name__)
 
 
+@pytest.mark.order(_LOGIN_ORDER)
 @scenario("test_auth.feature", "User can log in to Workbench via the web UI")
 def test_workbench_login():
     pass
 
 
+@pytest.mark.order(_SIGNOUT_ORDER)
 @scenario("test_auth.feature", "User can sign out of Workbench")
 def test_workbench_signout():
     pass
+
+
+def _restore_shared_session(page: Page, workbench_url: str) -> bool:
+    """Sign back in after the sign-out scenario, returning whether it worked.
+
+    The scenario deliberately ends the session every other scenario shares, so
+    it has to hand one back. Navigating to Workbench and completing the silent
+    SSO round-trip mints a fresh session in this browser context.
+
+    Returns False -- and warns -- when the round-trip cannot complete, e.g. the
+    IdP applied single-logout and cleared its own cookies too. That is not
+    something this fixture can repair, but it must be visible: silently leaving
+    the suite signed out is how a sign-out turns into a cascade of unrelated
+    auth failures in later scenarios.
+    """
+    logo = page.locator(Homepage.POSIT_LOGO)
+    try:
+        page.goto(workbench_url)
+        page.wait_for_load_state("load")
+        if logo.is_visible():
+            return True
+        sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
+        if sso_button.is_visible() and _silent_sso_signin(sso_button, logo, workbench_url):
+            return True
+    except (PlaywrightTimeoutError, PlaywrightError) as exc:
+        logger.warning("Could not sign back in after the sign-out scenario: %s", exc)
+        return False
+    logger.warning(
+        "Could not sign back in after the sign-out scenario at %s: the silent SSO round-trip "
+        "did not reach an authenticated homepage (the identity provider may have applied "
+        "single-logout). Later scenarios and the cached auth session are now signed out; "
+        "rerun with --interactive-auth to re-establish one.",
+        workbench_url,
+    )
+    return False
+
+
+@pytest.fixture
+def _restore_session_after_signout(page: Page, workbench_url: str):
+    """Put the shared Workbench session back after the sign-out scenario."""
+    yield
+    _restore_shared_session(page, workbench_url)
 
 
 @pytest.fixture
@@ -100,7 +163,7 @@ def current_user_displayed(page: Page):
 
 
 @when("I sign out of Workbench")
-def sign_out(page: Page):
+def sign_out(page: Page, _restore_session_after_signout):
     """Click the sign-out button on the Workbench homepage.
 
     Tries the legacy ``#signOutBtn`` first; on newer Workbench versions the


### PR DESCRIPTION
`test_workbench_signout` ends the session every other Workbench scenario shares: under `--interactive-auth` / `--headless-auth` they all authenticate as one account. It inherited the module's `order(10)` — the earliest mark in the whole Workbench suite — so the one scenario that signs the shared account out ran before nearly everything else, while sibling xdist workers were mid-test.

Order it last (95) and have it hand the session back via a silent SSO round-trip in teardown. When that round-trip cannot complete (e.g. the IdP applied single-logout) it warns loudly rather than leaving the suite and the on-disk auth cache silently signed out.

Both scenarios now carry explicit order marks instead of one inheriting a module-level `pytestmark`: stacking a per-function mark on a module mark leaves the winner up to pytest-order's mark resolution.

## Evidence

A cached auth session minted at the start of a 2-test run was already dead 5 minutes later — the only session-affecting test in that window being the sign-out. Probed read-only, no browser:

```
is_live: False
detail : the request landed on the sign-in page at https://dev.current.posit.team/auth-sign-in?appUri=%2F
```

Honest caveat: this is not proven deterministic. An earlier cache *did* survive a run containing a passing sign-out. Either way the scenario mutates shared state and should restore it.

Ordering verified at collection against a configured Workbench: `test_workbench_login` collects first (item 1), `test_workbench_signout` last (item 33 of 33), after `test_ide_extensions`.

## Still to verify live

Whether silent SSO can re-establish after a Workbench sign-out, or whether the IdP applies single-logout and forces a full interactive login. In the latter case the teardown warns rather than repairs — better than silent breakage, but worth knowing. **Do not merge before that is checked.**

Selftests cover both restore outcomes and both ordering invariants: 1315 passed, the 2 failures being the pre-existing flaky threadpool tests (#517) which fail identically on clean main. Ruff and mypy clean.