### PR TITLE
fix(workbench): read version from homepage footer, not phantom API

### DIFF
--- a/selftests/test_pages.py
+++ b/selftests/test_pages.py
@@ -18,6 +18,7 @@ from vip_tests.workbench.pages.homepage import (
     _close_dialog_via_escape,
     get_homepage,
     get_new_session_dialog_close_strategy,
+    parse_workbench_version,
 )
 from vip_tests.workbench.pages.rstudio_session import RStudioSession
 
@@ -52,6 +53,67 @@ class TestGetHomepage:
         assert Homepage_2026_05.SESSION_DETAILS_DIALOG != Homepage.SESSION_DETAILS_DIALOG
         assert Homepage_2026_05.POSIT_LOGO == Homepage.POSIT_LOGO
         assert Homepage_2026_05.NEW_SESSION_BUTTON == Homepage.NEW_SESSION_BUTTON
+
+
+class TestParseWorkbenchVersion:
+    """Cover ``parse_workbench_version`` against real homepage footer strings.
+
+    The three "real" cases below are the exact footer text captured from live
+    Workbench deployments (2026.01, 2026.06, 2026.07), so the regex is anchored
+    to formats that actually ship, not an invented shape.
+    """
+
+    # (footer_text, expected_version_substring)
+    REAL_FOOTERS = [
+        ('Posit Workbench 2026.01.0+392.pro5, "Apple Blossom" (7534b903).', "2026.01.0+392.pro5"),
+        ('Posit Workbench 2026.06.0+242.pro13, "Blue Plumbago" (e0e0c3b7).', "2026.06.0+242.pro13"),
+        (
+            'Posit Workbench 2026.07.0+139.pro9, "Pacific Dogwood" (f028a7ae).',
+            "2026.07.0+139.pro9",
+        ),
+    ]
+
+    @pytest.mark.parametrize("footer,expected", REAL_FOOTERS)
+    def test_extracts_version_from_real_footers(self, footer, expected):
+        assert parse_workbench_version(footer) == expected
+
+    @pytest.mark.parametrize("footer,expected", REAL_FOOTERS)
+    def test_parsed_output_feeds_product_version(self, footer, expected):
+        # The whole point of the substring shape: it must parse with
+        # ProductVersion (which then ignores the +build metadata for ordering).
+        parsed = parse_workbench_version(footer)
+        assert parsed is not None
+        pv = ProductVersion(parsed)
+        assert (pv.year, pv.month, pv.patch) == (
+            int(expected[:4]),
+            int(expected[5:7]),
+            int(expected.split("+")[0].rsplit(".", 1)[1]),
+        )
+
+    def test_build_metadata_ignored_in_comparison(self):
+        # Config carries the plain "2026.07.0"; the footer carries build metadata.
+        # ProductVersion must treat them as equal.
+        running = parse_workbench_version(self.REAL_FOOTERS[2][0])
+        assert ProductVersion(running) == ProductVersion("2026.07.0")
+
+    def test_plain_version_without_build_metadata(self):
+        assert parse_workbench_version("Posit Workbench 2025.09.1, foo") == "2025.09.1"
+
+    def test_prerelease_suffix_is_captured(self):
+        assert (
+            parse_workbench_version("Posit Workbench 2026.08.0-daily.20260801+9.pro1, x")
+            == "2026.08.0-daily.20260801+9.pro1"
+        )
+
+    def test_returns_none_when_no_version_present(self):
+        assert parse_workbench_version("Posit Workbench, welcome back") is None
+
+    def test_returns_none_for_empty_string(self):
+        assert parse_workbench_version("") is None
+
+    def test_returns_none_when_prefix_missing(self):
+        # A bare version with no "Posit Workbench" prefix is not our footer.
+        assert parse_workbench_version("Some other product 2026.07.0") is None
 
 
 class TestGetNewSessionDialogCloseStrategy:

