### PR TITLE
fix(proxy): pass authenticated proxy creds to Playwright's own fields

### DIFF
--- a/selftests/test_proxy.py
+++ b/selftests/test_proxy.py
@@ -360,6 +360,32 @@ def test_playwright_proxy_prefers_https_env(monkeypatch):
     assert pw is not None and pw["server"] == "http://httpsproxy:2"
 
 
+def test_playwright_proxy_splits_authenticated_credentials():
+    """An authenticated proxy must expose its creds in Playwright's dedicated
+    username/password fields, NOT embedded in ``server`` — Chromium ignores
+    userinfo in the server string, so leaving it there 407s the browser login
+    while every httpx path (which parses the userinfo) authenticates fine. The
+    ``server`` handed to Playwright must also be credential-free so the password
+    can't leak into browser logs."""
+    cfg = ProxyConfig(url="http://alice:s3cret@proxy.corp:8080")
+    pw = playwright_proxy(build_proxy_map(cfg))
+    assert pw is not None
+    assert pw["username"] == "alice"
+    assert pw["password"] == "s3cret"
+    assert pw["server"] == "http://proxy.corp:8080"
+    assert "s3cret" not in pw["server"]
+
+
+def test_playwright_proxy_no_credential_keys_when_unauthenticated():
+    """A proxy with no userinfo must not sprout empty username/password keys —
+    Playwright would try to authenticate with a blank user and could 407."""
+    pw = playwright_proxy(build_proxy_map(ProxyConfig(url="http://proxy.corp:8080")))
+    assert pw is not None
+    assert pw["server"] == "http://proxy.corp:8080"
+    assert "username" not in pw
+    assert "password" not in pw
+
+
 def test_http_only_env_browser_and_httpx_agree_via_tunnel(monkeypatch):
     """With only HTTP_PROXY set (the "single outbound tunnel" org), https must
     tunnel through that proxy on BOTH the httpx and browser paths, and they must

--- a/src/vip/proxy.py
+++ b/src/vip/proxy.py
@@ -347,13 +347,23 @@ def verify_with_env_ca(verify: bool | str) -> bool | str | ssl.SSLContext:
 def playwright_proxy(proxy_map: ProxyMap) -> dict[str, str] | None:
     """Render *proxy_map* as a Playwright ``launch(proxy=...)`` dict, or ``None``.
 
-    Playwright accepts a single ``server`` plus a comma-separated ``bypass``
-    list. The browser login navigates https Posit product URLs, so the server is
-    the proxy an https URL would select (see :func:`_primary_proxy_server`),
-    keeping the browser on the same route as the httpx paths. The ``bypass`` list
-    is the map's bypass (``None``-valued) patterns rendered back to bare
-    hostnames. Returns ``None`` when no proxy applies to the browser's https
-    traffic, so the caller launches Chromium exactly as before.
+    Playwright accepts a ``server`` plus optional ``username`` / ``password`` and
+    a comma-separated ``bypass`` list. The browser login navigates https Posit
+    product URLs, so the server is the proxy an https URL would select (see
+    :func:`_primary_proxy_server`), keeping the browser on the same route as the
+    httpx paths. The ``bypass`` list is the map's bypass (``None``-valued)
+    patterns rendered back to bare hostnames. Returns ``None`` when no proxy
+    applies to the browser's https traffic, so the caller launches Chromium
+    exactly as before.
+
+    An authenticated proxy is commonly given as ``http://user:pass@proxy:8080``.
+    httpx parses that userinfo into its own proxy auth, but Chromium **ignores**
+    credentials embedded in the proxy server string — Playwright expects them in
+    separate ``username`` / ``password`` fields. Passing the raw URL as ``server``
+    would make the browser log in fail with a 407 while every httpx path
+    authenticates fine: exactly the browser-vs-API split this module exists to
+    remove. So split any userinfo out of the server URL into ``username`` /
+    ``password`` and hand Playwright a credential-free ``server``.
     """
     server = _primary_proxy_server(proxy_map)
     if server is None:
@@ -364,10 +374,33 @@ def playwright_proxy(proxy_map: ProxyMap) -> dict[str, str] | None:
         if proxy_url is None
     ]
     proxy: dict[str, str] = {"server": server}
+    username, password = _split_proxy_userinfo(server)
+    if username is not None:
+        proxy["server"] = redact_proxy_url(server) or server
+        proxy["username"] = username
+        proxy["password"] = password or ""
     bypass = ",".join(h for h in bypass_hosts if h)
     if bypass:
         proxy["bypass"] = bypass
     return proxy
+
+
+def _split_proxy_userinfo(url: str) -> tuple[str | None, str | None]:
+    """Return the ``(username, password)`` embedded in a proxy URL, or ``(None, None)``.
+
+    Mirrors what :func:`redact_proxy_url` parses, but returns the credentials so
+    :func:`playwright_proxy` can hand them to Playwright's dedicated fields
+    rather than leaving them in the ``server`` string (which Chromium drops).
+    Returns ``(None, None)`` when the URL has no userinfo or cannot be parsed, so
+    an unauthenticated proxy is passed through as a bare ``server`` unchanged.
+    """
+    try:
+        parsed = httpx.URL(url)
+    except Exception:
+        return None, None
+    if not (parsed.username or parsed.password):
+        return None, None
+    return parsed.username, parsed.password
 
 
 def _primary_proxy_server(proxy_map: ProxyMap) -> str | None:


### PR DESCRIPTION
Follow-up to #583, from the adversarial review of that PR.

## Problem

`playwright_proxy` put the whole proxy URL — including any `user:pass@` userinfo — into Playwright's `server`. Chromium **ignores** credentials embedded in the server string (it expects separate `username`/`password` fields), so an authenticated proxy (`HTTPS_PROXY=http://user:pass@proxy:8080`, or `[proxy] url` with creds) 407s the browser login while every httpx path — which parses the userinfo via `httpx.Proxy` — authenticates fine.

That is the exact **browser-vs-API split** this module was written to eliminate, just surfacing on the credentials axis instead of the routing axis.

## Fix

- Split userinfo out of the server URL into Playwright's dedicated `username`/`password` fields.
- Hand Playwright a **credential-free (redacted) `server`**, so the password can't leak into browser logs either.
- Unauthenticated proxies are unchanged — no empty `username`/`password` keys (which would make Playwright attempt a blank-user auth).

## Tests

Two new selftests in `test_proxy.py`: credential split for an authenticated proxy, and no cred keys for an unauthenticated one. Full suite: 1536 passed / 1 skipped; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)