### PR TITLE
fix(cli): disambiguate vip version output labels

### DIFF
--- a/selftests/test_cli_version.py
+++ b/selftests/test_cli_version.py
@@ -52,6 +52,9 @@ class TestVersionSubcommand:
     """``vip version`` prints the vip version and the support floor."""
 
     def test_prints_version_and_floor(self, capsys, monkeypatch):
+        # Asserted as an exact string, not substrings: both numbers are
+        # calendar-versioned but unrelated, so each line must stay labeled or a
+        # reader will mistake VIP's version for the Posit Team release it targets.
         from vip import __version__
         from vip.cli import main
         from vip.version import MINIMUM_SUPPORTED_POSIT_TEAM
@@ -59,6 +62,7 @@ class TestVersionSubcommand:
         monkeypatch.setattr(sys, "argv", ["vip", "version"])
         main()  # a subcommand returns normally; no SystemExit
         out = capsys.readouterr().out
-        assert f"vip {__version__}" in out
-        assert MINIMUM_SUPPORTED_POSIT_TEAM in out
-        assert "minimum supported posit team version" in out.lower()
+        assert out.strip() == (
+            f"VIP version: {__version__}\n"
+            f"Supported Posit Team versions: {MINIMUM_SUPPORTED_POSIT_TEAM} and newer"
+        )

--- a/src/vip/cli.py
+++ b/src/vip/cli.py
@@ -1295,12 +1295,18 @@ def _reorder_help_args(argv: list[str], commands: set[str]) -> list[str]:
 
 
 def _format_version_details() -> str:
-    """Render the vip version and the minimum supported Posit Team release."""
+    """Render the vip version and the minimum supported Posit Team release.
+
+    VIP's own version and the Posit Team support floor are both calendar-versioned
+    (e.g. ``2026.7.0``) but are unrelated numbers, so each line is labeled
+    explicitly to avoid a reader mistaking one for the other.
+    """
     from vip import __version__
     from vip.version import MINIMUM_SUPPORTED_POSIT_TEAM
 
     return (
-        f"vip {__version__}\nMinimum supported Posit Team version: {MINIMUM_SUPPORTED_POSIT_TEAM}"
+        f"VIP version: {__version__}\n"
+        f"Supported Posit Team versions: {MINIMUM_SUPPORTED_POSIT_TEAM} and newer"
     )
 
 


### PR DESCRIPTION
## What

`vip version` now labels each of its two lines explicitly:

    VIP version: 0.58.13
    Supported Posit Team versions: 2026.04.0 and newer

Previously:

    vip 0.58.13
    Minimum supported Posit Team version: 2026.04.0

## Why

VIP is moving its own version numbering to calendar versioning, so its version will start to look like `2026.7.0` — the same shape as a Posit Team product version. The old output put an unlabeled VIP version directly above a Posit Team version, which reads as "this is the VIP for Posit Team 2026.07". The two numbers are unrelated: VIP's version says nothing about which product release it targets, and the support floor is a separate, independently maintained value.

Labeling both lines removes the ambiguity before the version format change lands and makes it hard to misread.

## Scope

The `--version` flag is deliberately unchanged. It still prints the conventional `vip <version>` and nothing else, since tooling may parse it.

`docker.yml`'s `docker run --rm "$ref" version` sanity check is a bare exit-code invocation with no output matching, so it is unaffected.

## Testing

`selftests/test_cli_version.py` previously asserted loose substrings. It now asserts the exact output string, so any future wording drift fails the test rather than passing silently.