--- a/src/vip/clients/workbench.py
+++ b/src/vip/clients/workbench.py
@@ -160,15 +160,14 @@ class WorkbenchClient(BaseClient):
         resp = self._client.get("/health-check")
         return resp.status_code
 
-    def server_settings(self) -> dict[str, Any]:
-        """Return server settings including version information.
-
-        Returns the parsed JSON from ``/api/server/settings``.  Raises
-        ``httpx.HTTPStatusError`` if the endpoint is not reachable.
-        """
-        resp = self._client.get("/api/server/settings")
-        resp.raise_for_status()
-        return resp.json()
+    # Note: Workbench has no unauthenticated server-info/version endpoint. The
+    # deployed version is read from the authenticated homepage footer instead
+    # (see ``vip_tests/workbench/test_version.py`` and
+    # ``pages/homepage.parse_workbench_version``). The documented REST API's
+    # ``/api/version`` is tier-gated (Enhanced/Advanced), disabled by default,
+    # and requires an API token this client does not carry — so there is no
+    # ``server_settings()`` method here (the old one hit a nonexistent
+    # ``/api/server/settings`` and always 404'd).
 
     # -- Sessions -----------------------------------------------------------
 

--- a/src/vip/load_users.py
+++ b/src/vip/load_users.py
@@ -97,8 +97,11 @@ class WorkbenchUser(HttpUser):
         self.client.get("/api/sessions", headers=self._headers)
 
     @task(5)
-    def server_settings(self):
-        self.client.get("/api/server/settings", headers=self._headers)
+    def server_version(self):
+        # Workbench's documented version endpoint is /api/version (there is no
+        # /api/server/settings — that path 404s). Requires an API token, which
+        # on_start sets from the injected credentials.
+        self.client.get("/api/version", headers=self._headers)
 
     @task(1)
     def health_check(self):

--- a/src/vip_tests/performance/test_load.py
+++ b/src/vip_tests/performance/test_load.py
@@ -53,7 +53,9 @@ def load_test_workbench(users, vip_config, performance_config):
     _check_user_count(users, performance_config)
     if not vip_config.workbench.api_key:
         pytest.skip("Workbench API key is not configured")
-    url = f"{vip_config.workbench.url}/api/server/settings"
+    # Workbench has no /api/server/settings endpoint (that path 404s). Load-test
+    # a real authenticated endpoint the client actually uses instead.
+    url = f"{vip_config.workbench.url}/api/sessions"
     headers = {"Authorization": f"Key {vip_config.workbench.api_key}"}
     return run_load_test(url, headers, users, performance_config)
 

--- a/src/vip_tests/prerequisites/test_versions.feature
+++ b/src/vip_tests/prerequisites/test_versions.feature
@@ -9,10 +9,10 @@ Feature: Product versions match configuration
     When I fetch the Connect server version
     Then the Connect version matches the configured value
 
-  Scenario: Workbench version matches configuration
-    Given Workbench is configured in vip.toml with a version expectation
-    When I fetch the Workbench server version
-    Then the Workbench version matches the configured value
+  # Workbench version is verified separately in the @workbench browser suite
+  # (workbench/test_version.feature): Workbench exposes no unauthenticated
+  # version endpoint, so the running version is read from the authenticated
+  # homepage footer rather than an API call.
 
   Scenario: Package Manager version matches configuration
     Given Package Manager is configured in vip.toml with a version expectation

--- a/src/vip_tests/prerequisites/test_versions.py
+++ b/src/vip_tests/prerequisites/test_versions.py
@@ -11,9 +11,10 @@ def test_connect_version():
     pass
 
 
-@scenario("test_versions.feature", "Workbench version matches configuration")
-def test_workbench_version():
-    pass
+# Workbench version verification lives in the @workbench browser suite
+# (workbench/test_version.py): the running version is scraped from the
+# authenticated homepage footer, since Workbench has no unauthenticated
+# version endpoint. See that file for the check.
 
 
 @scenario("test_versions.feature", "Package Manager version matches configuration")
