### PR TITLE
fix(auth): refresh the cached session after restoring a signed-out one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Key principles:
 |------------------------------------|------------------------------------|
 | `src/vip/cli.py` | CLI entry point: version, verify (including `--basic` to skip `@slow`-tagged scenarios), cleanup (Connect content + orphaned Workbench sessions via `--workbench-url`), install, uninstall, auth, scaffold commands; `--version` flag |
 | `src/vip/config.py` | TOML config loader and dataclasses |
-| `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers; `authenticated_page` opens a headless page from a cached auth session for `vip cleanup --workbench-url`; `auth_cache_path()` is the single source of truth for the `.vip-auth-cache.json` location (both `plugin.py` and `cli.py` must use it), and `_load_cached_auth` probes Workbench before trusting a cached session |
+| `src/vip/auth.py` | Interactive and headless browser authentication for OIDC providers; `authenticated_page` opens a headless page from a cached auth session for `vip cleanup --workbench-url`; `auth_cache_path()` is the single source of truth for the `.vip-auth-cache.json` location (both `plugin.py` and `cli.py` must use it), and `_load_cached_auth` probes Workbench before trusting a cached session; `refresh_auth_cache_from_storage_state` writes a live context's cookies back over a cache whose session has been invalidated (atomic, 0600, existing caches only) |
 | `src/vip/idp.py` | IdP login form strategies for headless auth (Keycloak, Okta) |
 | `src/vip/plugin.py` | pytest plugin: markers (including `slow`, used by `verify --basic`), auto-skip, JSON report output |
 | `src/vip/version.py` | `ProductVersion` parsing/comparison for `min_version` gating; `MINIMUM_SUPPORTED_POSIT_TEAM` support floor (powers `vip version`) |

--- a/selftests/test_auth.py
+++ b/selftests/test_auth.py
@@ -3032,3 +3032,84 @@ class TestProbeDetailNamesTheEvidence:
         out = capsys.readouterr().out
         assert "Workbench answered 401 Unauthorized" in out
         assert "sent back to the sign-in page" not in out
+
+
+class TestRefreshAuthCacheFromStorageState:
+    """A signed-out cache must be refreshable from a live browser context.
+
+    ``test_workbench_signout`` ends the shared session, and
+    ``restore_shared_session`` mints a fresh one *in the browser context* --
+    but the on-disk cache still holds the cookies sign-out killed. Every
+    subsequent ``vip verify`` then rejects the cache and re-authenticates
+    interactively, popping a browser at the user. Refreshing the cache from
+    the restored context closes that gap.
+    """
+
+    def _existing_cache(self, tmp_path):
+        import os
+
+        cache = tmp_path / ".vip-auth-cache.json"
+        cache.write_text('{"cookies": [{"name": "dead", "value": "old"}], "origins": []}')
+        os.chmod(cache, 0o600)
+        meta = cache.with_suffix(".meta.json")
+        meta.write_text('{"api_key": null, "workbench_url": "https://wb.example.com"}')
+        os.chmod(meta, 0o600)
+        return cache, meta
+
+    def test_rewrites_an_existing_cache_with_the_live_state(self, tmp_path):
+        import json
+
+        from vip.auth import refresh_auth_cache_from_storage_state
+
+        cache, meta = self._existing_cache(tmp_path)
+        meta_before = meta.read_text()
+        live = {"cookies": [{"name": "fresh", "value": "new"}], "origins": []}
+
+        assert refresh_auth_cache_from_storage_state(live, cache) is True
+        assert json.loads(cache.read_text()) == live
+        # The companion metadata (api key, URLs) is unrelated to session
+        # liveness and must survive untouched.
+        assert meta.read_text() == meta_before
+
+    def test_keeps_owner_only_permissions(self, tmp_path):
+        import stat
+
+        from vip.auth import refresh_auth_cache_from_storage_state
+
+        cache, _ = self._existing_cache(tmp_path)
+
+        refresh_auth_cache_from_storage_state({"cookies": [], "origins": []}, cache)
+
+        mode = stat.S_IMODE(cache.stat().st_mode)
+        assert mode == 0o600, f"session cookies must stay owner-only, got {oct(mode)}"
+
+    def test_does_not_create_a_cache_that_did_not_exist(self, tmp_path):
+        """No cache means no `--interactive-auth` run to refresh; stay out of it."""
+        from vip.auth import refresh_auth_cache_from_storage_state
+
+        cache = tmp_path / ".vip-auth-cache.json"
+
+        assert refresh_auth_cache_from_storage_state({"cookies": []}, cache) is False
+        assert not cache.exists()
+
+    def test_leaves_no_temp_file_behind(self, tmp_path):
+        from vip.auth import refresh_auth_cache_from_storage_state
+
+        cache, _ = self._existing_cache(tmp_path)
+
+        refresh_auth_cache_from_storage_state({"cookies": [], "origins": []}, cache)
+
+        assert sorted(p.name for p in tmp_path.iterdir()) == [
+            ".vip-auth-cache.json",
+            ".vip-auth-cache.meta.json",
+        ]
+
+    def test_never_raises_when_the_state_is_not_serialisable(self, tmp_path):
+        """Cleanup-path helper: a bad value must not blow up a passing test."""
+        from vip.auth import refresh_auth_cache_from_storage_state
+
+        cache, _ = self._existing_cache(tmp_path)
+        before = cache.read_text()
+
+        assert refresh_auth_cache_from_storage_state({"cookies": object()}, cache) is False
+        assert cache.read_text() == before, "a failed refresh must leave the cache intact"

--- a/selftests/test_workbench_login.py
+++ b/selftests/test_workbench_login.py
@@ -330,3 +330,74 @@ def test_restore_shared_session_returns_true_when_homepage_comes_back():
             return _AuthFakeLocator(visible=lambda: True)
 
     assert restore_shared_session(_RecoveredPage(), "https://wb.example.com") is True
+
+
+# ---------------------------------------------------------------------------
+# A restored session must also refresh the cache on disk
+# ---------------------------------------------------------------------------
+
+
+class _RestorablePage:
+    """A page whose SSO click gets back in, exposing a context storage state."""
+
+    STATE = {"cookies": [{"name": "fresh", "value": "new"}], "origins": []}
+
+    def __init__(self, *, recovers: bool = True):
+        self.url = "https://wb.example.com/auth-sign-in"
+        self._logged_in = False
+        self._recovers = recovers
+
+        class _Context:
+            def storage_state(self):
+                return _RestorablePage.STATE
+
+        self.context = _Context()
+
+    def goto(self, *a, **k):
+        pass
+
+    def wait_for_load_state(self, *a, **k):
+        pass
+
+    def locator(self, selector):
+        from vip_tests.workbench.pages import Homepage
+
+        if selector == Homepage.POSIT_LOGO:
+            return _AuthFakeLocator(visible=lambda: self._logged_in)
+        return _AuthFakeLocator(visible=lambda: False)
+
+    def get_by_role(self, role, name=None):
+        def _click():
+            if self._recovers:
+                self._logged_in = True
+
+        return _AuthFakeLocator(visible=lambda: True, on_click=_click)
+
+
+def test_successful_restore_refreshes_the_cached_auth_session(monkeypatch):
+    """Otherwise the next run finds a signed-out cache and re-auths interactively."""
+    from vip_tests.workbench import conftest as wb
+
+    saved: list[dict] = []
+    monkeypatch.setattr(
+        wb, "refresh_auth_cache_from_storage_state", lambda state: saved.append(state) or True
+    )
+
+    assert wb.restore_shared_session(_RestorablePage(), "https://wb.example.com") is True
+    assert saved == [_RestorablePage.STATE]
+
+
+def test_failed_restore_does_not_touch_the_cache(monkeypatch):
+    """A dead session must not overwrite whatever the cache still holds."""
+    from vip_tests.workbench import conftest as wb
+
+    saved: list[dict] = []
+    monkeypatch.setattr(
+        wb, "refresh_auth_cache_from_storage_state", lambda state: saved.append(state) or True
+    )
+
+    assert (
+        wb.restore_shared_session(_RestorablePage(recovers=False), "https://wb.example.com")
+        is False
+    )
+    assert saved == []

--- a/src/vip/auth.py
+++ b/src/vip/auth.py
@@ -8,6 +8,8 @@ closes the browser before tests start.
 
 from __future__ import annotations
 
+import contextlib
+import logging
 import os
 import shutil
 import tempfile
@@ -31,6 +33,8 @@ from playwright.sync_api import (
 )
 
 from vip.timeouts import scaled
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from vip.config import ProductConfig
@@ -529,6 +533,57 @@ def _cached_urls_match(
     return _normalize_url(cached_connect) == _normalize_url(requested_connect) and (
         _normalize_url(cached_workbench) == _normalize_url(requested_workbench)
     )
+
+
+def refresh_auth_cache_from_storage_state(
+    storage_state: dict, cache_path: Path | None = None
+) -> bool:
+    """Rewrite the cached storage state from a live browser context.
+
+    A scenario that ends the shared Workbench session (``test_workbench_signout``)
+    can mint a fresh one in its browser context, but the cache on disk still
+    holds the cookies the sign-out killed.  The next ``vip verify`` then probes
+    that cache, finds it dead, and drops into an interactive re-auth -- opening a
+    browser at the user on every run.  Writing the restored context's state back
+    keeps the cache usable.
+
+    Only refreshes a cache that already exists.  Absent means no
+    ``--interactive-auth`` run put one there (a password deployment, say), and
+    creating one here would leave a storage state with no companion
+    ``.meta.json`` for :func:`_load_cached_auth` to match URLs against.
+
+    The write is atomic (temp file in the same directory, then rename) so a
+    concurrent xdist worker reading the cache never sees a half-written file,
+    and the replacement carries the same owner-only permissions as the original
+    -- it holds live session cookies.
+
+    Returns True when the cache was refreshed.  Never raises: this runs on a
+    cleanup path, where failing loudly would mask the test's own result.
+    """
+    import json
+
+    path = cache_path if cache_path is not None else auth_cache_path()
+    if not path.exists():
+        return False
+
+    tmp: Path | None = None
+    try:
+        payload = json.dumps(storage_state)
+        # Same directory so the rename stays on one filesystem (and therefore
+        # atomic); mkstemp creates it 0600 already.
+        fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".vip-auth-cache-")
+        tmp = Path(tmp_name)
+        with os.fdopen(fd, "w") as handle:
+            handle.write(payload)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+        return True
+    except Exception as exc:
+        logger.debug("Could not refresh the auth cache at %s: %s", path, exc)
+        if tmp is not None and tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+        return False
 
 
 def _save_auth_cache(session: InteractiveAuthSession, cache_path: Path) -> None:

--- a/src/vip_tests/workbench/conftest.py
+++ b/src/vip_tests/workbench/conftest.py
@@ -23,6 +23,7 @@ from playwright.sync_api import Locator, Page, expect
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from pytest_bdd import given
 
+from vip.auth import refresh_auth_cache_from_storage_state
 from vip.clients.workbench import WorkbenchClient
 from vip.plugin import _auth_session_key
 from vip.timeouts import timeout_scale
@@ -570,12 +571,32 @@ def _silent_sso_signin(sso_button, homepage_logo, workbench_url: str) -> bool:
             return False
 
 
+def _refresh_cached_session(page: Page) -> bool:
+    """Write this context's storage state back to the auth cache. Always True.
+
+    The caller has already established that the session is live, so the return
+    value reports *the restore*, not the cache write: a cache that could not be
+    refreshed (absent, read-only) is a slower next run, not a failed restore,
+    and must not be reported as one.
+    """
+    try:
+        refresh_auth_cache_from_storage_state(page.context.storage_state())
+    except Exception as exc:
+        logger.debug("Could not read storage state to refresh the auth cache: %s", exc)
+    return True
+
+
 def restore_shared_session(page: Page, workbench_url: str) -> bool:
     """Sign back in after the sign-out scenario, returning whether it worked.
 
     The scenario deliberately ends the session every other scenario shares, so
     it has to hand one back. Navigating to Workbench and completing the silent
     SSO round-trip mints a fresh session in this browser context.
+
+    A successful restore also writes the fresh session back to the auth cache on
+    disk. Without that the in-run damage is repaired but the cache still holds
+    the cookies the sign-out killed, so the *next* ``vip verify`` rejects it and
+    drops into an interactive re-auth -- a browser popup on every run.
 
     Returns False -- and warns -- when the round-trip cannot complete, e.g. the
     IdP applied single-logout and cleared its own cookies too. That is not
@@ -588,10 +609,10 @@ def restore_shared_session(page: Page, workbench_url: str) -> bool:
         page.goto(workbench_url)
         page.wait_for_load_state("load")
         if logo.is_visible():
-            return True
+            return _refresh_cached_session(page)
         sso_button = page.get_by_role("button", name=re.compile(r"sign in", re.IGNORECASE)).first
         if sso_button.is_visible() and _silent_sso_signin(sso_button, logo, workbench_url):
-            return True
+            return _refresh_cached_session(page)
     except (PlaywrightTimeoutError, PlaywrightError) as exc:
         logger.warning("Could not sign back in after the sign-out scenario: %s", exc)
         return False


### PR DESCRIPTION
`test_workbench_signout` ends the shared Workbench session and `restore_shared_session` (added in #574) mints a fresh one — but only in the browser context. The cache on disk kept the cookies the sign-out killed, so every subsequent `vip verify` probed that cache, found it dead, and dropped into an interactive re-auth, opening a browser at the user on every single run.

## Approach

A successful restore writes the context's storage state back over the cache, via `refresh_auth_cache_from_storage_state` in `src/vip/auth.py` — which already owns `auth_cache_path()` and the cache format, so that knowledge stays in one place.

Four decisions worth reviewing:

- **Only refreshes a cache that already exists.** Absent means no `--interactive-auth` run put one there (a password deployment, say); creating one would leave a storage state with no companion `.meta.json` for `_load_cached_auth` to match URLs against.
- **Atomic and owner-only.** `mkstemp` in the same directory then `os.replace`, so a concurrent xdist worker never reads a half-written file, and the replacement keeps `0600` — it holds live session cookies.
- **A cache failure does not fail the restore.** `_refresh_cached_session` always returns `True`: an unwritable cache is a slower next run, not a failed restore, and reporting it as one would trip the loud warning meant for a genuinely signed-out suite.
- **`.meta.json` is left untouched** — API key and URLs are unrelated to session liveness. Asserted by a selftest.

## Live verification

Against Workbench 2026.06.0 behind Okta. Cache liveness probed read-only, no browser, via `_cached_workbench_session_is_live`.

**Before** — cache written by a fully passing run, checked 16 minutes later with only the sign-out in between:

```
is_live: False
detail : the request landed on the sign-in page at https://dev.current.posit.team/auth-sign-in?appUri=%2F
```

**After** — same probe, right after a sign-out run on this branch:

```
is_live   : True
detail    : (dashboard reached)
cache age : 50s
cache mode: 0o600
temp files left behind: none
```

And the next run reuses it instead of opening a browser:

```
>>> Reusing cached auth session from /Users/ianfloressiaca/.vip-auth-cache.json
1 passed, 1 skipped, 140 deselected in 0.46s
```

## Scope

This covers the sign-out path, the one place we hold a live context at the moment the session rotates. If the cache proves to die for other reasons (Workbench rotating cookies on login, an idle timeout), the general fix is to refresh at end of run rather than only after sign-out. The evidence points at sign-out, so this stays narrow.

Selftests cover the rewrite, permission preservation, refusing to create an absent cache, leaving no temp file behind, a non-serialisable state leaving the cache intact, and both restore paths. 1423 passed across three randomized runs; the 2 intermittent failures are the pre-existing flaky threadpool tests (#517), which fail identically on clean main. Ruff and mypy clean.