@@ -41,21 +42,6 @@ def connect_version_configured(vip_config):
 
 
 @given(
-    "Workbench is configured in vip.toml with a version expectation",
-    target_fixture="workbench_expected_version",
-)
-def workbench_version_configured(vip_config):
-    if not vip_config.workbench.is_configured:
-        pytest.skip("Workbench is not configured")
-    if not vip_config.workbench.version:
-        pytest.skip(
-            "No Workbench version configured in vip.toml — "
-            "set workbench.version to enable this check"
-        )
-    return vip_config.workbench.version
-
-
-@given(
     "Package Manager is configured in vip.toml with a version expectation",
     target_fixture="pm_expected_version",
 )
@@ -79,18 +65,6 @@ def fetch_connect_version(connect_client):
     return version
 
 
-@when("I fetch the Workbench server version", target_fixture="workbench_running_version")
-def fetch_workbench_version(workbench_client):
-    try:
-        info = workbench_client.server_settings()
-    except Exception as exc:
-        pytest.skip(f"Workbench server settings endpoint not available: {exc}")
-    version = info.get("version")
-    if not version:
-        pytest.skip("Workbench server_settings did not return a version field")
-    return version
-
-
 @when("I fetch the Package Manager server version", target_fixture="pm_running_version")
 def fetch_pm_version(pm_client):
     info = pm_client.status()
@@ -105,14 +79,6 @@ def assert_connect_version(connect_running_version, connect_expected_version):
     assert connect_running_version == connect_expected_version, (
         f"Connect version mismatch: running={connect_running_version!r}, "
         f"configured={connect_expected_version!r}"
-    )
-
-
-@then("the Workbench version matches the configured value")
-def assert_workbench_version(workbench_running_version, workbench_expected_version):
-    assert workbench_running_version == workbench_expected_version, (
-        f"Workbench version mismatch: running={workbench_running_version!r}, "
-        f"configured={workbench_expected_version!r}"
     )
 
 

--- a/src/vip_tests/workbench/pages/__init__.py
+++ b/src/vip_tests/workbench/pages/__init__.py
@@ -12,6 +12,7 @@ from .homepage import (
     NewSessionDialog,
     get_homepage,
     get_new_session_dialog_close_strategy,
+    parse_workbench_version,
 )
 from .ide_base import IDEBase
 from .jupyterlab_session import JupyterLabSession
@@ -33,4 +34,5 @@ __all__ = [
     "VSCodeSession",
     "get_homepage",
     "get_new_session_dialog_close_strategy",
+    "parse_workbench_version",
 ]

--- a/src/vip_tests/workbench/pages/homepage.py
+++ b/src/vip_tests/workbench/pages/homepage.py
@@ -5,6 +5,7 @@ Mirrors: rstudio-pro/e2e/pages/homepage.page.ts
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -13,6 +14,32 @@ from playwright.sync_api import Page
 from vip.version import ProductVersion
 
 _T = TypeVar("_T")
+
+# Matches the calendar version (with optional pre-release and +build metadata)
+# embedded in the homepage footer string, e.g. the "2026.07.0+139.pro9" inside
+#   Posit Workbench 2026.07.0+139.pro9, "Pacific Dogwood" (f028a7ae).
+# Kept in sync with the shape ``vip.version.ProductVersion`` accepts, so the
+# captured substring feeds straight into it. Build metadata is preserved here
+# (ProductVersion ignores it for comparison but keeps it for display).
+_FOOTER_VERSION_RE = re.compile(
+    r"Posit Workbench\s+"
+    r"(?P<version>\d{4}\.\d{2}\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)"
+)
+
+
+def parse_workbench_version(footer_text: str) -> str | None:
+    """Extract the Workbench version string from the homepage footer text.
+
+    *footer_text* is the rendered footer, e.g.
+    ``'Posit Workbench 2026.07.0+139.pro9, "Pacific Dogwood" (f028a7ae).'``.
+    Returns the version substring (``'2026.07.0+139.pro9'``) — including any
+    ``+build`` metadata — or ``None`` when the text carries no recognizable
+    version (a redesign moved/renamed the string, or an unexpected page).
+    The returned value is shaped to parse directly with
+    :class:`vip.version.ProductVersion`.
+    """
+    match = _FOOTER_VERSION_RE.search(footer_text)
+    return match.group("version") if match else None
 
 
 class NewSessionDialog:
@@ -143,6 +170,17 @@ class Homepage:
 
     # Footer
     FOOTER_POSIT_LINK = "a:text-is('Posit Workbench')"
+    # The footer bar renders the running product version in a bare <div> with no
+    # id/class, e.g.:
+    #   Posit Workbench 2026.07.0+139.pro9, "Pacific Dogwood" (f028a7ae).
+    # Match it by its stable "Posit Workbench <YYYY.MM" text prefix rather than
+    # structural position (the surrounding flex layout has changed across the
+    # 2026.05 redesign). The ``text=`` engine (not ``:has-text``) resolves to the
+    # *smallest* element containing the text — the version <div> itself — so it
+    # won't also match the ancestor layout divs and trip strict mode. Workbench
+    # exposes no unauthenticated version endpoint, so this footer string is how
+    # VIP reads the deployed version; parse it with :func:`parse_workbench_version`.
+    VERSION_FOOTER = r"text=/Posit Workbench 20\d\d/"
 
     @staticmethod
     def session_link(name: str) -> str:

--- a/src/vip_tests/workbench/test_version.feature
+++ b/src/vip_tests/workbench/test_version.feature
@@ -1,0 +1,15 @@
+@workbench
+Feature: Workbench version matches configuration
+  As a Posit Team administrator
+  I want to verify that the running Workbench version matches the configured expectation
+  So that I know the correct Workbench release is deployed
+
+  # Workbench exposes no unauthenticated version endpoint (the REST API's
+  # /api/version is tier-gated, disabled by default, and needs an API token),
+  # so the running version is read from the authenticated homepage footer.
+
+  Scenario: Workbench version matches configuration
+    Given Workbench is accessible and I am logged in
+    And Workbench has a version expectation in vip.toml
+    When I read the Workbench version from the homepage footer
+    Then the Workbench version matches the configured value

--- a/src/vip_tests/workbench/test_version.py
+++ b/src/vip_tests/workbench/test_version.py
@@ -1,0 +1,79 @@
+"""Step definitions for the Workbench version check.
+
+Workbench has no unauthenticated version endpoint, so the running version is
+scraped from the authenticated homepage footer rather than fetched from an API
+(see ``pages/homepage.py`` for the selector and parser). This mirrors the
+Connect and Package Manager version scenarios in
+``prerequisites/test_versions.py``, which *do* have API endpoints to hit.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_bdd import given, scenario, then, when
+
+from vip.version import ProductVersion
+from vip_tests.workbench.conftest import (
+    TIMEOUT_PAGE_LOAD,
+)
+from vip_tests.workbench.pages import Homepage, parse_workbench_version
+
+# Read-only homepage check; no session is launched. Order it with the other
+# lightweight homepage reads rather than the session-launching tests.
+pytestmark = pytest.mark.order(20)
+
+
+@scenario("test_version.feature", "Workbench version matches configuration")
+def test_workbench_version():
+    pass
+
+
+@given(
+    "Workbench has a version expectation in vip.toml",
+    target_fixture="workbench_expected_version",
+)
+def workbench_version_configured(vip_config):
+    if not vip_config.workbench.version:
+        pytest.skip(
+            "No Workbench version configured in vip.toml — "
+            "set workbench.version to enable this check"
+        )
+    return vip_config.workbench.version
+
+
+@when(
+    "I read the Workbench version from the homepage footer",
+    target_fixture="workbench_running_version",
+)
+def read_workbench_version(page: Page):
+    footer = page.locator(Homepage.VERSION_FOOTER).first
+    expect(footer).to_be_visible(timeout=TIMEOUT_PAGE_LOAD)
+    footer_text = footer.inner_text().strip()
+    running = parse_workbench_version(footer_text)
+    if not running:
+        pytest.skip(
+            "Could not parse a Workbench version from the homepage footer "
+            f"(text was {footer_text!r}) — the footer format may have changed"
+        )
+    return running
+
+
+@then("the Workbench version matches the configured value")
+def assert_workbench_version(workbench_running_version, workbench_expected_version):
+    # Compare via ProductVersion so build metadata (e.g. the "+139.pro9" the
+    # footer carries) is ignored: config holds "2026.07.0" while the running
+    # string is "2026.07.0+139.pro9". A raw string == would always fail here.
+    try:
+        running = ProductVersion(workbench_running_version)
+        expected = ProductVersion(workbench_expected_version)
+    except ValueError as exc:
+        pytest.skip(
+            f"Cannot compare Workbench versions (running="
+            f"{workbench_running_version!r}, configured="
+            f"{workbench_expected_version!r}): {exc}"
+        )
+    assert running == expected, (
+        f"Workbench version mismatch: running={workbench_running_version!r}, "
+        f"configured={workbench_expected_version!r}"
+    )


### PR DESCRIPTION
## Problem

`prerequisites/test_versions.py::test_workbench_version` produced a confusing skip:

```
SKIPPED (Workbench server settings endpoint not available: Client error
'404 Not Found' for url '.../api/server/settings'
For more information check: https://developer.mozilla.org/.../404)
```

Root cause: `WorkbenchClient.server_settings()` called `GET /api/server/settings`, which **does not exist** in Workbench. The real version endpoint is `/api/version` — but it's tier-gated (Enhanced/Advanced), disabled by default, and requires an API token VIP does not carry (Workbench auth is cookie/OIDC-based). So the call always 404'd, `raise_for_status()` raised `httpx.HTTPStatusError`, and the step's `except Exception → pytest.skip` folded httpx's raw message (MDN link and all) into the skip reason. A permanent 404 silently masqueraded as "skipped" and never failed.

This check is **not** redundant: `min_version` gating compares against the *configured* version in `vip.toml`, never the running server — so nothing else confirmed the deployed Workbench version.

## Fix

Workbench exposes no unauthenticated version endpoint, so the running version is read from the **authenticated homepage footer**, e.g.:

```
Posit Workbench 2026.07.0+139.pro9, "Pacific Dogwood" (f028a7ae).
```

- Add `Homepage.VERSION_FOOTER` selector + a pure `parse_workbench_version()` helper (exported from `pages`).
- New `@workbench` browser test `workbench/test_version.{feature,py}`: reuses the shared login step, scrapes the footer, and compares via `ProductVersion` so `+build` metadata is ignored (config `2026.07.0` == running `2026.07.0+139.pro9`). Skips cleanly when no version is configured.
- Remove the Workbench scenario/steps from `prerequisites/test_versions` (Connect + Package Manager keep their real API checks).
- Remove the dead `WorkbenchClient.server_settings()`, and fix two other stale `/api/server/settings` references found along the way: the perf load test was load-testing a 404 route → now `/api/sessions`; the locust task → `/api/version`.
- Selftests pin `parse_workbench_version` against footer strings captured from three live deployments (2026.01 / 2026.06 / 2026.07) plus edge cases.

## Verification

- Footer format + presence confirmed live on three Workbench instances (2026.01, 2026.06, 2026.07).
- ruff (0.15.0) check + format clean; mypy clean; selftests `1456 passed, 1 skipped`.
- New BDD test collects with no step-definition errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)